### PR TITLE
Diagnosing IE11 hash test failure

### DIFF
--- a/packages/hash/karma.conf.js
+++ b/packages/hash/karma.conf.js
@@ -12,7 +12,7 @@ const plugins = [
 ];
 
 // don't test IE11 until hash loss issue is resolved
-delete customLaunchers["bs_ie_11"];
+// delete customLaunchers["bs_ie_11"];
 
 module.exports = function(config) {
   config.set({

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -12,10 +12,6 @@ function ignoreFirstCall(fn) {
   };
 }
 
-function isIE11() {
-  return /Trident\//.test(navigator.userAgent);
-}
-
 describe("hash integration tests", () => {
   let testHistory;
 
@@ -129,11 +125,6 @@ describe("hash integration tests", () => {
   });
 
   describe("browser navigation", () => {
-    if (isIE11()) {
-      console.log("[NEEDS FIX] IE11 swallows hash change, skipping test");
-      return;
-    }
-
     it("can detect navigation triggered by the browser", done => {
       testHistory.push("/uno");
       testHistory.push("/dos");


### PR DESCRIPTION
There are inconsistent errors with the "browser navigation" hash test on IE11 running on BrowserStack.