### PR TITLE
Unify navigation methods under history.navigate()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- stable
+- "9"
 cache:
   directories:
   - node_modules

--- a/docs/about/introduction.md
+++ b/docs/about/introduction.md
@@ -7,7 +7,7 @@ Hickory provides a three packages that allow you to easily power navigation with
 At the root of your project, you will create a history object. There are three choices: `Browser`, `Hash`, and `InMemory`. You can read more about how to pick the right one for your application in the [choosing your history type](./choosing.md) documentation. For simplicity, all example code here will use the `Browser` history type.
 
 ```js
-import Browser from '@hickory/Browser';
+import Browser from "@hickory/Browser";
 
 const history = Browser();
 ```
@@ -54,14 +54,14 @@ The key is made up of two numbers separated by a period. The first number is the
 
 ## Navigation
 
-Your history object will have a number of methods that allow you to navigate within your application.
+Your history object provides a `navigate()` method to perform navigation. There are three ways that you can use this.
 
-### `push`, `replace`, and `update`
+### `PUSH`, `REPLACE`, and `ANCHOR`
 
-`push`, `replace`, and `update` all have similar functionality. Each one takes a single argument: the location that you want to navigate to. This can either be a string or an object. If it is a string, it will be parsed and turned into a location object. If it is an object, it will be modified to fill in any missing properties (as well as the `key`).
+`PUSH`, `REPLACE`, and `ANCHOR` all have similar functionality. Each one takes a single argument: the location that you want to navigate to. This can either be a string or an object. If it is a string, it will be parsed and turned into a location object. If it is an object, it will be modified to fill in any missing properties (as well as the `key`).
 
 ```js
-history.push('/do#re');
+history.navigate("/do#re", "PUSH");
 // {
 //   pathname: '/do',
 //   query: {},
@@ -70,7 +70,7 @@ history.push('/do#re');
 //   key: '1.0'
 // }
 
-history.replace({ pathname: '/mi', query: { fa: 'so' }});
+history.navigate({ pathname: "/mi", query: { fa: "so" } }, "REPLACE");
 // {
 //   pathname: '/mi',
 //   query: { fa: 'so' },
@@ -79,7 +79,7 @@ history.replace({ pathname: '/mi', query: { fa: 'so' }});
 //   key: '1.1'
 // }
 
-history.update({ state: { rest: ['la', 'ti', 'do'] }})
+history.navigate({ state: { rest: ["la", "ti", "do"] } }, "ANCHOR");
 // {
 //   pathname: '/',
 //   query: {},
@@ -93,11 +93,11 @@ history.update({ state: { rest: ['la', 'ti', 'do'] }})
 
 #### Differences
 
-You can imagine the locations that have been visited in your application as an array of location objects. When you `push`, you add a new location after the current location. This means that if you are not at the end of the array, any "future" locations will be wiped out. When you `replace`, you are just replacing the current location object with a new one. This does not affect any "future" locations.
+You can imagine the locations that have been visited in your application as an array of location objects. When you `PUSH`, you add a new location after the current location. This means that if you are not at the end of the array, any "future" locations will be wiped out. When you `REPLACE`, you are just replacing the current location object with a new one. This does not affect any "future" locations.
 
-`update` combines `push` and `replace` to act more like a browser does. If you attempt to navigate to a location that generates the same URI as the current location, `replace` will be called. If the new location generates a different URI, then `push` will be called.
+`ANCHOR` combines `PUSH` and `REPLACE` to act more like a browser does. If you attempt to navigate to a location that generates the same URI as the current location, `REPLACE` will be called. If the new location generates a different URI, then `PUSH` will be called.
 
-**Unless you have a specific reason to use `push`/`replace`, you should always navigate to locations with `update`.**
+**Unless you have a specific reason to use `PUSH`/`REPLACE`, you should always navigate to locations with `ANCHOR`.**
 
 ### `go`
 
@@ -118,7 +118,7 @@ history.respondWith(function(pending) {
   // do any route matching/data loading, and once that
   // is done, call finish.
   pending.finish();
-})
+});
 ```
 
 ## One history

--- a/docs/api/Browser.md
+++ b/docs/api/Browser.md
@@ -1,7 +1,7 @@
 # Browser API
 
 ```js
-import Browser from '@hickory/browser';
+import Browser from "@hickory/browser";
 
 const history = Browser();
 ```
@@ -32,53 +32,64 @@ The action used to get to the current location object.
 
 ## Methods
 
-### push
-
-```js
-history.push('/the-producers');
-history.push({
-  pathname: '/oklahoma',
-  state: { musical: true }
-});
-```
-
-The `push` function is used to navigate to a new location. It adds the new location after the current location. This means that if the current location is not the last location in the history array, any locations that come after the current one will be wiped out.
-
-#### arguments
-
-`to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
-
-### replace
-
-```js
-history.replace('/cats');
-history.replace({
-  pathname: '/rent',
-  state: { musical: true }
-});
-```
-
-The `replace` function is used to navigate to a new location. It replaces the current location with the new one. Any location objects that come after the current location in the history array will be preserved.
-
-#### arguments
-
-`to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
-
 ### navigate
 
 ```js
-history.navigate('/hairspray');
+history.navigate("/the-producers");
 history.navigate({
-  pathname: '/hamilton',
+  pathname: "/oklahoma",
   state: { musical: true }
 });
 ```
 
-The `navigate` function decides whether to `push` or `replace` for you. The path string that it creates is compared to the path string of the current location. If they are the same, then it will call `replace`. If they are different, then it will call `push`. This is done to mimic browser behavior and **unless you have a reason not to, you should prefer this over `push` and `replace`.**
+The `navigate` function is used to navigate to a new location.
+
+There are three ways that it can do this: `PUSH`, `REPLACE`, and `ANCHOR`.
+
+1. `PUSH` navigation pushes the new location onto the session history after the current location. Any existing locations after the current location are dropped.
+
+```js
+history.navigate("/lion-king", "PUSH");
+history.navigate(
+  {
+    pathname: "/wicked",
+    state: { musical: true }
+  },
+  "PUSH"
+);
+```
+
+2. `REPLACE` navigation replaces the current location with the new location. Any existing locations after the current location are unaffected.
+
+```js
+history.navigate("/cats", "REPLACE");
+history.navigate(
+  {
+    pathname: "/rent",
+    state: { musical: true }
+  },
+  "REPLACE"
+);
+```
+
+3. `ANCHOR` mimics the behavior of clicking on an `<a>` element. When the new location's URL is exactly the same as the current location's, it will act like `REPLACE`; when they are different, it will act like `PUSH`.
+
+```js
+history.navigate("/hairspray", "ANCHOR");
+history.navigate(
+  {
+    pathname: "/hamilton",
+    state: { musical: true }
+  },
+  "ANCHOR"
+);
+```
 
 #### arguments
 
 `to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
+
+`navType` - `ANCHOR`, `PUSH`, or `REPLACE`. If none are provided, this will default to `ANCHOR`.
 
 ### go
 
@@ -88,7 +99,7 @@ history.go();
 history.go(2);
 ```
 
-The `go` function is used to jump forward and backward to already visited locations. If you call it with a negative number, it goes backward. With a positive number, it goes forward. If you call it with no value (or `0`), it will re-emit the current location (with a `POP` action).]
+The `go` function is used to jump forward and backward to already visited locations. If you call it with a negative number, it goes backward. With a positive number, it goes forward. If you call it with no value (or `0`), it will reload the current location.
 
 #### arguments
 
@@ -97,7 +108,7 @@ The `go` function is used to jump forward and backward to already visited locati
 ### toHref
 
 ```js
-history.toHref({ pathname: '/spamalot' });
+history.toHref({ pathname: "/spamalot" });
 // /spamalot
 ```
 
@@ -122,7 +133,7 @@ The response handler function will be passed a "pending navigation" object. This
 
 * `location` - This is the location object that is being navigated to.
 * `action` - This is the string (`POP`, `PUSH`, or `REPLACE`) for the navigation type.
-* `finish` -  Once all matching/loading has finished, then you need to call the `finish` method to finalize the navigation. If you do not call this, the navigation will not actually occur.
+* `finish` - Once all matching/loading has finished, then you need to call the `finish` method to finalize the navigation. If you do not call this, the navigation will not actually occur.
 * `cancel` - This method allows you to cancel a navigation. It should be called if another location change occurs while the current pending navigation is still pending. Calling `cancel` gives your history instance the opportunity to roll back to its previous state. This is only really necessary for `POP` navigation since the browser has already changed the location before Hickory knows about the location change. This method takes one argument, an action string; the action string may be used to alter the cancel behavior.
 
 #### arguments

--- a/docs/api/Hash.md
+++ b/docs/api/Hash.md
@@ -1,7 +1,7 @@
 # Hash API
 
 ```js
-import Hash from '@hickory/hash';
+import Hash from "@hickory/hash";
 
 const history = Hash();
 ```
@@ -31,13 +31,13 @@ const history = Hash();
 **Note:** While you _can_ use the `baseSegment` with a `Hash` history, you probably should not. The `baseSegment` only affects the `pathname` of location objects (and the URIs those produce). For example, if you create a history like this:
 
 ```js
-const history = Hash({ baseSegment: '/test' });
+const history = Hash({ baseSegment: "/test" });
 ```
 
 The `/test` segment will be stripped from and included in the hash segment of the full URI.
 
 ```js
-const uri = history.toHref({ pathname: '/pathname' });
+const uri = history.toHref({ pathname: "/pathname" });
 // uri === '#/test/pathname'
 ```
 
@@ -55,53 +55,64 @@ The action used to get to the current location object.
 
 ## Methods
 
-### push
-
-```js
-history.push('/the-producers');
-history.push({
-  pathname: '/oklahoma',
-  state: { musical: true }
-});
-```
-
-The `push` function is used to navigate to a new location. It adds the new location after the current location. This means that if the current location is not the last location in the history array, any locations that come after the current one will be wiped out.
-
-#### arguments
-
-`to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
-
-### replace
-
-```js
-history.replace('/cats');
-history.replace({
-  pathname: '/rent',
-  state: { musical: true }
-});
-```
-
-The `replace` function is used to navigate to a new location. It replaces the current location with the new one. Any location objects that come after the current location in the history array will be preserved.
-
-#### arguments
-
-`to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
-
 ### navigate
 
 ```js
-history.navigate('/hairspray');
+history.navigate("/the-producers");
 history.navigate({
-  pathname: '/hamilton',
+  pathname: "/oklahoma",
   state: { musical: true }
 });
 ```
 
-The `navigate` function decides whether to `push` or `replace` for you. The path string that it creates is compared to the path string of the current location. If they are the same, then it will call `replace`. If they are different, then it will call `push`. This is done to mimic browser behavior and **unless you have a reason not to, you should prefer this over `push` and `replace`.**
+The `navigate` function is used to navigate to a new location.
+
+There are three ways that it can do this: `PUSH`, `REPLACE`, and `ANCHOR`.
+
+1. `PUSH` navigation pushes the new location onto the session history after the current location. Any existing locations after the current location are dropped.
+
+```js
+history.navigate("/lion-king", "PUSH");
+history.navigate(
+  {
+    pathname: "/wicked",
+    state: { musical: true }
+  },
+  "PUSH"
+);
+```
+
+2. `REPLACE` navigation replaces the current location with the new location. Any existing locations after the current location are unaffected.
+
+```js
+history.navigate("/cats", "REPLACE");
+history.navigate(
+  {
+    pathname: "/rent",
+    state: { musical: true }
+  },
+  "REPLACE"
+);
+```
+
+3. `ANCHOR` mimics the behavior of clicking on an `<a>` element. When the new location's URL is exactly the same as the current location's, it will act like `REPLACE`; when they are different, it will act like `PUSH`.
+
+```js
+history.navigate("/hairspray", "ANCHOR");
+history.navigate(
+  {
+    pathname: "/hamilton",
+    state: { musical: true }
+  },
+  "ANCHOR"
+);
+```
 
 #### arguments
 
 `to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
+
+`navType` - `ANCHOR`, `PUSH`, or `REPLACE`. If none are provided, this will default to `ANCHOR`.
 
 ### go
 
@@ -120,7 +131,7 @@ The `go` function is used to jump forward and backward to already visited locati
 ### toHref
 
 ```js
-history.toHref({ pathname: '/spamalot' });
+history.toHref({ pathname: "/spamalot" });
 // #/spamalot
 ```
 
@@ -145,7 +156,7 @@ The response handler function will be passed a "pending navigation" object. This
 
 * `location` - This is the location object that is being navigated to.
 * `action` - This is the string (`POP`, `PUSH`, or `REPLACE`) for the navigation type.
-* `finish` -  Once all matching/loading has finished, then you need to call the `finish` method to finalize the navigation. If you do not call this, the navigation will not actually occur.
+* `finish` - Once all matching/loading has finished, then you need to call the `finish` method to finalize the navigation. If you do not call this, the navigation will not actually occur.
 * `cancel` - This method allows you to cancel a navigation. It should be called if another location change occurs while the current pending navigation is still pending. Calling `cancel` gives your history instance the opportunity to roll back to its previous state. This is only really necessary for `POP` navigation since the browser has already changed the location before Hickory knows about the location change. This method takes one argument, an action string; the action string may be used to alter the cancel behavior.
 
 #### arguments

--- a/docs/api/InMemory.md
+++ b/docs/api/InMemory.md
@@ -1,7 +1,7 @@
 # InMemory API
 
 ```js
-import InMemory from '@hickory/in-memory';
+import InMemory from "@hickory/in-memory";
 
 const history = InMemory();
 ```
@@ -40,53 +40,64 @@ The index of the current location in the locations array.
 
 ## Methods
 
-### push
-
-```js
-history.push('/the-producers');
-history.push({
-  pathname: '/oklahoma',
-  state: { musical: true }
-});
-```
-
-The `push` function is used to navigate to a new location. It adds the new location after the current location. This means that if the current location is not the last location in the history array, any locations that come after the current one will be wiped out.
-
-#### arguments
-
-`to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
-
-### replace
-
-```js
-history.replace('/cats');
-history.replace({
-  pathname: '/rent',
-  state: { musical: true }
-});
-```
-
-The `replace` function is used to navigate to a new location. It replaces the current location with the new one. Any location objects that come after the current location in the history array will be preserved.
-
-#### arguments
-
-`to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
-
 ### navigate
 
 ```js
-history.navigate('/hairspray');
+history.navigate("/the-producers");
 history.navigate({
-  pathname: '/hamilton',
+  pathname: "/oklahoma",
   state: { musical: true }
 });
 ```
 
-The `navigate` function decides whether to `push` or `replace` for you. The path string that it creates is compared to the path string of the current location. If they are the same, then it will call `replace`. If they are different, then it will call `push`. This is done to mimic browser behavior and **unless you have a reason not to, you should prefer this over `push` and `replace`.**
+The `navigate` function is used to navigate to a new location.
+
+There are three ways that it can do this: `PUSH`, `REPLACE`, and `ANCHOR`.
+
+1. `PUSH` navigation pushes the new location onto the session history after the current location. Any existing locations after the current location are dropped.
+
+```js
+history.navigate("/lion-king", "PUSH");
+history.navigate(
+  {
+    pathname: "/wicked",
+    state: { musical: true }
+  },
+  "PUSH"
+);
+```
+
+2. `REPLACE` navigation replaces the current location with the new location. Any existing locations after the current location are unaffected.
+
+```js
+history.navigate("/cats", "REPLACE");
+history.navigate(
+  {
+    pathname: "/rent",
+    state: { musical: true }
+  },
+  "REPLACE"
+);
+```
+
+3. `ANCHOR` mimics the behavior of clicking on an `<a>` element. When the new location's URL is exactly the same as the current location's, it will act like `REPLACE`; when they are different, it will act like `PUSH`.
+
+```js
+history.navigate("/hairspray", "ANCHOR");
+history.navigate(
+  {
+    pathname: "/hamilton",
+    state: { musical: true }
+  },
+  "ANCHOR"
+);
+```
 
 #### arguments
 
 `to` - This can either be a string or an object. If it is a string, it will be parsed to create a location object. If it is an object, then its properties will be used to create a new location object. If the provided object is missing any location properties, then those will be given default values on the new location object.
+
+`navType` - `ANCHOR`, `PUSH`, or `REPLACE`. If none are provided, this will default to `ANCHOR`.
 
 ### go
 
@@ -105,7 +116,7 @@ The `go` function is used to jump forward and backward to already visited locati
 ### toHref
 
 ```js
-history.toHref({ pathname: '/spamalot' });
+history.toHref({ pathname: "/spamalot" });
 // /spamalot
 ```
 
@@ -130,7 +141,7 @@ The response handler function will be passed a "pending navigation" object. This
 
 * `location` - This is the location object that is being navigated to.
 * `action` - This is the string (`POP`, `PUSH`, or `REPLACE`) for the navigation type.
-* `finish` -  Once all matching/loading has finished, then you need to call the `finish` method to finalize the navigation. If you do not call this, the navigation will not actually occur.
+* `finish` - Once all matching/loading has finished, then you need to call the `finish` method to finalize the navigation. If you do not call this, the navigation will not actually occur.
 * `cancel` - This method allows you to cancel a navigation. It should be called if another location change occurs while the current pending navigation is still pending. Calling `cancel` gives your history instance the opportunity to roll back to its previous state. **Note:** This function is used by the browser and hash histories, but isn't actually necessary for the in-memory history.
 
 #### arguments

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+* `history.go()` and `history.go(0)` now reload the page.
+* Unify `navigate()`, `push()`, and `replace()` under `navigate()`. The optional second argument controls which type of navigation: `ANCHOR` (default), `PUSH`, or `REPLACE`.
+
 ## 1.0.0-beta.6
 
 * Re-export `LocationDetails`.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -18,7 +18,8 @@ import {
   ToArgument,
   ResponseHandler,
   PendingNavigation,
-  Action
+  Action,
+  NavType
 } from "@hickory/root";
 
 export {
@@ -31,6 +32,11 @@ export {
 
 export interface Options extends RootOptions {
   raw?: (pathname: string) => string;
+}
+
+interface NavSetup {
+  action: Action;
+  finish(): void;
 }
 
 function noop() {}
@@ -73,7 +79,21 @@ export default function Browser(options: Options = {}): History {
     return createPath(location);
   }
 
-  let responseHandler: ResponseHandler;
+  function setupReplace(location: HickoryLocation): NavSetup {
+    location.key = keygen.minor(browserHistory.location.key);
+    return {
+      action: "REPLACE",
+      finish: finalizeReplace(location)
+    };
+  }
+
+  function setupPush(location: HickoryLocation): NavSetup {
+    location.key = keygen.major(browserHistory.location.key);
+    return {
+      action: "PUSH",
+      finish: finalizePush(location)
+    };
+  }
 
   function finalizePush(location: HickoryLocation) {
     return () => {
@@ -95,6 +115,7 @@ export default function Browser(options: Options = {}): History {
     };
   }
 
+  let responseHandler: ResponseHandler;
   const browserHistory = {
     // set action before location because locationFromBrowser enforces that the location has a key
     action: (getStateFromHistory().key !== undefined
@@ -104,7 +125,8 @@ export default function Browser(options: Options = {}): History {
     // set response handler
     respondWith: function(fn: ResponseHandler) {
       responseHandler = fn;
-      responseHandler({
+      // immediately invoke
+      fn({
         location: browserHistory.location,
         action: browserHistory.action,
         finish: noop,
@@ -120,27 +142,28 @@ export default function Browser(options: Options = {}): History {
         fn();
       });
     },
-    // navigation
-    navigate: function navigate(to: ToArgument): void {
-      const location = createLocation(to, null);
-      const path = createPath(location);
-      const currentPath = createPath(browserHistory.location);
-
-      if (path === currentPath) {
-        browserHistory.replace(to);
-      } else {
-        browserHistory.push(to);
+    update: function update(to: ToArgument, navType: NavType = "ANCHOR"): void {
+      let setup: NavSetup;
+      const location = createLocation(to);
+      switch (navType) {
+        case "ANCHOR":
+          setup =
+            createPath(location) === createPath(browserHistory.location)
+              ? setupReplace(location)
+              : setupPush(location);
+          break;
+        case "PUSH":
+          setup = setupPush(location);
+          break;
+        case "REPLACE":
+          setup = setupReplace(location);
+          break;
       }
-    },
-    push: function push(to: ToArgument): void {
-      // the major version should be the current key + 1
-      const key = keygen.major(browserHistory.location.key);
-      const location = createLocation(to, key);
       confirmNavigation(
         {
           to: location,
           from: browserHistory.location,
-          action: "PUSH"
+          action: setup.action
         },
         () => {
           if (!responseHandler) {
@@ -148,54 +171,15 @@ export default function Browser(options: Options = {}): History {
           }
           responseHandler({
             location,
-            action: "PUSH",
-            finish: finalizePush(location),
-            cancel: noop
-          });
-        }
-      );
-    },
-    replace: function replace(to: ToArgument): void {
-      // pass the current key to just increment the minor portion
-      const key = keygen.minor(browserHistory.location.key);
-      const location = createLocation(to, key);
-      confirmNavigation(
-        {
-          to: location,
-          from: browserHistory.location,
-          action: "REPLACE"
-        },
-        () => {
-          if (!responseHandler) {
-            return;
-          }
-          responseHandler({
-            location,
-            action: "REPLACE",
-            finish: finalizeReplace(location),
+            action: setup.action,
+            finish: setup.finish,
             cancel: noop
           });
         }
       );
     },
     go: function go(num: number): void {
-      // Calling window.history.go with no value reloads the page. Instead
-      // we will just call the responseHandler with the current location
-      if (!num) {
-        if (!responseHandler) {
-          return;
-        }
-        responseHandler({
-          location: browserHistory.location,
-          action: "POP",
-          finish: () => {
-            browserHistory.action = "POP";
-          },
-          cancel: noop
-        });
-      } else {
-        window.history.go(num);
-      }
+      window.history.go(num);
     }
   };
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -142,7 +142,10 @@ export default function Browser(options: Options = {}): History {
         fn();
       });
     },
-    update: function update(to: ToArgument, navType: NavType = "ANCHOR"): void {
+    navigate: function navigate(
+      to: ToArgument,
+      navType: NavType = "ANCHOR"
+    ): void {
       let setup: NavSetup;
       const location = createLocation(to);
       switch (navType) {

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -29,7 +29,7 @@ describe("browser integration tests", () => {
     testHistory.destroy();
   });
 
-  describe("update()", () => {
+  describe("navigate()", () => {
     describe("ANCHOR (default)", () => {
       beforeEach(() => {
         spyOn(window.history, "pushState").and.callThrough();
@@ -42,13 +42,13 @@ describe("browser integration tests", () => {
       });
 
       it("can navigate with navigate", () => {
-        testHistory.update("/the-new-location");
+        testHistory.navigate("/the-new-location");
         expect(window.location.pathname).toEqual("/the-new-location");
       });
 
       it("sets the state", () => {
         const providedState = { isSet: true };
-        testHistory.update({
+        testHistory.navigate({
           pathname: "/next",
           state: providedState
         });
@@ -58,7 +58,7 @@ describe("browser integration tests", () => {
       });
 
       it("calls history.pushState when navigating to a new location", () => {
-        testHistory.update("/new-location");
+        testHistory.navigate("/new-location");
         expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(1);
         expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
           0
@@ -66,7 +66,7 @@ describe("browser integration tests", () => {
       });
 
       it("calls history.replaceState when navigating to the same location", () => {
-        testHistory.update("/");
+        testHistory.navigate("/");
         expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(0);
         expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
           1
@@ -76,13 +76,13 @@ describe("browser integration tests", () => {
 
     describe("PUSH", () => {
       it("can navigate with push", () => {
-        testHistory.update("/the-new-location", "PUSH");
+        testHistory.navigate("/the-new-location", "PUSH");
         expect(window.location.pathname).toEqual("/the-new-location");
       });
 
       it("sets the state", () => {
         const providedState = { isSet: true };
-        testHistory.update(
+        testHistory.navigate(
           {
             pathname: "/next",
             state: providedState
@@ -95,7 +95,7 @@ describe("browser integration tests", () => {
       });
 
       it("pushes URL using rawPathname, not pathname", () => {
-        testHistory.update(
+        testHistory.navigate(
           {
             pathname: "/encoded-percent%25"
           },
@@ -108,13 +108,13 @@ describe("browser integration tests", () => {
 
     describe("REPLACE", () => {
       it("can navigate with replace", () => {
-        testHistory.update("/the-same-location", "REPLACE");
+        testHistory.navigate("/the-same-location", "REPLACE");
         expect(window.location.pathname).toEqual("/the-same-location");
       });
 
       it("sets the state", () => {
         const providedState = { isSet: true };
-        testHistory.update(
+        testHistory.navigate(
           {
             pathname: "/next",
             state: providedState
@@ -130,9 +130,9 @@ describe("browser integration tests", () => {
 
   describe("go", () => {
     it("can navigate with go", done => {
-      testHistory.update("/one", "PUSH");
-      testHistory.update("/two", "PUSH");
-      testHistory.update("/three", "PUSH");
+      testHistory.navigate("/one", "PUSH");
+      testHistory.navigate("/two", "PUSH");
+      testHistory.navigate("/three", "PUSH");
 
       const goRouter = ignoreFirstCall(function(pending) {
         expect(pending.location.pathname).toEqual("/one");
@@ -145,9 +145,9 @@ describe("browser integration tests", () => {
 
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
-      testHistory.update("/uno", "PUSH");
-      testHistory.update("/dos", "PUSH");
-      testHistory.update("/tres", "PUSH");
+      testHistory.navigate("/uno", "PUSH");
+      testHistory.navigate("/dos", "PUSH");
+      testHistory.navigate("/tres", "PUSH");
 
       const goRouter = ignoreFirstCall(function(pending) {
         expect(pending.location.pathname).toEqual("/uno");

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -1,5 +1,5 @@
 ///<reference path="../../node_modules/@types/jasmine/index.d.ts"/>
-import Browser from '../../src';
+import Browser from "../../src";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -12,12 +12,12 @@ function ignoreFirstCall(fn) {
   };
 }
 
-describe('browser integration tests', () => {
+describe("browser integration tests", () => {
   let testHistory;
 
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
-    window.history.pushState(null, '', '/');
+    window.history.pushState(null, "", "/");
     testHistory = Browser();
     function router(pending) {
       pending.finish();
@@ -29,93 +29,113 @@ describe('browser integration tests', () => {
     testHistory.destroy();
   });
 
-  describe('navigate', () => {
-    beforeEach(() => {
-      spyOn(window.history, 'pushState').and.callThrough();
-      spyOn(window.history, 'replaceState').and.callThrough();
-    });
-
-    afterEach(() => {
-      (window.history.pushState as jasmine.Spy).calls.reset();
-      (window.history.replaceState as jasmine.Spy).calls.reset();
-    });
-
-    it('can navigate with navigate', () => {
-      testHistory.navigate('/the-new-location');
-      expect(window.location.pathname).toEqual('/the-new-location');
-    });
-
-    it('sets the state', () => {
-      const providedState = { isSet: true };
-      testHistory.navigate('/next', providedState);
-      const { state, key } = testHistory.location;
-      expect(window.history.state.state).toEqual(state);
-      expect(window.history.state.key).toBe(key);
-    });
-
-    it('calls history.pushState when navigating to a new location', () => {
-      testHistory.navigate('/new-location');
-      expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(1);
-      expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
-        0
-      );
-    });
-
-    it('calls history.replaceState when navigating to the same location', () => {
-      testHistory.navigate('/');
-      expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(0);
-      expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
-        1
-      );
-    });
-  });
-
-  describe('push', () => {
-    it('can navigate with push', () => {
-      testHistory.push('/the-new-location');
-      expect(window.location.pathname).toEqual('/the-new-location');
-    });
-
-    it('sets the state', () => {
-      const providedState = { isSet: true };
-      testHistory.push('/next', providedState);
-      const { state, key } = testHistory.location;
-      expect(window.history.state.state).toEqual(state);
-      expect(window.history.state.key).toBe(key);
-    });
-
-    it('pushes URL using rawPathname, not pathname', () => {
-      testHistory.push({
-        pathname: '/encoded-percent%25'
+  describe("update()", () => {
+    describe("ANCHOR (default)", () => {
+      beforeEach(() => {
+        spyOn(window.history, "pushState").and.callThrough();
+        spyOn(window.history, "replaceState").and.callThrough();
       });
-      expect(window.location.pathname).toEqual('/encoded-percent%25');
-      expect(testHistory.location.pathname).toEqual('/encoded-percent%');
+
+      afterEach(() => {
+        (window.history.pushState as jasmine.Spy).calls.reset();
+        (window.history.replaceState as jasmine.Spy).calls.reset();
+      });
+
+      it("can navigate with navigate", () => {
+        testHistory.update("/the-new-location");
+        expect(window.location.pathname).toEqual("/the-new-location");
+      });
+
+      it("sets the state", () => {
+        const providedState = { isSet: true };
+        testHistory.update({
+          pathname: "/next",
+          state: providedState
+        });
+        const { state, key } = testHistory.location;
+        expect(window.history.state.state).toEqual(state);
+        expect(window.history.state.key).toBe(key);
+      });
+
+      it("calls history.pushState when navigating to a new location", () => {
+        testHistory.update("/new-location");
+        expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(1);
+        expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
+          0
+        );
+      });
+
+      it("calls history.replaceState when navigating to the same location", () => {
+        testHistory.update("/");
+        expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(0);
+        expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
+          1
+        );
+      });
+    });
+
+    describe("PUSH", () => {
+      it("can navigate with push", () => {
+        testHistory.update("/the-new-location", "PUSH");
+        expect(window.location.pathname).toEqual("/the-new-location");
+      });
+
+      it("sets the state", () => {
+        const providedState = { isSet: true };
+        testHistory.update(
+          {
+            pathname: "/next",
+            state: providedState
+          },
+          "PUSH"
+        );
+        const { state, key } = testHistory.location;
+        expect(window.history.state.state).toEqual(state);
+        expect(window.history.state.key).toBe(key);
+      });
+
+      it("pushes URL using rawPathname, not pathname", () => {
+        testHistory.update(
+          {
+            pathname: "/encoded-percent%25"
+          },
+          "PUSH"
+        );
+        expect(window.location.pathname).toEqual("/encoded-percent%25");
+        expect(testHistory.location.pathname).toEqual("/encoded-percent%");
+      });
+    });
+
+    describe("REPLACE", () => {
+      it("can navigate with replace", () => {
+        testHistory.update("/the-same-location", "REPLACE");
+        expect(window.location.pathname).toEqual("/the-same-location");
+      });
+
+      it("sets the state", () => {
+        const providedState = { isSet: true };
+        testHistory.update(
+          {
+            pathname: "/next",
+            state: providedState
+          },
+          "REPLACE"
+        );
+        const { state, key } = testHistory.location;
+        expect(window.history.state.state).toEqual(state);
+        expect(window.history.state.key).toBe(key);
+      });
     });
   });
 
-  describe('replace', () => {
-    it('can navigate with replace', () => {
-      testHistory.replace('/the-same-location');
-      expect(window.location.pathname).toEqual('/the-same-location');
-    });
-
-    it('sets the state', () => {
-      const providedState = { isSet: true };
-      testHistory.replace('/next', providedState);
-      const { state, key } = testHistory.location;
-      expect(window.history.state.state).toEqual(state);
-      expect(window.history.state.key).toBe(key);
-    });
-  });
-
-  describe('go', () => {
-    it('can navigate with go', done => {
-      testHistory.push('/one');
-      testHistory.push('/two');
-      testHistory.push('/three');
+  describe("go", () => {
+    it("can navigate with go", done => {
+      testHistory.update("/one", "PUSH");
+      testHistory.update("/two", "PUSH");
+      testHistory.update("/three", "PUSH");
 
       const goRouter = ignoreFirstCall(function(pending) {
-        expect(pending.location.pathname).toEqual('/one');
+        expect(pending.location.pathname).toEqual("/one");
         done();
       });
       testHistory.respondWith(goRouter);
@@ -123,14 +143,14 @@ describe('browser integration tests', () => {
     });
   });
 
-  describe('browser navigation', () => {
-    it('can detect navigation triggered by the browser', done => {
-      testHistory.push('/uno');
-      testHistory.push('/dos');
-      testHistory.push('/tres');
+  describe("browser navigation", () => {
+    it("can detect navigation triggered by the browser", done => {
+      testHistory.update("/uno", "PUSH");
+      testHistory.update("/dos", "PUSH");
+      testHistory.update("/tres", "PUSH");
 
       const goRouter = ignoreFirstCall(function(pending) {
-        expect(pending.location.pathname).toEqual('/uno');
+        expect(pending.location.pathname).toEqual("/uno");
         done();
       });
       testHistory.respondWith(goRouter);

--- a/packages/browser/tests/unit/anchor.spec.ts
+++ b/packages/browser/tests/unit/anchor.spec.ts
@@ -15,7 +15,7 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "ANCHOR")', () => {
+describe('navigate(..., "ANCHOR")', () => {
   let dom;
   let window;
 
@@ -35,7 +35,7 @@ describe('update(..., "ANCHOR")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = Browser();
-      testHistory.update("/two");
+      testHistory.navigate("/two");
       expect(window.location.pathname).toBe("/one");
     });
   });
@@ -45,7 +45,7 @@ describe('update(..., "ANCHOR")', () => {
       const testHistory = Browser();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two");
+      testHistory.navigate("/two");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -59,7 +59,7 @@ describe('update(..., "ANCHOR")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing");
+        testHistory.navigate("/two?test=ing");
       });
 
       it("is a location object created from pushed object", () => {
@@ -71,7 +71,7 @@ describe('update(..., "ANCHOR")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" });
+        testHistory.navigate({ pathname: "/two", hash: "test" });
       });
 
       it("(new) increments major key", () => {
@@ -84,7 +84,7 @@ describe('update(..., "ANCHOR")', () => {
         const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.update("/next");
+        testHistory.navigate("/next");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -105,7 +105,7 @@ describe('update(..., "ANCHOR")', () => {
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.update("/one");
+        testHistory.navigate("/one");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -125,7 +125,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
       });
 
       it('(same) is "REPLACE"', () => {
@@ -135,7 +135,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/one");
+        testHistory.navigate("/one");
       });
     });
 
@@ -148,15 +148,15 @@ describe('update(..., "ANCHOR")', () => {
           expect(window.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate() is not called", () => {
         const testHistory = Browser();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
         expect(window.location.pathname).toBe("/one");
       });
 
@@ -166,7 +166,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -178,7 +178,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
         expect(testHistory.action).toBe("PUSH");
       });
 
@@ -188,7 +188,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/one");
+        testHistory.navigate("/one");
         expect(testHistory.action).toBe("REPLACE");
       });
     });
@@ -202,7 +202,7 @@ describe('update(..., "ANCHOR")', () => {
           expect(window.location.pathname).toBe("/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
 
       it("does not update the action value", () => {
@@ -213,7 +213,7 @@ describe('update(..., "ANCHOR")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
     });
   });
@@ -228,7 +228,7 @@ describe('update(..., "ANCHOR")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next");
+      testHistory.navigate("/next");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -241,7 +241,7 @@ describe('update(..., "ANCHOR")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next");
+      testHistory.navigate("/next");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/browser/tests/unit/anchor.spec.ts
+++ b/packages/browser/tests/unit/anchor.spec.ts
@@ -1,6 +1,6 @@
-import 'jest';
-import Browser from '../../src';
-import { jsdom } from 'jsdom';
+import "jest";
+import Browser from "../../src";
+import { jsdom } from "jsdom";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -15,13 +15,13 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('navigate', () => {
+describe('update(..., "ANCHOR")', () => {
   let dom;
   let window;
 
   beforeEach(() => {
-    dom = jsdom('', {
-      url: 'http://example.com/one'
+    dom = jsdom("", {
+      url: "http://example.com/one"
     });
     window = global.window = dom.defaultView;
     global.document = dom;
@@ -32,83 +32,83 @@ describe('navigate', () => {
     global.document = undefined;
   });
 
-  describe('without a response handler', () => {
-    it('does nothing', () => {
+  describe("without a response handler", () => {
+    it("does nothing", () => {
       const testHistory = Browser();
-      testHistory.navigate('/two');
-      expect(window.location.pathname).toBe('/one');
+      testHistory.update("/two");
+      expect(window.location.pathname).toBe("/one");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
       const testHistory = Browser();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.navigate('/two');
+      testHistory.update("/two");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.navigate('/two?test=ing');
+        testHistory.update("/two?test=ing");
       });
 
-      it('is a location object created from pushed object', () => {
+      it("is a location object created from pushed object", () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.navigate({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" });
       });
 
-      it('(new) increments major key', () => {
+      it("(new) increments major key", () => {
         const testHistory = Browser();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor] = testHistory.location.key.split('.');
+        const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.navigate('/next');
+        testHistory.update("/next");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
 
         expect(currentMajorNum).toEqual(initMajorNum + 1);
-        expect(currentMinor).toBe('0');
+        expect(currentMinor).toBe("0");
       });
 
-      it('(same) increments minor key', () => {
+      it("(same) increments minor key", () => {
         const testHistory = Browser();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor, initMinor] = testHistory.location.key.split('.');
+        const [initMajor, initMinor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.navigate('/one');
+        testHistory.update("/one");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
         const currentMinorNum = parseInt(currentMinor, 10);
 
@@ -117,58 +117,58 @@ describe('navigate', () => {
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('(new) is "PUSH"', () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('PUSH');
+          expect(pending.action).toBe("PUSH");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
+        testHistory.update("/next");
       });
 
       it('(same) is "REPLACE"', () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('REPLACE');
+          expect(pending.action).toBe("REPLACE");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/one');
+        testHistory.update("/one");
       });
     });
 
-    describe('finish', () => {
-      it('updates browser history when finish function is called', () => {
+    describe("finish", () => {
+      it("updates browser history when finish function is called", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
           pending.finish();
-          expect(window.location.pathname).toBe('/two');
+          expect(window.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
 
-      it('does nothing if update is not called', () => {
+      it("does nothing if update is not called", () => {
         const testHistory = Browser();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
-        expect(window.location.pathname).toBe('/one');
+        testHistory.update("/two");
+        expect(window.location.pathname).toBe("/one");
       });
 
-      it('sets history.location to new location object', () => {
+      it("sets history.location to new location object", () => {
         const testHistory = Browser();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
+        testHistory.update("/next");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
@@ -178,8 +178,8 @@ describe('navigate', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
-        expect(testHistory.action).toBe('PUSH');
+        testHistory.update("/next");
+        expect(testHistory.action).toBe("PUSH");
       });
 
       it('(same) sets history.action to "REPLACE"', () => {
@@ -188,38 +188,38 @@ describe('navigate', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/one');
-        expect(testHistory.action).toBe('REPLACE');
+        testHistory.update("/one");
+        expect(testHistory.action).toBe("REPLACE");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update browser history when cancel function is called', () => {
+    describe("cancel", () => {
+      it("does not update browser history when cancel function is called", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
           pending.cancel();
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
 
-      it('does not update the action value', () => {
+      it("does not update the action value", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
       const testHistory = Browser();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -228,11 +228,11 @@ describe('navigate', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.navigate('/next');
+      testHistory.update("/next");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
+    it("does not call response pending when the user prevents the navigation", () => {
       const testHistory = Browser();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -241,7 +241,7 @@ describe('navigate', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.navigate('/next');
+      testHistory.update("/next");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/browser/tests/unit/go.spec.ts
+++ b/packages/browser/tests/unit/go.spec.ts
@@ -59,7 +59,7 @@ describe("go", () => {
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(pushRouter);
-          testHistory.update("/seven", "PUSH");
+          testHistory.navigate("/seven", "PUSH");
         });
         const pushRouter = ignoreFirstCall(function(pending) {
           cancelGo("PUSH");
@@ -70,11 +70,11 @@ describe("go", () => {
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
-        testHistory.update("/six", "PUSH"); // 5.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
+        testHistory.navigate("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -93,7 +93,7 @@ describe("go", () => {
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(replaceRouter);
-          testHistory.update("/seven", "REPLACE");
+          testHistory.navigate("/seven", "REPLACE");
         });
         const replaceRouter = ignoreFirstCall(function(pending) {
           cancelGo("REPLACE");
@@ -104,11 +104,11 @@ describe("go", () => {
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
-        testHistory.update("/six", "PUSH"); // 5.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
+        testHistory.navigate("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -138,11 +138,11 @@ describe("go", () => {
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
-        testHistory.update("/six", "PUSH"); // 5.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
+        testHistory.navigate("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -171,8 +171,8 @@ describe("go", () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router);
 
-      testHistory.update("/two", "PUSH"); // 1.0
-      testHistory.update("/three", "PUSH"); // 2.0
+      testHistory.navigate("/two", "PUSH"); // 1.0
+      testHistory.navigate("/three", "PUSH"); // 2.0
       setup = true;
       testHistory.go(-2);
     });
@@ -187,8 +187,8 @@ describe("go", () => {
       }
       testHistory.respondWith(router);
 
-      testHistory.update("/two", "PUSH"); // 1.0
-      testHistory.update("/three", "PUSH"); // 2.0
+      testHistory.navigate("/two", "PUSH"); // 1.0
+      testHistory.navigate("/three", "PUSH"); // 2.0
       // don't add function until we have setup the history
       testHistory.confirmWith(confirm);
       testHistory.go(-2);

--- a/packages/browser/tests/unit/go.spec.ts
+++ b/packages/browser/tests/unit/go.spec.ts
@@ -1,6 +1,6 @@
-import 'jest';
-import Browser from '../../src';
-import { jsdom } from 'jsdom';
+import "jest";
+import Browser from "../../src";
+import { jsdom } from "jsdom";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -15,13 +15,13 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('go', () => {
+describe("go", () => {
   let dom;
   let window;
 
   beforeEach(() => {
-    dom = jsdom('', {
-      url: 'http://example.com/one'
+    dom = jsdom("", {
+      url: "http://example.com/one"
     });
     window = global.window = dom.defaultView;
     global.document = dom;
@@ -32,61 +32,21 @@ describe('go', () => {
     global.document = undefined;
   });
 
-  describe('with no value', () => {
-    it('calls response handler with current location and "POP" action', done => {
-      const testHistory = Browser();
-      const router = ignoreFirstCall(function(pending) {
-        expect(pending.location).toMatchObject({
-          pathname: '/one'
-        });
-        expect(pending.action).toBe('POP');
-        done();
-      });
-      testHistory.respondWith(router); // calls router
-      testHistory.go();
+  it("calls window.history.go with provided value", () => {
+    const realGo = window.history.go;
+    const mockGo = (window.history.go = jest.fn());
+    const testHistory = Browser();
+
+    [undefined, 0, 1, -1].forEach((value, index) => {
+      testHistory.go(value);
+      expect(mockGo.mock.calls[index][0]).toBe(value);
     });
+    window.history.go = realGo;
   });
 
-  it('does nothing if the value is outside of the range', () => {
-    const testHistory = Browser();
-    const router = jest.fn();
-    testHistory.respondWith(router);
-    testHistory.go(10);
-    // just verifying that a popstate event hasn't emitted to
-    // trigger the history's event handler
-    setTimeout(() => {
-      expect(router.mock.calls.length).toBe(1);
-    }, 50);
-  });
-
-  it('calls response handler with expected location and action', done => {
-    const testHistory = Browser();
-    let setup = false;
-    function router(pending) {
-      pending.finish();
-      if (!setup) {
-        return;
-      }
-      expect(pending.location).toMatchObject({
-        pathname: '/four',
-        key: '3.0'
-      });
-      expect(pending.action).toBe('POP');
-      done();
-    }
-    testHistory.respondWith(router);
-    testHistory.push('/two'); // 1.0
-    testHistory.push('/three'); // 2.0
-    testHistory.push('/four'); // 3.0
-    testHistory.push('/five'); // 4.0
-    testHistory.push('/six'); // 5.0
-    setup = true;
-    testHistory.go(-2);
-  });
-
-  describe('respondWith', () => {
-    describe('cancel', () => {
-      it('undoes the pop if pushing before pending response finishes', done => {
+  describe("respondWith", () => {
+    describe("cancel", () => {
+      it("undoes the pop if pushing before pending response finishes", done => {
         const testHistory = Browser();
         let setup = false;
         function initialRouter(pending) {
@@ -95,32 +55,32 @@ describe('go', () => {
         let cancelGo;
         const goRouter = ignoreFirstCall(function(pending) {
           // at this point, the browser has popped
-          expect(window.location.pathname).toBe('/four');
+          expect(window.location.pathname).toBe("/four");
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(pushRouter);
-          testHistory.push('/seven');
+          testHistory.update("/seven", "PUSH");
         });
         const pushRouter = ignoreFirstCall(function(pending) {
-          cancelGo('PUSH');
+          cancelGo("PUSH");
           setTimeout(() => {
-            expect(window.location.pathname).toBe('/six');
+            expect(window.location.pathname).toBe("/six");
             done();
           }, 50);
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
-        testHistory.push('/six'); // 5.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.update("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
       });
 
-      it('undoes the pop if replacing before pending response finishes', done => {
+      it("undoes the pop if replacing before pending response finishes", done => {
         const testHistory = Browser();
         let setup = false;
         function initialRouter(pending) {
@@ -129,32 +89,32 @@ describe('go', () => {
         let cancelGo;
         const goRouter = ignoreFirstCall(function(pending) {
           // at this point, the browser has popped
-          expect(window.location.pathname).toBe('/four');
+          expect(window.location.pathname).toBe("/four");
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(replaceRouter);
-          testHistory.replace('/seven');
+          testHistory.update("/seven", "REPLACE");
         });
         const replaceRouter = ignoreFirstCall(function(pending) {
-          cancelGo('REPLACE');
+          cancelGo("REPLACE");
           setTimeout(() => {
-            expect(window.location.pathname).toBe('/six');
+            expect(window.location.pathname).toBe("/six");
             done();
           }, 50);
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
-        testHistory.push('/six'); // 5.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.update("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
       });
 
-      it('does nothing if popping before pending response finishes', done => {
+      it("does nothing if popping before pending response finishes", done => {
         const testHistory = Browser();
         let setup = false;
         function initialRouter(pending) {
@@ -163,26 +123,26 @@ describe('go', () => {
         let cancelGo;
         const goRouter = ignoreFirstCall(function(pending) {
           // at this point, the browser has popped
-          expect(window.location.pathname).toBe('/four');
+          expect(window.location.pathname).toBe("/four");
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(popRouter);
           testHistory.go(-1);
         });
         const popRouter = ignoreFirstCall(function(pending) {
-          cancelGo('POP');
+          cancelGo("POP");
           setTimeout(() => {
-            expect(window.location.pathname).toBe('/three');
+            expect(window.location.pathname).toBe("/three");
             done();
           }, 50);
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
-        testHistory.push('/six'); // 5.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.update("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -190,8 +150,8 @@ describe('go', () => {
     });
   });
 
-  describe('with user confirmation', () => {
-    it('calls response handler after the user confirms the navigation', done => {
+  describe("with user confirmation", () => {
+    it("calls response handler after the user confirms the navigation", done => {
       const testHistory = Browser();
       let setup = false;
       const router = ignoreFirstCall(function(pending) {
@@ -200,8 +160,8 @@ describe('go', () => {
           return;
         }
         expect(testHistory.location).toMatchObject({
-          pathname: '/one',
-          key: '0.0'
+          pathname: "/one",
+          key: "0.0"
         });
         done();
       });
@@ -211,13 +171,13 @@ describe('go', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router);
 
-      testHistory.push('/two'); // 1.0
-      testHistory.push('/three'); // 2.0
+      testHistory.update("/two", "PUSH"); // 1.0
+      testHistory.update("/three", "PUSH"); // 2.0
       setup = true;
       testHistory.go(-2);
     });
 
-    it('does not call response handler when the user prevents the navigation', done => {
+    it("does not call response handler when the user prevents the navigation", done => {
       const testHistory = Browser();
       const confirm = (info, confirm, prevent) => {
         prevent();
@@ -227,8 +187,8 @@ describe('go', () => {
       }
       testHistory.respondWith(router);
 
-      testHistory.push('/two'); // 1.0
-      testHistory.push('/three'); // 2.0
+      testHistory.update("/two", "PUSH"); // 1.0
+      testHistory.update("/three", "PUSH"); // 2.0
       // don't add function until we have setup the history
       testHistory.confirmWith(confirm);
       testHistory.go(-2);
@@ -236,8 +196,8 @@ describe('go', () => {
       // need to wait for window.history.go to emit a popstate event
       setTimeout(() => {
         expect(testHistory.location).toMatchObject({
-          pathname: '/three',
-          key: '2.0'
+          pathname: "/three",
+          key: "2.0"
         });
         done();
       }, 50);

--- a/packages/browser/tests/unit/push.spec.ts
+++ b/packages/browser/tests/unit/push.spec.ts
@@ -15,7 +15,7 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "PUSH")', () => {
+describe('navigate(..., "PUSH")', () => {
   let dom;
   let window;
 
@@ -35,7 +35,7 @@ describe('update(..., "PUSH")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = Browser();
-      testHistory.update("/two", "PUSH");
+      testHistory.navigate("/two", "PUSH");
       expect(window.location.pathname).toBe("/one");
     });
   });
@@ -45,7 +45,7 @@ describe('update(..., "PUSH")', () => {
       const testHistory = Browser();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two", "PUSH");
+      testHistory.navigate("/two", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -59,7 +59,7 @@ describe('update(..., "PUSH")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing", "PUSH");
+        testHistory.navigate("/two?test=ing", "PUSH");
       });
 
       it("is a location object created from pushed object", () => {
@@ -71,7 +71,7 @@ describe('update(..., "PUSH")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" }, "PUSH");
+        testHistory.navigate({ pathname: "/two", hash: "test" }, "PUSH");
       });
 
       it("increments current major key value by 1, sets minor value to 0", () => {
@@ -84,7 +84,7 @@ describe('update(..., "PUSH")', () => {
         const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -104,7 +104,7 @@ describe('update(..., "PUSH")', () => {
             pending.action === "POP" &&
             pending.location.pathname === "/three"
           ) {
-            testHistory.update("/new-four", "PUSH");
+            testHistory.navigate("/new-four", "PUSH");
             afterPop = true;
           }
           if (afterPop) {
@@ -114,10 +114,10 @@ describe('update(..., "PUSH")', () => {
         }
         testHistory.respondWith(router); // calls router
         // just getting the history in the expected state
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
         testHistory.go(-2); // 2.0
       });
     });
@@ -130,7 +130,7 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
       });
     });
 
@@ -143,15 +143,15 @@ describe('update(..., "PUSH")', () => {
           expect(window.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate is not called", () => {
         const testHistory = Browser();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
         expect(window.location.pathname).toBe("/one");
       });
 
@@ -161,7 +161,7 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -173,13 +173,13 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
         expect(testHistory.action).toBe("PUSH");
       });
     });
 
     describe("cancel", () => {
-      it("does not update browser history when cancel function is called", () => {
+      it("does not navigate browser history when cancel function is called", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
           expect(window.location.pathname).toBe("/one");
@@ -187,10 +187,10 @@ describe('update(..., "PUSH")', () => {
           expect(window.location.pathname).toBe("/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
 
-      it("does not update the action value", () => {
+      it("does not navigate the action value", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
           expect(testHistory.action).toBe("PUSH");
@@ -198,7 +198,7 @@ describe('update(..., "PUSH")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
     });
   });
@@ -213,7 +213,7 @@ describe('update(..., "PUSH")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "PUSH");
+      testHistory.navigate("/next", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -226,7 +226,7 @@ describe('update(..., "PUSH")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "PUSH");
+      testHistory.navigate("/next", "PUSH");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/browser/tests/unit/push.spec.ts
+++ b/packages/browser/tests/unit/push.spec.ts
@@ -1,6 +1,6 @@
-import 'jest';
-import Browser from '../../src';
-import { jsdom } from 'jsdom';
+import "jest";
+import Browser from "../../src";
+import { jsdom } from "jsdom";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -15,13 +15,13 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('push', () => {
+describe('update(..., "PUSH")', () => {
   let dom;
   let window;
 
   beforeEach(() => {
-    dom = jsdom('', {
-      url: 'http://example.com/one'
+    dom = jsdom("", {
+      url: "http://example.com/one"
     });
     window = global.window = dom.defaultView;
     global.document = dom;
@@ -32,66 +32,66 @@ describe('push', () => {
     global.document = undefined;
   });
 
-  describe('without a response handler', () => {
-    it('does nothing', () => {
+  describe("without a response handler", () => {
+    it("does nothing", () => {
       const testHistory = Browser();
-      testHistory.push('/two');
-      expect(window.location.pathname).toBe('/one');
+      testHistory.update("/two", "PUSH");
+      expect(window.location.pathname).toBe("/one");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
       const testHistory = Browser();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.push('/two');
+      testHistory.update("/two", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.push('/two?test=ing');
+        testHistory.update("/two?test=ing", "PUSH");
       });
 
-      it('is a location object created from pushed object', () => {
+      it("is a location object created from pushed object", () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.push({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" }, "PUSH");
       });
 
-      it('increments current major key value by 1, sets minor value to 0', () => {
+      it("increments current major key value by 1, sets minor value to 0", () => {
         const testHistory = Browser();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor] = testHistory.location.key.split('.');
+        const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
 
         expect(currentMajorNum).toEqual(initMajorNum + 1);
-        expect(currentMinor).toBe('0');
+        expect(currentMinor).toBe("0");
       });
 
       it("increments from current location's key when not at end of locations", done => {
@@ -101,69 +101,69 @@ describe('push', () => {
         function router(pending) {
           pending.finish();
           if (
-            pending.action === 'POP' &&
-            pending.location.pathname === '/three'
+            pending.action === "POP" &&
+            pending.location.pathname === "/three"
           ) {
-            testHistory.push('/new-four');
+            testHistory.update("/new-four", "PUSH");
             afterPop = true;
           }
           if (afterPop) {
-            expect(testHistory.location.key).toBe('3.0');
+            expect(testHistory.location.key).toBe("3.0");
             done();
           }
         }
         testHistory.respondWith(router); // calls router
         // just getting the history in the expected state
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
         testHistory.go(-2); // 2.0
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('is "PUSH"', () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('PUSH');
+          expect(pending.action).toBe("PUSH");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
       });
     });
 
-    describe('finish', () => {
-      it('updates browser history when finish function is called', () => {
+    describe("finish", () => {
+      it("updates browser history when finish function is called", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
           pending.finish();
-          expect(window.location.pathname).toBe('/two');
+          expect(window.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
 
-      it('does nothing if update is not called', () => {
+      it("does nothing if update is not called", () => {
         const testHistory = Browser();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
-        expect(window.location.pathname).toBe('/one');
+        testHistory.update("/two", "PUSH");
+        expect(window.location.pathname).toBe("/one");
       });
 
-      it('sets history.location to new location object', () => {
+      it("sets history.location to new location object", () => {
         const testHistory = Browser();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
@@ -173,38 +173,38 @@ describe('push', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
-        expect(testHistory.action).toBe('PUSH');
+        testHistory.update("/next", "PUSH");
+        expect(testHistory.action).toBe("PUSH");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update browser history when cancel function is called', () => {
+    describe("cancel", () => {
+      it("does not update browser history when cancel function is called", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
           pending.cancel();
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
 
-      it('does not update the action value', () => {
+      it("does not update the action value", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
       const testHistory = Browser();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -213,11 +213,11 @@ describe('push', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.push('/next');
+      testHistory.update("/next", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
+    it("does not call response pending when the user prevents the navigation", () => {
       const testHistory = Browser();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -226,7 +226,7 @@ describe('push', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.push('/next');
+      testHistory.update("/next", "PUSH");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/browser/tests/unit/replace.spec.ts
+++ b/packages/browser/tests/unit/replace.spec.ts
@@ -1,6 +1,6 @@
-import 'jest';
-import Browser from '../../src';
-import { jsdom } from 'jsdom';
+import "jest";
+import Browser from "../../src";
+import { jsdom } from "jsdom";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -15,13 +15,13 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('replace', () => {
+describe('update(..., "REPLACE")', () => {
   let dom;
   let window;
 
   beforeEach(() => {
-    dom = jsdom('', {
-      url: 'http://example.com/one'
+    dom = jsdom("", {
+      url: "http://example.com/one"
     });
     window = global.window = dom.defaultView;
     global.document = dom;
@@ -32,46 +32,46 @@ describe('replace', () => {
     global.document = undefined;
   });
 
-  describe('without a response handler', () => {
-    it('does nothing', () => {
+  describe("without a response handler", () => {
+    it("does nothing", () => {
       const testHistory = Browser();
-      testHistory.replace('/two');
-      expect(window.location.pathname).toBe('/one');
+      testHistory.update("/two", "REPLACE");
+      expect(window.location.pathname).toBe("/one");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
       const testHistory = Browser();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.replace('/two');
+      testHistory.update("/two", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.replace('/two?test=ing');
+        testHistory.update("/two?test=ing", "REPLACE");
       });
 
-      it('is a location object created from pushed object', () => {
+      it("is a location object created from pushed object", () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.replace({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" }, "REPLACE");
       });
 
       it("key maintains current location's major value, increments the minor value", () => {
@@ -81,14 +81,14 @@ describe('replace', () => {
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor, initMinor] = testHistory.location.key.split('.');
+        const [initMajor, initMinor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
         const currentMinorNum = parseInt(currentMinor, 10);
 
@@ -97,48 +97,48 @@ describe('replace', () => {
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('is "REPLACE"', () => {
         const testHistory = Browser();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('REPLACE');
+          expect(pending.action).toBe("REPLACE");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
       });
     });
 
-    describe('finish', () => {
-      it('updates browser history when finish function is called', () => {
+    describe("finish", () => {
+      it("updates browser history when finish function is called", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
           pending.finish();
-          expect(window.location.pathname).toBe('/two');
+          expect(window.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
 
-      it('does nothing if update is not called', () => {
+      it("does nothing if update is not called", () => {
         const testHistory = Browser();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
-        expect(window.location.pathname).toBe('/one');
+        testHistory.update("/two", "REPLACE");
+        expect(window.location.pathname).toBe("/one");
       });
 
-      it('sets history.location to new location object', () => {
+      it("sets history.location to new location object", () => {
         const testHistory = Browser();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
@@ -148,38 +148,38 @@ describe('replace', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
-        expect(testHistory.action).toBe('REPLACE');
+        testHistory.update("/next", "REPLACE");
+        expect(testHistory.action).toBe("REPLACE");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update browser history when cancel function is called', () => {
+    describe("cancel", () => {
+      it("does not update browser history when cancel function is called", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
           pending.cancel();
-          expect(window.location.pathname).toBe('/one');
+          expect(window.location.pathname).toBe("/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
 
-      it('does not update the action value', () => {
+      it("does not update the action value", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
       const testHistory = Browser();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -188,11 +188,11 @@ describe('replace', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.replace('/next');
+      testHistory.update("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
+    it("does not call response pending when the user prevents the navigation", () => {
       const testHistory = Browser();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -201,7 +201,7 @@ describe('replace', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.replace('/next');
+      testHistory.update("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/browser/tests/unit/replace.spec.ts
+++ b/packages/browser/tests/unit/replace.spec.ts
@@ -15,7 +15,7 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "REPLACE")', () => {
+describe('navigate(..., "REPLACE")', () => {
   let dom;
   let window;
 
@@ -35,7 +35,7 @@ describe('update(..., "REPLACE")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = Browser();
-      testHistory.update("/two", "REPLACE");
+      testHistory.navigate("/two", "REPLACE");
       expect(window.location.pathname).toBe("/one");
     });
   });
@@ -45,7 +45,7 @@ describe('update(..., "REPLACE")', () => {
       const testHistory = Browser();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two", "REPLACE");
+      testHistory.navigate("/two", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -59,7 +59,7 @@ describe('update(..., "REPLACE")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing", "REPLACE");
+        testHistory.navigate("/two?test=ing", "REPLACE");
       });
 
       it("is a location object created from pushed object", () => {
@@ -71,7 +71,7 @@ describe('update(..., "REPLACE")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" }, "REPLACE");
+        testHistory.navigate({ pathname: "/two", hash: "test" }, "REPLACE");
       });
 
       it("key maintains current location's major value, increments the minor value", () => {
@@ -85,7 +85,7 @@ describe('update(..., "REPLACE")', () => {
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -105,7 +105,7 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
       });
     });
 
@@ -118,15 +118,15 @@ describe('update(..., "REPLACE")', () => {
           expect(window.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate is not called", () => {
         const testHistory = Browser();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
         expect(window.location.pathname).toBe("/one");
       });
 
@@ -136,7 +136,7 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -148,13 +148,13 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
         expect(testHistory.action).toBe("REPLACE");
       });
     });
 
     describe("cancel", () => {
-      it("does not update browser history when cancel function is called", () => {
+      it("does not navigate browser history when cancel function is called", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
           expect(window.location.pathname).toBe("/one");
@@ -162,10 +162,10 @@ describe('update(..., "REPLACE")', () => {
           expect(window.location.pathname).toBe("/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
 
-      it("does not update the action value", () => {
+      it("does not navigate the action value", () => {
         const testHistory = Browser();
         let router = ignoreFirstCall(function(pending) {
           expect(testHistory.action).toBe("PUSH");
@@ -173,7 +173,7 @@ describe('update(..., "REPLACE")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
     });
   });
@@ -188,7 +188,7 @@ describe('update(..., "REPLACE")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "REPLACE");
+      testHistory.navigate("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -201,7 +201,7 @@ describe('update(..., "REPLACE")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "REPLACE");
+      testHistory.navigate("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/browser/types/index.d.ts
+++ b/packages/browser/types/index.d.ts
@@ -1,19 +1,6 @@
-import {
-  History,
-  LocationDetails,
-  PartialLocation,
-  HickoryLocation,
-  AnyLocation,
-  Options as RootOptions
-} from "@hickory/root";
-export {
-  History,
-  HickoryLocation,
-  PartialLocation,
-  AnyLocation,
-  LocationDetails
-};
+import { History, LocationDetails, PartialLocation, HickoryLocation, AnyLocation, Options as RootOptions } from "@hickory/root";
+export { History, HickoryLocation, PartialLocation, AnyLocation, LocationDetails };
 export interface Options extends RootOptions {
-  raw?: (pathname: string) => string;
+    raw?: (pathname: string) => string;
 }
 export default function Browser(options?: Options): History;

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+* `history.go()` and `history.go(0)` now reload the page.
+* Unify `navigate()`, `push()`, and `replace()` under `navigate()`. The optional second argument controls which type of navigation: `ANCHOR` (default), `PUSH`, or `REPLACE`.
+
 ## 1.0.0-beta.6
 
 * Re-export `LocationDetails`.

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -156,7 +156,10 @@ export default function HashHistory(options: Options = {}): History {
         fn();
       });
     },
-    update: function update(to: ToArgument, navType: NavType = "ANCHOR"): void {
+    navigate: function navigate(
+      to: ToArgument,
+      navType: NavType = "ANCHOR"
+    ): void {
       let setup: NavSetup;
       const location = createLocation(to);
       switch (navType) {

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -18,7 +18,8 @@ import {
   ToArgument,
   ResponseHandler,
   PendingNavigation,
-  Action
+  Action,
+  NavType
 } from "@hickory/root";
 
 export {
@@ -38,6 +39,11 @@ function ensureHash(encode: (path: string) => string): void {
 export interface Options extends RootOptions {
   raw?: (pathname: string) => string;
   hashType?: string;
+}
+
+interface NavSetup {
+  action: Action;
+  finish(): void;
 }
 
 function noop() {}
@@ -88,7 +94,21 @@ export default function HashHistory(options: Options = {}): History {
     return encodeHashPath(createPath(location));
   }
 
-  let responseHandler: ResponseHandler;
+  function setupReplace(location: HickoryLocation): NavSetup {
+    location.key = keygen.minor(hashHistory.location.key);
+    return {
+      action: "REPLACE",
+      finish: finalizeReplace(location)
+    };
+  }
+
+  function setupPush(location: HickoryLocation): NavSetup {
+    location.key = keygen.major(hashHistory.location.key);
+    return {
+      action: "PUSH",
+      finish: finalizePush(location)
+    };
+  }
 
   function finalizePush(location: HickoryLocation) {
     return () => {
@@ -110,6 +130,7 @@ export default function HashHistory(options: Options = {}): History {
     };
   }
 
+  let responseHandler: ResponseHandler;
   const hashHistory: History = {
     // location
     action: (getStateFromHistory().key !== undefined
@@ -135,25 +156,28 @@ export default function HashHistory(options: Options = {}): History {
         fn();
       });
     },
-    navigate: function navigate(to: ToArgument): void {
-      const location = createLocation(to, null);
-      const path = createPath(location);
-      const currentPath = createPath(hashHistory.location);
-
-      if (path === currentPath) {
-        hashHistory.replace(to);
-      } else {
-        hashHistory.push(to);
+    update: function update(to: ToArgument, navType: NavType = "ANCHOR"): void {
+      let setup: NavSetup;
+      const location = createLocation(to);
+      switch (navType) {
+        case "ANCHOR":
+          setup =
+            createPath(location) === createPath(hashHistory.location)
+              ? setupReplace(location)
+              : setupPush(location);
+          break;
+        case "PUSH":
+          setup = setupPush(location);
+          break;
+        case "REPLACE":
+          setup = setupReplace(location);
+          break;
       }
-    },
-    push: function push(to: ToArgument): void {
-      const key = keygen.major(hashHistory.location.key);
-      const location = createLocation(to, key);
       confirmNavigation(
         {
           to: location,
           from: hashHistory.location,
-          action: "PUSH"
+          action: setup.action
         },
         () => {
           if (!responseHandler) {
@@ -161,31 +185,8 @@ export default function HashHistory(options: Options = {}): History {
           }
           responseHandler({
             location,
-            action: "PUSH",
-            finish: finalizePush(location),
-            cancel: noop
-          });
-        }
-      );
-    },
-    replace: function replace(to: ToArgument): void {
-      // pass the current key to just increment the minor portion
-      const key = keygen.minor(hashHistory.location.key);
-      const location = createLocation(to, key);
-      confirmNavigation(
-        {
-          to: location,
-          from: hashHistory.location,
-          action: "REPLACE"
-        },
-        () => {
-          if (!responseHandler) {
-            return;
-          }
-          responseHandler({
-            location,
-            action: "REPLACE",
-            finish: finalizeReplace(location),
+            action: setup.action,
+            finish: setup.finish,
             cancel: noop
           });
         }

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -193,23 +193,7 @@ export default function HashHistory(options: Options = {}): History {
       );
     },
     go: function go(num: number): void {
-      // calling window.history.go with no value reloads the page, but
-      // we will just re-emit instead
-      if (!num) {
-        if (!responseHandler) {
-          return;
-        }
-        responseHandler({
-          location: hashHistory.location,
-          action: "POP",
-          finish: () => {
-            hashHistory.action = "POP";
-          },
-          cancel: noop
-        });
-      } else {
-        window.history.go(num);
-      }
+      window.history.go(num);
     }
   };
 

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -29,90 +29,109 @@ describe("hash integration tests", () => {
     testHistory.destroy();
   });
 
-  describe("navigate", () => {
-    beforeEach(() => {
-      spyOn(window.history, "pushState").and.callThrough();
-      spyOn(window.history, "replaceState").and.callThrough();
-    });
-
-    afterEach(() => {
-      (window.history.pushState as jasmine.Spy).calls.reset();
-      (window.history.replaceState as jasmine.Spy).calls.reset();
-    });
-
-    it("can navigate with navigate", () => {
-      testHistory.navigate("/the-new-location");
-      expect(window.location.hash).toEqual("#/the-new-location");
-    });
-
-    it("sets the state", () => {
-      const providedState = { isSet: true };
-      testHistory.navigate("/next", providedState);
-      const { state, key } = testHistory.location;
-      expect(window.history.state.state).toEqual(state);
-      expect(window.history.state.key).toBe(key);
-    });
-
-    it("calls history.pushState when navigating to a new location", () => {
-      testHistory.navigate("/new-location");
-      expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(1);
-      expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
-        0
-      );
-    });
-
-    it("calls history.replaceState when navigating to the same location", () => {
-      testHistory.navigate("/");
-      expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(0);
-      expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
-        1
-      );
-    });
-  });
-
-  describe("push", () => {
-    it("can navigate with push", () => {
-      testHistory.push("/a-new-position");
-      expect(window.location.hash).toEqual("#/a-new-position");
-    });
-
-    it("sets the state", () => {
-      const providedState = { isSet: true };
-      testHistory.push("/next", providedState);
-      const { state, key } = testHistory.location;
-      expect(window.history.state.state).toEqual(state);
-      expect(window.history.state.key).toBe(key);
-    });
-
-    it("pushes URL using rawPathname, not pathname", () => {
-      testHistory.push({
-        pathname: "/encoded-percent%25"
+  describe("update()", () => {
+    describe("ANCHOR (default)", () => {
+      beforeEach(() => {
+        spyOn(window.history, "pushState").and.callThrough();
+        spyOn(window.history, "replaceState").and.callThrough();
       });
-      expect(window.location.hash).toEqual("#/encoded-percent%25");
-      expect(testHistory.location.pathname).toEqual("/encoded-percent%");
-    });
-  });
 
-  describe("replace", () => {
-    it("can navigate with replace", () => {
-      testHistory.replace("/the-same-position");
-      expect(window.location.hash).toEqual("#/the-same-position");
+      afterEach(() => {
+        (window.history.pushState as jasmine.Spy).calls.reset();
+        (window.history.replaceState as jasmine.Spy).calls.reset();
+      });
+
+      it("can navigate with navigate", () => {
+        testHistory.update("/the-new-location");
+        expect(window.location.hash).toEqual("#/the-new-location");
+      });
+
+      it("sets the state", () => {
+        const providedState = { isSet: true };
+        testHistory.update({
+          pathname: "/next",
+          state: providedState
+        });
+        const { state, key } = testHistory.location;
+        expect(window.history.state.state).toEqual(state);
+        expect(window.history.state.key).toBe(key);
+      });
+
+      it("calls history.pushState when navigating to a new location", () => {
+        testHistory.update("/new-location");
+        expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(1);
+        expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
+          0
+        );
+      });
+
+      it("calls history.replaceState when navigating to the same location", () => {
+        testHistory.update("/");
+        expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(0);
+        expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
+          1
+        );
+      });
+    });
+    describe("PUSH", () => {
+      it("can navigate with push", () => {
+        testHistory.update("/a-new-position", "PUSH");
+        expect(window.location.hash).toEqual("#/a-new-position");
+      });
+
+      it("sets the state", () => {
+        const providedState = { isSet: true };
+        testHistory.update(
+          {
+            pathname: "/next",
+            state: providedState
+          },
+          "PUSH"
+        );
+        const { state, key } = testHistory.location;
+        expect(window.history.state.state).toEqual(state);
+        expect(window.history.state.key).toBe(key);
+      });
+
+      it("pushes URL using rawPathname, not pathname", () => {
+        testHistory.update(
+          {
+            pathname: "/encoded-percent%25"
+          },
+          "PUSH"
+        );
+        expect(window.location.hash).toEqual("#/encoded-percent%25");
+        expect(testHistory.location.pathname).toEqual("/encoded-percent%");
+      });
     });
 
-    it("sets the state", () => {
-      const providedState = { isSet: true };
-      testHistory.replace("/next", providedState);
-      const { state, key } = testHistory.location;
-      expect(window.history.state.state).toEqual(state);
-      expect(window.history.state.key).toBe(key);
+    describe("REPLACE", () => {
+      it("can navigate with replace", () => {
+        testHistory.update("/the-same-position", "REPLACE");
+        expect(window.location.hash).toEqual("#/the-same-position");
+      });
+
+      it("sets the state", () => {
+        const providedState = { isSet: true };
+        testHistory.update(
+          {
+            pathname: "/next",
+            state: providedState
+          },
+          "REPLACE"
+        );
+        const { state, key } = testHistory.location;
+        expect(window.history.state.state).toEqual(state);
+        expect(window.history.state.key).toBe(key);
+      });
     });
   });
 
   describe("go", () => {
     it("can navigate with go", done => {
-      testHistory.push("/eins");
-      testHistory.push("/zwei");
-      testHistory.push("/drei");
+      testHistory.update("/eins", "PUSH");
+      testHistory.update("/zwei", "PUSH");
+      testHistory.update("/drei", "PUSH");
 
       const goRouter = ignoreFirstCall(function(pending) {
         expect(pending.location.pathname).toEqual("/eins");
@@ -126,9 +145,9 @@ describe("hash integration tests", () => {
 
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
-      testHistory.push("/uno");
-      testHistory.push("/dos");
-      testHistory.push("/tres");
+      testHistory.update("/uno", "PUSH");
+      testHistory.update("/dos", "PUSH");
+      testHistory.update("/tres", "PUSH");
 
       const goRouter = ignoreFirstCall(function(pending) {
         expect(pending.location.pathname).toEqual("/uno");

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -29,7 +29,7 @@ describe("hash integration tests", () => {
     testHistory.destroy();
   });
 
-  describe("update()", () => {
+  describe("navigate()", () => {
     describe("ANCHOR (default)", () => {
       beforeEach(() => {
         spyOn(window.history, "pushState").and.callThrough();
@@ -42,13 +42,13 @@ describe("hash integration tests", () => {
       });
 
       it("can navigate with navigate", () => {
-        testHistory.update("/the-new-location");
+        testHistory.navigate("/the-new-location");
         expect(window.location.hash).toEqual("#/the-new-location");
       });
 
       it("sets the state", () => {
         const providedState = { isSet: true };
-        testHistory.update({
+        testHistory.navigate({
           pathname: "/next",
           state: providedState
         });
@@ -58,7 +58,7 @@ describe("hash integration tests", () => {
       });
 
       it("calls history.pushState when navigating to a new location", () => {
-        testHistory.update("/new-location");
+        testHistory.navigate("/new-location");
         expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(1);
         expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
           0
@@ -66,7 +66,7 @@ describe("hash integration tests", () => {
       });
 
       it("calls history.replaceState when navigating to the same location", () => {
-        testHistory.update("/");
+        testHistory.navigate("/");
         expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(0);
         expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
           1
@@ -75,13 +75,13 @@ describe("hash integration tests", () => {
     });
     describe("PUSH", () => {
       it("can navigate with push", () => {
-        testHistory.update("/a-new-position", "PUSH");
+        testHistory.navigate("/a-new-position", "PUSH");
         expect(window.location.hash).toEqual("#/a-new-position");
       });
 
       it("sets the state", () => {
         const providedState = { isSet: true };
-        testHistory.update(
+        testHistory.navigate(
           {
             pathname: "/next",
             state: providedState
@@ -94,7 +94,7 @@ describe("hash integration tests", () => {
       });
 
       it("pushes URL using rawPathname, not pathname", () => {
-        testHistory.update(
+        testHistory.navigate(
           {
             pathname: "/encoded-percent%25"
           },
@@ -107,13 +107,13 @@ describe("hash integration tests", () => {
 
     describe("REPLACE", () => {
       it("can navigate with replace", () => {
-        testHistory.update("/the-same-position", "REPLACE");
+        testHistory.navigate("/the-same-position", "REPLACE");
         expect(window.location.hash).toEqual("#/the-same-position");
       });
 
       it("sets the state", () => {
         const providedState = { isSet: true };
-        testHistory.update(
+        testHistory.navigate(
           {
             pathname: "/next",
             state: providedState
@@ -129,9 +129,9 @@ describe("hash integration tests", () => {
 
   describe("go", () => {
     it("can navigate with go", done => {
-      testHistory.update("/eins", "PUSH");
-      testHistory.update("/zwei", "PUSH");
-      testHistory.update("/drei", "PUSH");
+      testHistory.navigate("/eins", "PUSH");
+      testHistory.navigate("/zwei", "PUSH");
+      testHistory.navigate("/drei", "PUSH");
 
       const goRouter = ignoreFirstCall(function(pending) {
         expect(pending.location.pathname).toEqual("/eins");
@@ -145,9 +145,9 @@ describe("hash integration tests", () => {
 
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
-      testHistory.update("/uno", "PUSH");
-      testHistory.update("/dos", "PUSH");
-      testHistory.update("/tres", "PUSH");
+      testHistory.navigate("/uno", "PUSH");
+      testHistory.navigate("/dos", "PUSH");
+      testHistory.navigate("/tres", "PUSH");
 
       const goRouter = ignoreFirstCall(function(pending) {
         expect(pending.location.pathname).toEqual("/uno");

--- a/packages/hash/tests/unit/anchor.spec.ts
+++ b/packages/hash/tests/unit/anchor.spec.ts
@@ -1,5 +1,6 @@
-import 'jest';
-import InMemory from '../src';
+import "jest";
+import Hash from "../../src";
+import { jsdom } from "jsdom";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -14,84 +15,100 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('navigate', () => {
-  describe('without a response handler', () => {
-    it('does nothing', () => {
-      const testHistory = InMemory();
-      testHistory.navigate('/two');
-      expect(testHistory.location.pathname).toBe('/');
+describe('update(..., "ANCHOR")', () => {
+  let dom;
+  let window;
+
+  beforeEach(() => {
+    dom = jsdom("", {
+      url: "http://example.com/#/one"
+    });
+    window = global.window = dom.defaultView;
+    global.document = dom;
+  });
+
+  afterEach(() => {
+    dom.close();
+    global.document = undefined;
+  });
+
+  describe("without a response handler", () => {
+    it("does nothing", () => {
+      const testHistory = Hash();
+      testHistory.update("/two");
+      expect(window.location.hash).toBe("#/one");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
-      const testHistory = InMemory();
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
+      const testHistory = Hash();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.navigate('/two');
+      testHistory.update("/two");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
-        const testHistory = InMemory();
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
+        const testHistory = Hash();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.navigate('/two?test=ing');
+        testHistory.update("/two?test=ing");
       });
 
-      it('is a location object created from pushed object', () => {
-        const testHistory = InMemory();
+      it("is a location object created from pushed object", () => {
+        const testHistory = Hash();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.navigate({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" });
       });
 
-      it('(new) increments major key', () => {
-        const testHistory = InMemory();
+      it("(new) increments major key", () => {
+        const testHistory = Hash();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor] = testHistory.location.key.split('.');
+        const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.navigate('/next');
+        testHistory.update("/next");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
 
         expect(currentMajorNum).toEqual(initMajorNum + 1);
-        expect(currentMinor).toBe('0');
+        expect(currentMinor).toBe("0");
       });
 
-      it('(same) increments minor key', () => {
-        const testHistory = InMemory();
+      it("(same) increments minor key", () => {
+        const testHistory = Hash();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor, initMinor] = testHistory.location.key.split('.');
+        const [initMajor, initMinor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.navigate('/');
+        testHistory.update("/one");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
         const currentMinorNum = parseInt(currentMinor, 10);
 
@@ -100,110 +117,110 @@ describe('navigate', () => {
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('(new) is "PUSH"', () => {
-        const testHistory = InMemory();
+        const testHistory = Hash();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('PUSH');
+          expect(pending.action).toBe("PUSH");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
+        testHistory.update("/next");
       });
 
       it('(same) is "REPLACE"', () => {
-        const testHistory = InMemory();
+        const testHistory = Hash();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('REPLACE');
+          expect(pending.action).toBe("REPLACE");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/');
+        testHistory.update("/one");
       });
     });
 
-    describe('finish', () => {
-      it('updates InMemory history when finish function is called', () => {
-        const testHistory = InMemory();
+    describe("finish", () => {
+      it("updates Hash history when finish function is called", () => {
+        const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.location.pathname).toBe('/');
+          expect(window.location.hash).toBe("#/one");
           pending.finish();
-          expect(testHistory.location.pathname).toBe('/two');
+          expect(window.location.hash).toBe("#/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
 
-      it('does nothing if update is not called', () => {
-        const testHistory = InMemory();
+      it("does nothing if update is not called", () => {
+        const testHistory = Hash();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
-        expect(testHistory.location.pathname).toBe('/');
+        testHistory.update("/two");
+        expect(window.location.hash).toBe("#/one");
       });
 
-      it('sets history.location to new location object', () => {
-        const testHistory = InMemory();
+      it("sets history.location to new location object", () => {
+        const testHistory = Hash();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
+        testHistory.update("/next");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
       it('(new) sets history.action to "PUSH"', () => {
-        const testHistory = InMemory();
+        const testHistory = Hash();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
-        expect(testHistory.action).toBe('PUSH');
+        testHistory.update("/next");
+        expect(testHistory.action).toBe("PUSH");
       });
 
       it('(same) sets history.action to "REPLACE"', () => {
-        const testHistory = InMemory();
+        const testHistory = Hash();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/');
-        expect(testHistory.action).toBe('REPLACE');
+        testHistory.update("/one");
+        expect(testHistory.action).toBe("REPLACE");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update InMemory history when cancel function is called', () => {
-        const testHistory = InMemory();
+    describe("cancel", () => {
+      it("does not update Hash history when cancel function is called", () => {
+        const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.location.pathname).toBe('/');
+          expect(window.location.hash).toBe("#/one");
           pending.cancel();
-          expect(testHistory.location.pathname).toBe('/');
+          expect(window.location.hash).toBe("#/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
 
-      it('does not update the action value', () => {
-        const testHistory = InMemory();
+      it("does not update the action value", () => {
+        const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
-      const testHistory = InMemory();
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
+      const testHistory = Hash();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
         confirm();
@@ -211,12 +228,12 @@ describe('navigate', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.navigate('/next');
+      testHistory.update("/next");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
-      const testHistory = InMemory();
+    it("does not call response pending when the user prevents the navigation", () => {
+      const testHistory = Hash();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
         prevent();
@@ -224,7 +241,7 @@ describe('navigate', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.navigate('/next');
+      testHistory.update("/next");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/hash/tests/unit/anchor.spec.ts
+++ b/packages/hash/tests/unit/anchor.spec.ts
@@ -15,7 +15,7 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "ANCHOR")', () => {
+describe('navigate(..., "ANCHOR")', () => {
   let dom;
   let window;
 
@@ -35,7 +35,7 @@ describe('update(..., "ANCHOR")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = Hash();
-      testHistory.update("/two");
+      testHistory.navigate("/two");
       expect(window.location.hash).toBe("#/one");
     });
   });
@@ -45,7 +45,7 @@ describe('update(..., "ANCHOR")', () => {
       const testHistory = Hash();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two");
+      testHistory.navigate("/two");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -59,7 +59,7 @@ describe('update(..., "ANCHOR")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing");
+        testHistory.navigate("/two?test=ing");
       });
 
       it("is a location object created from pushed object", () => {
@@ -71,7 +71,7 @@ describe('update(..., "ANCHOR")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" });
+        testHistory.navigate({ pathname: "/two", hash: "test" });
       });
 
       it("(new) increments major key", () => {
@@ -84,7 +84,7 @@ describe('update(..., "ANCHOR")', () => {
         const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.update("/next");
+        testHistory.navigate("/next");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -105,7 +105,7 @@ describe('update(..., "ANCHOR")', () => {
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.update("/one");
+        testHistory.navigate("/one");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -125,7 +125,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
       });
 
       it('(same) is "REPLACE"', () => {
@@ -135,7 +135,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/one");
+        testHistory.navigate("/one");
       });
     });
 
@@ -148,15 +148,15 @@ describe('update(..., "ANCHOR")', () => {
           expect(window.location.hash).toBe("#/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate is not called", () => {
         const testHistory = Hash();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
         expect(window.location.hash).toBe("#/one");
       });
 
@@ -166,7 +166,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -178,7 +178,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
         expect(testHistory.action).toBe("PUSH");
       });
 
@@ -188,7 +188,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/one");
+        testHistory.navigate("/one");
         expect(testHistory.action).toBe("REPLACE");
       });
     });
@@ -202,7 +202,7 @@ describe('update(..., "ANCHOR")', () => {
           expect(window.location.hash).toBe("#/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
 
       it("does not update the action value", () => {
@@ -213,7 +213,7 @@ describe('update(..., "ANCHOR")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
     });
   });
@@ -228,7 +228,7 @@ describe('update(..., "ANCHOR")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next");
+      testHistory.navigate("/next");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -241,7 +241,7 @@ describe('update(..., "ANCHOR")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next");
+      testHistory.navigate("/next");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/hash/tests/unit/go.spec.ts
+++ b/packages/hash/tests/unit/go.spec.ts
@@ -60,11 +60,11 @@ describe("go", () => {
       done();
     }
     testHistory.respondWith(router);
-    testHistory.update("/two", "PUSH"); // 1.0
-    testHistory.update("/three", "PUSH"); // 2.0
-    testHistory.update("/four", "PUSH"); // 3.0
-    testHistory.update("/five", "PUSH"); // 4.0
-    testHistory.update("/six", "PUSH"); // 5.0
+    testHistory.navigate("/two", "PUSH"); // 1.0
+    testHistory.navigate("/three", "PUSH"); // 2.0
+    testHistory.navigate("/four", "PUSH"); // 3.0
+    testHistory.navigate("/five", "PUSH"); // 4.0
+    testHistory.navigate("/six", "PUSH"); // 5.0
     setup = true;
     testHistory.go(-2);
   });
@@ -84,7 +84,7 @@ describe("go", () => {
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(pushRouter);
-          testHistory.update("/seven", "PUSH");
+          testHistory.navigate("/seven", "PUSH");
         });
         const pushRouter = ignoreFirstCall(function(pending) {
           cancelGo("PUSH");
@@ -95,11 +95,11 @@ describe("go", () => {
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
-        testHistory.update("/six", "PUSH"); // 5.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
+        testHistory.navigate("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -118,7 +118,7 @@ describe("go", () => {
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(replaceRouter);
-          testHistory.update("/seven", "REPLACE");
+          testHistory.navigate("/seven", "REPLACE");
         });
         const replaceRouter = ignoreFirstCall(function(pending) {
           cancelGo("REPLACE");
@@ -129,11 +129,11 @@ describe("go", () => {
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
-        testHistory.update("/six", "PUSH"); // 5.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
+        testHistory.navigate("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -163,11 +163,11 @@ describe("go", () => {
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
-        testHistory.update("/six", "PUSH"); // 5.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
+        testHistory.navigate("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -196,8 +196,8 @@ describe("go", () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router);
 
-      testHistory.update("/two", "PUSH"); // 1.0
-      testHistory.update("/three", "PUSH"); // 2.0
+      testHistory.navigate("/two", "PUSH"); // 1.0
+      testHistory.navigate("/three", "PUSH"); // 2.0
       setup = true;
       testHistory.go(-2);
     });
@@ -212,8 +212,8 @@ describe("go", () => {
       }
       testHistory.respondWith(router);
 
-      testHistory.update("/two", "PUSH"); // 1.0
-      testHistory.update("/three", "PUSH"); // 2.0
+      testHistory.navigate("/two", "PUSH"); // 1.0
+      testHistory.navigate("/three", "PUSH"); // 2.0
       // don't add function until we have setup the history
       testHistory.confirmWith(confirm);
       testHistory.go(-2);

--- a/packages/hash/tests/unit/go.spec.ts
+++ b/packages/hash/tests/unit/go.spec.ts
@@ -1,6 +1,6 @@
-import 'jest';
-import Hash from '../../src';
-import { jsdom } from 'jsdom';
+import "jest";
+import Hash from "../../src";
+import { jsdom } from "jsdom";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -15,13 +15,13 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('go', () => {
+describe("go", () => {
   let dom;
   let window;
 
   beforeEach(() => {
-    dom = jsdom('', {
-      url: 'http://example.com/#/one'
+    dom = jsdom("", {
+      url: "http://example.com/#/one"
     });
     window = global.window = dom.defaultView;
     global.document = dom;
@@ -32,14 +32,14 @@ describe('go', () => {
     global.document = undefined;
   });
 
-  describe('with no value', () => {
+  describe("with no value", () => {
     it('calls response handler with current location and "POP" action', done => {
       const testHistory = Hash();
       const router = ignoreFirstCall(function(pending) {
         expect(pending.location).toMatchObject({
-          pathname: '/one'
+          pathname: "/one"
         });
-        expect(pending.action).toBe('POP');
+        expect(pending.action).toBe("POP");
         done();
       });
       testHistory.respondWith(router); // calls router
@@ -47,7 +47,7 @@ describe('go', () => {
     });
   });
 
-  it('does nothing if the value is outside of the range', () => {
+  it("does nothing if the value is outside of the range", () => {
     const testHistory = Hash();
     const router = jest.fn();
     testHistory.respondWith(router);
@@ -59,7 +59,7 @@ describe('go', () => {
     }, 50);
   });
 
-  it('calls response handler with expected location and action', done => {
+  it("calls response handler with expected location and action", done => {
     const testHistory = Hash();
     let setup = false;
     function router(pending) {
@@ -68,25 +68,25 @@ describe('go', () => {
         return;
       }
       expect(pending.location).toMatchObject({
-        pathname: '/four',
-        key: '3.0'
+        pathname: "/four",
+        key: "3.0"
       });
-      expect(pending.action).toBe('POP');
+      expect(pending.action).toBe("POP");
       done();
     }
     testHistory.respondWith(router);
-    testHistory.push('/two'); // 1.0
-    testHistory.push('/three'); // 2.0
-    testHistory.push('/four'); // 3.0
-    testHistory.push('/five'); // 4.0
-    testHistory.push('/six'); // 5.0
+    testHistory.update("/two", "PUSH"); // 1.0
+    testHistory.update("/three", "PUSH"); // 2.0
+    testHistory.update("/four", "PUSH"); // 3.0
+    testHistory.update("/five", "PUSH"); // 4.0
+    testHistory.update("/six", "PUSH"); // 5.0
     setup = true;
     testHistory.go(-2);
   });
 
-  describe('respondWith', () => {
-    describe('cancel', () => {
-      it('undoes the pop if pushing before pending response finishes', done => {
+  describe("respondWith", () => {
+    describe("cancel", () => {
+      it("undoes the pop if pushing before pending response finishes", done => {
         const testHistory = Hash();
         let setup = false;
         function initialRouter(pending) {
@@ -95,32 +95,32 @@ describe('go', () => {
         let cancelGo;
         const goRouter = ignoreFirstCall(function(pending) {
           // at this point, the Hash has popped
-          expect(window.location.hash).toBe('#/four');
+          expect(window.location.hash).toBe("#/four");
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(pushRouter);
-          testHistory.push('/seven');
+          testHistory.update("/seven", "PUSH");
         });
         const pushRouter = ignoreFirstCall(function(pending) {
-          cancelGo('PUSH');
+          cancelGo("PUSH");
           setTimeout(() => {
-            expect(window.location.hash).toBe('#/six');
+            expect(window.location.hash).toBe("#/six");
             done();
           }, 50);
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
-        testHistory.push('/six'); // 5.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.update("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
       });
 
-      it('undoes the pop if replacing before pending response finishes', done => {
+      it("undoes the pop if replacing before pending response finishes", done => {
         const testHistory = Hash();
         let setup = false;
         function initialRouter(pending) {
@@ -129,32 +129,32 @@ describe('go', () => {
         let cancelGo;
         const goRouter = ignoreFirstCall(function(pending) {
           // at this point, the Hash has popped
-          expect(window.location.hash).toBe('#/four');
+          expect(window.location.hash).toBe("#/four");
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(replaceRouter);
-          testHistory.replace('/seven');
+          testHistory.update("/seven", "REPLACE");
         });
         const replaceRouter = ignoreFirstCall(function(pending) {
-          cancelGo('REPLACE');
+          cancelGo("REPLACE");
           setTimeout(() => {
-            expect(window.location.hash).toBe('#/six');
+            expect(window.location.hash).toBe("#/six");
             done();
           }, 50);
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
-        testHistory.push('/six'); // 5.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.update("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
       });
 
-      it('does nothing if popping before pending response finishes', done => {
+      it("does nothing if popping before pending response finishes", done => {
         const testHistory = Hash();
         let setup = false;
         function initialRouter(pending) {
@@ -163,26 +163,26 @@ describe('go', () => {
         let cancelGo;
         const goRouter = ignoreFirstCall(function(pending) {
           // at this point, the Hash has popped
-          expect(window.location.hash).toBe('#/four');
+          expect(window.location.hash).toBe("#/four");
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(popRouter);
           testHistory.go(-1);
         });
         const popRouter = ignoreFirstCall(function(pending) {
-          cancelGo('POP');
+          cancelGo("POP");
           setTimeout(() => {
-            expect(window.location.hash).toBe('#/three');
+            expect(window.location.hash).toBe("#/three");
             done();
           }, 50);
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
-        testHistory.push('/six'); // 5.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.update("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -190,8 +190,8 @@ describe('go', () => {
     });
   });
 
-  describe('with user confirmation', () => {
-    it('calls response handler after the user confirms the navigation', done => {
+  describe("with user confirmation", () => {
+    it("calls response handler after the user confirms the navigation", done => {
       const testHistory = Hash();
       let setup = false;
       const router = ignoreFirstCall(function(pending) {
@@ -200,8 +200,8 @@ describe('go', () => {
           return;
         }
         expect(testHistory.location).toMatchObject({
-          pathname: '/one',
-          key: '0.0'
+          pathname: "/one",
+          key: "0.0"
         });
         done();
       });
@@ -211,13 +211,13 @@ describe('go', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router);
 
-      testHistory.push('/two'); // 1.0
-      testHistory.push('/three'); // 2.0
+      testHistory.update("/two", "PUSH"); // 1.0
+      testHistory.update("/three", "PUSH"); // 2.0
       setup = true;
       testHistory.go(-2);
     });
 
-    it('does not call response handler when the user prevents the navigation', done => {
+    it("does not call response handler when the user prevents the navigation", done => {
       const testHistory = Hash();
       const confirm = (info, confirm, prevent) => {
         prevent();
@@ -227,8 +227,8 @@ describe('go', () => {
       }
       testHistory.respondWith(router);
 
-      testHistory.push('/two'); // 1.0
-      testHistory.push('/three'); // 2.0
+      testHistory.update("/two", "PUSH"); // 1.0
+      testHistory.update("/three", "PUSH"); // 2.0
       // don't add function until we have setup the history
       testHistory.confirmWith(confirm);
       testHistory.go(-2);
@@ -236,8 +236,8 @@ describe('go', () => {
       // need to wait for window.history.go to emit a popstate event
       setTimeout(() => {
         expect(testHistory.location).toMatchObject({
-          pathname: '/three',
-          key: '2.0'
+          pathname: "/three",
+          key: "2.0"
         });
         done();
       }, 50);

--- a/packages/hash/tests/unit/go.spec.ts
+++ b/packages/hash/tests/unit/go.spec.ts
@@ -32,31 +32,16 @@ describe("go", () => {
     global.document = undefined;
   });
 
-  describe("with no value", () => {
-    it('calls response handler with current location and "POP" action', done => {
-      const testHistory = Hash();
-      const router = ignoreFirstCall(function(pending) {
-        expect(pending.location).toMatchObject({
-          pathname: "/one"
-        });
-        expect(pending.action).toBe("POP");
-        done();
-      });
-      testHistory.respondWith(router); // calls router
-      testHistory.go();
-    });
-  });
-
-  it("does nothing if the value is outside of the range", () => {
+  it("calls window.history.go with provided value", () => {
+    const realGo = window.history.go;
+    const mockGo = (window.history.go = jest.fn());
     const testHistory = Hash();
-    const router = jest.fn();
-    testHistory.respondWith(router);
-    testHistory.go(10);
-    // just verifying that a popstate event hasn't emitted to
-    // trigger the history's event handler
-    setTimeout(() => {
-      expect(router.mock.calls.length).toBe(1);
-    }, 50);
+
+    [undefined, 0, 1, -1].forEach((value, index) => {
+      testHistory.go(value);
+      expect(mockGo.mock.calls[index][0]).toBe(value);
+    });
+    window.history.go = realGo;
   });
 
   it("calls response handler with expected location and action", done => {

--- a/packages/hash/tests/unit/push.spec.ts
+++ b/packages/hash/tests/unit/push.spec.ts
@@ -15,7 +15,7 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "PUSH")', () => {
+describe('navigate(..., "PUSH")', () => {
   let dom;
   let window;
 
@@ -35,7 +35,7 @@ describe('update(..., "PUSH")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = Hash();
-      testHistory.update("/two", "PUSH");
+      testHistory.navigate("/two", "PUSH");
       expect(window.location.hash).toBe("#/one");
     });
   });
@@ -45,7 +45,7 @@ describe('update(..., "PUSH")', () => {
       const testHistory = Hash();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two", "PUSH");
+      testHistory.navigate("/two", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -59,7 +59,7 @@ describe('update(..., "PUSH")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing", "PUSH");
+        testHistory.navigate("/two?test=ing", "PUSH");
       });
 
       it("is a location object created from pushed object", () => {
@@ -71,7 +71,7 @@ describe('update(..., "PUSH")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" }, "PUSH");
+        testHistory.navigate({ pathname: "/two", hash: "test" }, "PUSH");
       });
 
       it("increments current major key value by 1, sets minor value to 0", () => {
@@ -84,7 +84,7 @@ describe('update(..., "PUSH")', () => {
         const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -104,7 +104,7 @@ describe('update(..., "PUSH")', () => {
             pending.action === "POP" &&
             pending.location.pathname === "/three"
           ) {
-            testHistory.update("/new-four", "PUSH");
+            testHistory.navigate("/new-four", "PUSH");
             afterPop = true;
           }
           if (afterPop) {
@@ -114,10 +114,10 @@ describe('update(..., "PUSH")', () => {
         }
         testHistory.respondWith(router); // calls router
         // just getting the history in the expected state
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
         testHistory.go(-2); // 2.0
       });
     });
@@ -130,7 +130,7 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
       });
     });
 
@@ -143,15 +143,15 @@ describe('update(..., "PUSH")', () => {
           expect(window.location.hash).toBe("#/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate is not called", () => {
         const testHistory = Hash();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
         expect(window.location.hash).toBe("#/one");
       });
 
@@ -161,7 +161,7 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -173,7 +173,7 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
         expect(testHistory.action).toBe("PUSH");
       });
     });
@@ -187,7 +187,7 @@ describe('update(..., "PUSH")', () => {
           expect(window.location.hash).toBe("#/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
 
       it("does not update the action value", () => {
@@ -198,7 +198,7 @@ describe('update(..., "PUSH")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
     });
   });
@@ -213,7 +213,7 @@ describe('update(..., "PUSH")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "PUSH");
+      testHistory.navigate("/next", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -226,7 +226,7 @@ describe('update(..., "PUSH")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "PUSH");
+      testHistory.navigate("/next", "PUSH");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/hash/tests/unit/push.spec.ts
+++ b/packages/hash/tests/unit/push.spec.ts
@@ -1,6 +1,6 @@
-import 'jest';
-import Hash from '../../src';
-import { jsdom } from 'jsdom';
+import "jest";
+import Hash from "../../src";
+import { jsdom } from "jsdom";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -15,13 +15,13 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('push', () => {
+describe('update(..., "PUSH")', () => {
   let dom;
   let window;
 
   beforeEach(() => {
-    dom = jsdom('', {
-      url: 'http://example.com/#/one'
+    dom = jsdom("", {
+      url: "http://example.com/#/one"
     });
     window = global.window = dom.defaultView;
     global.document = dom;
@@ -32,66 +32,66 @@ describe('push', () => {
     global.document = undefined;
   });
 
-  describe('without a response handler', () => {
-    it('does nothing', () => {
+  describe("without a response handler", () => {
+    it("does nothing", () => {
       const testHistory = Hash();
-      testHistory.push('/two');
-      expect(window.location.hash).toBe('#/one');
+      testHistory.update("/two", "PUSH");
+      expect(window.location.hash).toBe("#/one");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
       const testHistory = Hash();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.push('/two');
+      testHistory.update("/two", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
         const testHistory = Hash();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.push('/two?test=ing');
+        testHistory.update("/two?test=ing", "PUSH");
       });
 
-      it('is a location object created from pushed object', () => {
+      it("is a location object created from pushed object", () => {
         const testHistory = Hash();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.push({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" }, "PUSH");
       });
 
-      it('increments current major key value by 1, sets minor value to 0', () => {
+      it("increments current major key value by 1, sets minor value to 0", () => {
         const testHistory = Hash();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor] = testHistory.location.key.split('.');
+        const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
 
         expect(currentMajorNum).toEqual(initMajorNum + 1);
-        expect(currentMinor).toBe('0');
+        expect(currentMinor).toBe("0");
       });
 
       it("increments from current location's key when not at end of locations", done => {
@@ -101,69 +101,69 @@ describe('push', () => {
         function router(pending) {
           pending.finish();
           if (
-            pending.action === 'POP' &&
-            pending.location.pathname === '/three'
+            pending.action === "POP" &&
+            pending.location.pathname === "/three"
           ) {
-            testHistory.push('/new-four');
+            testHistory.update("/new-four", "PUSH");
             afterPop = true;
           }
           if (afterPop) {
-            expect(testHistory.location.key).toBe('3.0');
+            expect(testHistory.location.key).toBe("3.0");
             done();
           }
         }
         testHistory.respondWith(router); // calls router
         // just getting the history in the expected state
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
         testHistory.go(-2); // 2.0
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('is "PUSH"', () => {
         const testHistory = Hash();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('PUSH');
+          expect(pending.action).toBe("PUSH");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
       });
     });
 
-    describe('finish', () => {
-      it('updates Hash history when finish function is called', () => {
+    describe("finish", () => {
+      it("updates Hash history when finish function is called", () => {
         const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.hash).toBe('#/one');
+          expect(window.location.hash).toBe("#/one");
           pending.finish();
-          expect(window.location.hash).toBe('#/two');
+          expect(window.location.hash).toBe("#/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
 
-      it('does nothing if update is not called', () => {
+      it("does nothing if update is not called", () => {
         const testHistory = Hash();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
-        expect(window.location.hash).toBe('#/one');
+        testHistory.update("/two", "PUSH");
+        expect(window.location.hash).toBe("#/one");
       });
 
-      it('sets history.location to new location object', () => {
+      it("sets history.location to new location object", () => {
         const testHistory = Hash();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
@@ -173,38 +173,38 @@ describe('push', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
-        expect(testHistory.action).toBe('PUSH');
+        testHistory.update("/next", "PUSH");
+        expect(testHistory.action).toBe("PUSH");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update Hash history when cancel function is called', () => {
+    describe("cancel", () => {
+      it("does not update Hash history when cancel function is called", () => {
         const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.hash).toBe('#/one');
+          expect(window.location.hash).toBe("#/one");
           pending.cancel();
-          expect(window.location.hash).toBe('#/one');
+          expect(window.location.hash).toBe("#/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
 
-      it('does not update the action value', () => {
+      it("does not update the action value", () => {
         const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
       const testHistory = Hash();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -213,11 +213,11 @@ describe('push', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.push('/next');
+      testHistory.update("/next", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
+    it("does not call response pending when the user prevents the navigation", () => {
       const testHistory = Hash();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -226,7 +226,7 @@ describe('push', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.push('/next');
+      testHistory.update("/next", "PUSH");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/hash/tests/unit/replace.spec.ts
+++ b/packages/hash/tests/unit/replace.spec.ts
@@ -15,7 +15,7 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "REPLACE")', () => {
+describe('navigate(..., "REPLACE")', () => {
   let dom;
   let window;
 
@@ -35,7 +35,7 @@ describe('update(..., "REPLACE")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = Hash();
-      testHistory.update("/two", "REPLACE");
+      testHistory.navigate("/two", "REPLACE");
       expect(window.location.hash).toBe("#/one");
     });
   });
@@ -45,7 +45,7 @@ describe('update(..., "REPLACE")', () => {
       const testHistory = Hash();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two", "REPLACE");
+      testHistory.navigate("/two", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -59,7 +59,7 @@ describe('update(..., "REPLACE")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing", "REPLACE");
+        testHistory.navigate("/two?test=ing", "REPLACE");
       });
 
       it("is a location object created from pushed object", () => {
@@ -71,7 +71,7 @@ describe('update(..., "REPLACE")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" }, "REPLACE");
+        testHistory.navigate({ pathname: "/two", hash: "test" }, "REPLACE");
       });
 
       it("key maintains current location's major value, increments the minor value", () => {
@@ -85,7 +85,7 @@ describe('update(..., "REPLACE")', () => {
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -105,7 +105,7 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
       });
     });
 
@@ -118,15 +118,15 @@ describe('update(..., "REPLACE")', () => {
           expect(window.location.hash).toBe("#/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate is not called", () => {
         const testHistory = Hash();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
         expect(window.location.hash).toBe("#/one");
       });
 
@@ -136,7 +136,7 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -148,13 +148,13 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
         expect(testHistory.action).toBe("REPLACE");
       });
     });
 
     describe("cancel", () => {
-      it("does not update Hash history when cancel function is called", () => {
+      it("does not navigate Hash history when cancel function is called", () => {
         const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
           expect(window.location.hash).toBe("#/one");
@@ -162,10 +162,10 @@ describe('update(..., "REPLACE")', () => {
           expect(window.location.hash).toBe("#/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
 
-      it("does not update the action value", () => {
+      it("does not navigate the action value", () => {
         const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
           expect(testHistory.action).toBe("PUSH");
@@ -173,7 +173,7 @@ describe('update(..., "REPLACE")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
     });
   });
@@ -188,7 +188,7 @@ describe('update(..., "REPLACE")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "REPLACE");
+      testHistory.navigate("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -201,7 +201,7 @@ describe('update(..., "REPLACE")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "REPLACE");
+      testHistory.navigate("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/hash/tests/unit/replace.spec.ts
+++ b/packages/hash/tests/unit/replace.spec.ts
@@ -1,6 +1,6 @@
-import 'jest';
-import Hash from '../../src';
-import { jsdom } from 'jsdom';
+import "jest";
+import Hash from "../../src";
+import { jsdom } from "jsdom";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -15,13 +15,13 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('replace', () => {
+describe('update(..., "REPLACE")', () => {
   let dom;
   let window;
 
   beforeEach(() => {
-    dom = jsdom('', {
-      url: 'http://example.com/#/one'
+    dom = jsdom("", {
+      url: "http://example.com/#/one"
     });
     window = global.window = dom.defaultView;
     global.document = dom;
@@ -32,46 +32,46 @@ describe('replace', () => {
     global.document = undefined;
   });
 
-  describe('without a response handler', () => {
-    it('does nothing', () => {
+  describe("without a response handler", () => {
+    it("does nothing", () => {
       const testHistory = Hash();
-      testHistory.replace('/two');
-      expect(window.location.hash).toBe('#/one');
+      testHistory.update("/two", "REPLACE");
+      expect(window.location.hash).toBe("#/one");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
       const testHistory = Hash();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.replace('/two');
+      testHistory.update("/two", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
         const testHistory = Hash();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.replace('/two?test=ing');
+        testHistory.update("/two?test=ing", "REPLACE");
       });
 
-      it('is a location object created from pushed object', () => {
+      it("is a location object created from pushed object", () => {
         const testHistory = Hash();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.replace({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" }, "REPLACE");
       });
 
       it("key maintains current location's major value, increments the minor value", () => {
@@ -81,14 +81,14 @@ describe('replace', () => {
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor, initMinor] = testHistory.location.key.split('.');
+        const [initMajor, initMinor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
         const currentMinorNum = parseInt(currentMinor, 10);
 
@@ -97,48 +97,48 @@ describe('replace', () => {
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('is "REPLACE"', () => {
         const testHistory = Hash();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('REPLACE');
+          expect(pending.action).toBe("REPLACE");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
       });
     });
 
-    describe('finish', () => {
-      it('updates Hash history when finish function is called', () => {
+    describe("finish", () => {
+      it("updates Hash history when finish function is called", () => {
         const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.hash).toBe('#/one');
+          expect(window.location.hash).toBe("#/one");
           pending.finish();
-          expect(window.location.hash).toBe('#/two');
+          expect(window.location.hash).toBe("#/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
 
-      it('does nothing if update is not called', () => {
+      it("does nothing if update is not called", () => {
         const testHistory = Hash();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
-        expect(window.location.hash).toBe('#/one');
+        testHistory.update("/two", "REPLACE");
+        expect(window.location.hash).toBe("#/one");
       });
 
-      it('sets history.location to new location object', () => {
+      it("sets history.location to new location object", () => {
         const testHistory = Hash();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
@@ -148,38 +148,38 @@ describe('replace', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
-        expect(testHistory.action).toBe('REPLACE');
+        testHistory.update("/next", "REPLACE");
+        expect(testHistory.action).toBe("REPLACE");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update Hash history when cancel function is called', () => {
+    describe("cancel", () => {
+      it("does not update Hash history when cancel function is called", () => {
         const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.hash).toBe('#/one');
+          expect(window.location.hash).toBe("#/one");
           pending.cancel();
-          expect(window.location.hash).toBe('#/one');
+          expect(window.location.hash).toBe("#/one");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
 
-      it('does not update the action value', () => {
+      it("does not update the action value", () => {
         const testHistory = Hash();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
       const testHistory = Hash();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -188,11 +188,11 @@ describe('replace', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.replace('/next');
+      testHistory.update("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
+    it("does not call response pending when the user prevents the navigation", () => {
       const testHistory = Hash();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -201,7 +201,7 @@ describe('replace', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.replace('/next');
+      testHistory.update("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/hash/types/index.d.ts
+++ b/packages/hash/types/index.d.ts
@@ -1,20 +1,7 @@
-import {
-  History,
-  LocationDetails,
-  HickoryLocation,
-  PartialLocation,
-  AnyLocation,
-  Options as RootOptions
-} from "@hickory/root";
-export {
-  History,
-  HickoryLocation,
-  PartialLocation,
-  AnyLocation,
-  LocationDetails
-};
+import { History, LocationDetails, HickoryLocation, PartialLocation, AnyLocation, Options as RootOptions } from "@hickory/root";
+export { History, HickoryLocation, PartialLocation, AnyLocation, LocationDetails };
 export interface Options extends RootOptions {
-  raw?: (pathname: string) => string;
-  hashType?: string;
+    raw?: (pathname: string) => string;
+    hashType?: string;
 }
 export default function HashHistory(options?: Options): History;

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Unify `navigate()`, `push()`, and `replace()` under `navigate()`. The optional second argument controls which type of navigation: `ANCHOR` (default), `PUSH`, or `REPLACE`.
+
 ## 1.0.0-beta.4
 
 * Re-export `LocationDetails`.

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -11,7 +11,8 @@ import {
   ToArgument,
   ResponseHandler,
   PendingNavigation,
-  Action
+  Action,
+  NavType
 } from "@hickory/root";
 
 export {
@@ -30,6 +31,11 @@ export interface Options extends RootOptions {
 export interface InMemoryHistory extends History {
   locations: Array<HickoryLocation>;
   index: number;
+}
+
+interface NavSetup {
+  action: Action;
+  finish(): void;
 }
 
 function noop() {}
@@ -73,7 +79,21 @@ export default function InMemory(options: Options = {}): InMemoryHistory {
     return createPath(location);
   }
 
-  let responseHandler: ResponseHandler;
+  function setupReplace(location: HickoryLocation): NavSetup {
+    location.key = keygen.minor(memoryHistory.location.key);
+    return {
+      action: "REPLACE",
+      finish: finalizeReplace(location)
+    };
+  }
+
+  function setupPush(location: HickoryLocation): NavSetup {
+    location.key = keygen.major(memoryHistory.location.key);
+    return {
+      action: "PUSH",
+      finish: finalizePush(location)
+    };
+  }
 
   function finalizePush(location: HickoryLocation) {
     return () => {
@@ -95,6 +115,7 @@ export default function InMemory(options: Options = {}): InMemoryHistory {
     };
   }
 
+  let responseHandler: ResponseHandler;
   const memoryHistory: InMemoryHistory = {
     // location
     location: initialLocations[initialIndex],
@@ -120,24 +141,28 @@ export default function InMemory(options: Options = {}): InMemoryHistory {
         fn();
       });
     },
-    navigate: function navigate(to: ToArgument): void {
-      const location: HickoryLocation = createLocation(to, null);
-      const path: string = createPath(location);
-      const currentPath: string = createPath(memoryHistory.location);
-      if (path === currentPath) {
-        memoryHistory.replace(to);
-      } else {
-        memoryHistory.push(to);
+    update: function update(to: ToArgument, navType: NavType = "ANCHOR"): void {
+      let setup: NavSetup;
+      const location = createLocation(to);
+      switch (navType) {
+        case "ANCHOR":
+          setup =
+            createPath(location) === createPath(memoryHistory.location)
+              ? setupReplace(location)
+              : setupPush(location);
+          break;
+        case "PUSH":
+          setup = setupPush(location);
+          break;
+        case "REPLACE":
+          setup = setupReplace(location);
+          break;
       }
-    },
-    push: function push(to: ToArgument): void {
-      const key: string = keygen.major(memoryHistory.location.key);
-      const location: HickoryLocation = createLocation(to, key);
       confirmNavigation(
         {
           to: location,
           from: memoryHistory.location,
-          action: "PUSH"
+          action: setup.action
         },
         () => {
           if (!responseHandler) {
@@ -145,30 +170,8 @@ export default function InMemory(options: Options = {}): InMemoryHistory {
           }
           responseHandler({
             location,
-            action: "PUSH",
-            finish: finalizePush(location),
-            cancel: noop
-          });
-        }
-      );
-    },
-    replace: function replace(to: ToArgument): void {
-      const key: string = keygen.minor(memoryHistory.location.key);
-      const location: HickoryLocation = createLocation(to, key);
-      confirmNavigation(
-        {
-          to: location,
-          from: memoryHistory.location,
-          action: "REPLACE"
-        },
-        () => {
-          if (!responseHandler) {
-            return;
-          }
-          responseHandler({
-            location,
-            action: "REPLACE",
-            finish: finalizeReplace(location),
+            action: setup.action,
+            finish: setup.finish,
             cancel: noop
           });
         }

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -141,7 +141,10 @@ export default function InMemory(options: Options = {}): InMemoryHistory {
         fn();
       });
     },
-    update: function update(to: ToArgument, navType: NavType = "ANCHOR"): void {
+    navigate: function navigate(
+      to: ToArgument,
+      navType: NavType = "ANCHOR"
+    ): void {
       let setup: NavSetup;
       const location = createLocation(to);
       switch (navType) {

--- a/packages/in-memory/tests/anchor.spec.ts
+++ b/packages/in-memory/tests/anchor.spec.ts
@@ -14,11 +14,11 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "ANCHOR")', () => {
+describe('navigate(..., "ANCHOR")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = InMemory();
-      testHistory.update("/two");
+      testHistory.navigate("/two");
       expect(testHistory.location.pathname).toBe("/");
     });
   });
@@ -28,7 +28,7 @@ describe('update(..., "ANCHOR")', () => {
       const testHistory = InMemory();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two");
+      testHistory.navigate("/two");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -42,7 +42,7 @@ describe('update(..., "ANCHOR")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing");
+        testHistory.navigate("/two?test=ing");
       });
 
       it("is a location object created from pushed object", () => {
@@ -54,7 +54,7 @@ describe('update(..., "ANCHOR")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" });
+        testHistory.navigate({ pathname: "/two", hash: "test" });
       });
 
       it("(new) increments major key", () => {
@@ -67,7 +67,7 @@ describe('update(..., "ANCHOR")', () => {
         const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.update("/next");
+        testHistory.navigate("/next");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -88,7 +88,7 @@ describe('update(..., "ANCHOR")', () => {
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.update("/");
+        testHistory.navigate("/");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -108,7 +108,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
       });
 
       it('(same) is "REPLACE"', () => {
@@ -118,7 +118,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/");
+        testHistory.navigate("/");
       });
     });
 
@@ -131,15 +131,15 @@ describe('update(..., "ANCHOR")', () => {
           expect(testHistory.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate is not called", () => {
         const testHistory = InMemory();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
         expect(testHistory.location.pathname).toBe("/");
       });
 
@@ -149,7 +149,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -161,7 +161,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next");
+        testHistory.navigate("/next");
         expect(testHistory.action).toBe("PUSH");
       });
 
@@ -171,7 +171,7 @@ describe('update(..., "ANCHOR")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/");
+        testHistory.navigate("/");
         expect(testHistory.action).toBe("REPLACE");
       });
     });
@@ -185,7 +185,7 @@ describe('update(..., "ANCHOR")', () => {
           expect(testHistory.location.pathname).toBe("/");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
 
       it("does not update the action value", () => {
@@ -196,7 +196,7 @@ describe('update(..., "ANCHOR")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two");
+        testHistory.navigate("/two");
       });
     });
   });
@@ -211,7 +211,7 @@ describe('update(..., "ANCHOR")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next");
+      testHistory.navigate("/next");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -224,7 +224,7 @@ describe('update(..., "ANCHOR")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next");
+      testHistory.navigate("/next");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/in-memory/tests/anchor.spec.ts
+++ b/packages/in-memory/tests/anchor.spec.ts
@@ -1,6 +1,5 @@
-import 'jest';
-import Hash from '../../src';
-import { jsdom } from 'jsdom';
+import "jest";
+import InMemory from "../src";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -15,100 +14,84 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('navigate', () => {
-  let dom;
-  let window;
-
-  beforeEach(() => {
-    dom = jsdom('', {
-      url: 'http://example.com/#/one'
-    });
-    window = global.window = dom.defaultView;
-    global.document = dom;
-  });
-
-  afterEach(() => {
-    dom.close();
-    global.document = undefined;
-  });
-
-  describe('without a response handler', () => {
-    it('does nothing', () => {
-      const testHistory = Hash();
-      testHistory.navigate('/two');
-      expect(window.location.hash).toBe('#/one');
+describe('update(..., "ANCHOR")', () => {
+  describe("without a response handler", () => {
+    it("does nothing", () => {
+      const testHistory = InMemory();
+      testHistory.update("/two");
+      expect(testHistory.location.pathname).toBe("/");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
-      const testHistory = Hash();
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
+      const testHistory = InMemory();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.navigate('/two');
+      testHistory.update("/two");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
-        const testHistory = Hash();
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
+        const testHistory = InMemory();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.navigate('/two?test=ing');
+        testHistory.update("/two?test=ing");
       });
 
-      it('is a location object created from pushed object', () => {
-        const testHistory = Hash();
+      it("is a location object created from pushed object", () => {
+        const testHistory = InMemory();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.navigate({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" });
       });
 
-      it('(new) increments major key', () => {
-        const testHistory = Hash();
+      it("(new) increments major key", () => {
+        const testHistory = InMemory();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor] = testHistory.location.key.split('.');
+        const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.navigate('/next');
+        testHistory.update("/next");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
 
         expect(currentMajorNum).toEqual(initMajorNum + 1);
-        expect(currentMinor).toBe('0');
+        expect(currentMinor).toBe("0");
       });
 
-      it('(same) increments minor key', () => {
-        const testHistory = Hash();
+      it("(same) increments minor key", () => {
+        const testHistory = InMemory();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor, initMinor] = testHistory.location.key.split('.');
+        const [initMajor, initMinor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.navigate('/one');
+        testHistory.update("/");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
         const currentMinorNum = parseInt(currentMinor, 10);
 
@@ -117,110 +100,110 @@ describe('navigate', () => {
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('(new) is "PUSH"', () => {
-        const testHistory = Hash();
+        const testHistory = InMemory();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('PUSH');
+          expect(pending.action).toBe("PUSH");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
+        testHistory.update("/next");
       });
 
       it('(same) is "REPLACE"', () => {
-        const testHistory = Hash();
+        const testHistory = InMemory();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('REPLACE');
+          expect(pending.action).toBe("REPLACE");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/one');
+        testHistory.update("/");
       });
     });
 
-    describe('finish', () => {
-      it('updates Hash history when finish function is called', () => {
-        const testHistory = Hash();
+    describe("finish", () => {
+      it("updates InMemory history when finish function is called", () => {
+        const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.hash).toBe('#/one');
+          expect(testHistory.location.pathname).toBe("/");
           pending.finish();
-          expect(window.location.hash).toBe('#/two');
+          expect(testHistory.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
 
-      it('does nothing if update is not called', () => {
-        const testHistory = Hash();
+      it("does nothing if update is not called", () => {
+        const testHistory = InMemory();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
-        expect(window.location.hash).toBe('#/one');
+        testHistory.update("/two");
+        expect(testHistory.location.pathname).toBe("/");
       });
 
-      it('sets history.location to new location object', () => {
-        const testHistory = Hash();
+      it("sets history.location to new location object", () => {
+        const testHistory = InMemory();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
+        testHistory.update("/next");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
       it('(new) sets history.action to "PUSH"', () => {
-        const testHistory = Hash();
+        const testHistory = InMemory();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/next');
-        expect(testHistory.action).toBe('PUSH');
+        testHistory.update("/next");
+        expect(testHistory.action).toBe("PUSH");
       });
 
       it('(same) sets history.action to "REPLACE"', () => {
-        const testHistory = Hash();
+        const testHistory = InMemory();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/one');
-        expect(testHistory.action).toBe('REPLACE');
+        testHistory.update("/");
+        expect(testHistory.action).toBe("REPLACE");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update Hash history when cancel function is called', () => {
-        const testHistory = Hash();
+    describe("cancel", () => {
+      it("does not update InMemory history when cancel function is called", () => {
+        const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(window.location.hash).toBe('#/one');
+          expect(testHistory.location.pathname).toBe("/");
           pending.cancel();
-          expect(window.location.hash).toBe('#/one');
+          expect(testHistory.location.pathname).toBe("/");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
 
-      it('does not update the action value', () => {
-        const testHistory = Hash();
+      it("does not update the action value", () => {
+        const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.navigate('/two');
+        testHistory.update("/two");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
-      const testHistory = Hash();
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
+      const testHistory = InMemory();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
         confirm();
@@ -228,12 +211,12 @@ describe('navigate', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.navigate('/next');
+      testHistory.update("/next");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
-      const testHistory = Hash();
+    it("does not call response pending when the user prevents the navigation", () => {
+      const testHistory = InMemory();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
         prevent();
@@ -241,7 +224,7 @@ describe('navigate', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.navigate('/next');
+      testHistory.update("/next");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/in-memory/tests/go.spec.ts
+++ b/packages/in-memory/tests/go.spec.ts
@@ -76,11 +76,11 @@ describe("go", () => {
         done();
       }
       testHistory.respondWith(router);
-      testHistory.update("/two", "PUSH"); // 1.0
-      testHistory.update("/three", "PUSH"); // 2.0
-      testHistory.update("/four", "PUSH"); // 3.0
-      testHistory.update("/five", "PUSH"); // 4.0
-      testHistory.update("/six", "PUSH"); // 5.0
+      testHistory.navigate("/two", "PUSH"); // 1.0
+      testHistory.navigate("/three", "PUSH"); // 2.0
+      testHistory.navigate("/four", "PUSH"); // 3.0
+      testHistory.navigate("/five", "PUSH"); // 4.0
+      testHistory.navigate("/six", "PUSH"); // 5.0
       setup = true;
       testHistory.go(-2);
     });
@@ -110,18 +110,18 @@ describe("go", () => {
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(pushRouter);
-          testHistory.update("/seven", "PUSH");
+          testHistory.navigate("/seven", "PUSH");
         });
         const pushRouter = ignoreFirstCall(function(pending) {
           cancelGo("PUSH");
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
-        testHistory.update("/six", "PUSH"); // 5.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
+        testHistory.navigate("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
@@ -152,8 +152,8 @@ describe("go", () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router);
 
-      testHistory.update("/two", "PUSH"); // 1.0
-      testHistory.update("/three", "PUSH"); // 2.0
+      testHistory.navigate("/two", "PUSH"); // 1.0
+      testHistory.navigate("/three", "PUSH"); // 2.0
       setup = true;
       testHistory.go(-2);
     });
@@ -168,8 +168,8 @@ describe("go", () => {
       }
       testHistory.respondWith(router);
 
-      testHistory.update("/two", "PUSH"); // 1.0
-      testHistory.update("/three", "PUSH"); // 2.0
+      testHistory.navigate("/two", "PUSH"); // 1.0
+      testHistory.navigate("/three", "PUSH"); // 2.0
       // don't add function until we have setup the history
       testHistory.confirmWith(confirm);
       testHistory.go(-2);

--- a/packages/in-memory/tests/go.spec.ts
+++ b/packages/in-memory/tests/go.spec.ts
@@ -1,5 +1,5 @@
-import 'jest';
-import InMemory from '../src';
+import "jest";
+import InMemory from "../src";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -14,9 +14,9 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('go', () => {
-  describe('with no value', () => {
-    it('does nothing if there is no responseHandler', () => {
+describe("go", () => {
+  describe("with no value", () => {
+    it("does nothing if there is no responseHandler", () => {
       const testHistory = InMemory();
       expect(() => {
         testHistory.go();
@@ -27,9 +27,9 @@ describe('go', () => {
       const testHistory = InMemory();
       const router = ignoreFirstCall(function(pending) {
         expect(pending.location).toMatchObject({
-          pathname: '/'
+          pathname: "/"
         });
-        expect(pending.action).toBe('POP');
+        expect(pending.action).toBe("POP");
         done();
       });
       testHistory.respondWith(router); // calls router
@@ -38,10 +38,10 @@ describe('go', () => {
 
     it('sets history.action to "POP" when calling "finish"', done => {
       const testHistory = InMemory();
-      expect(testHistory.action).toBe('PUSH');
+      expect(testHistory.action).toBe("PUSH");
       const router = ignoreFirstCall(function(pending) {
         pending.finish();
-        expect(testHistory.action).toBe('POP');
+        expect(testHistory.action).toBe("POP");
         done();
       });
       testHistory.respondWith(router);
@@ -49,8 +49,8 @@ describe('go', () => {
     });
   });
 
-  describe('with a value', () => {
-    it('does nothing if the value is outside of the range', () => {
+  describe("with a value", () => {
+    it("does nothing if the value is outside of the range", () => {
       const testHistory = InMemory();
       const router = jest.fn();
       testHistory.respondWith(router);
@@ -60,7 +60,7 @@ describe('go', () => {
       expect(router.mock.calls.length).toBe(1);
     });
 
-    it('calls response handler with expected location and action', done => {
+    it("calls response handler with expected location and action", done => {
       const testHistory = InMemory();
       let setup = false;
       function router(pending) {
@@ -69,25 +69,25 @@ describe('go', () => {
           return;
         }
         expect(pending.location).toMatchObject({
-          pathname: '/four',
-          key: '3.0'
+          pathname: "/four",
+          key: "3.0"
         });
-        expect(pending.action).toBe('POP');
+        expect(pending.action).toBe("POP");
         done();
       }
       testHistory.respondWith(router);
-      testHistory.push('/two'); // 1.0
-      testHistory.push('/three'); // 2.0
-      testHistory.push('/four'); // 3.0
-      testHistory.push('/five'); // 4.0
-      testHistory.push('/six'); // 5.0
+      testHistory.update("/two", "PUSH"); // 1.0
+      testHistory.update("/three", "PUSH"); // 2.0
+      testHistory.update("/four", "PUSH"); // 3.0
+      testHistory.update("/five", "PUSH"); // 4.0
+      testHistory.update("/six", "PUSH"); // 5.0
       setup = true;
       testHistory.go(-2);
     });
 
-    it('does nothing if there is no responseHandler', () => {
+    it("does nothing if there is no responseHandler", () => {
       const testHistory = InMemory({
-        locations: ['/one', '/two'],
+        locations: ["/one", "/two"],
         index: 1
       });
       expect(() => {
@@ -96,9 +96,9 @@ describe('go', () => {
     });
   });
 
-  describe('respondWith', () => {
-    describe('cancel', () => {
-      it('does not update InMemory history when cancel function is called', () => {
+  describe("respondWith", () => {
+    describe("cancel", () => {
+      it("does not update InMemory history when cancel function is called", () => {
         const testHistory = InMemory();
         let setup = false;
         function initialRouter(pending) {
@@ -106,33 +106,33 @@ describe('go', () => {
         }
         let cancelGo;
         const goRouter = ignoreFirstCall(function(pending) {
-          expect(testHistory.location.pathname).toBe('/six');
+          expect(testHistory.location.pathname).toBe("/six");
           cancelGo = pending.cancel;
           // trigger a push call and don't resolve the go
           testHistory.respondWith(pushRouter);
-          testHistory.push('/seven');
+          testHistory.update("/seven", "PUSH");
         });
         const pushRouter = ignoreFirstCall(function(pending) {
-          cancelGo('PUSH');
+          cancelGo("PUSH");
         });
 
         testHistory.respondWith(initialRouter);
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
-        testHistory.push('/six'); // 5.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.update("/six", "PUSH"); // 5.0
 
         testHistory.respondWith(goRouter);
         testHistory.go(-2);
 
-        expect(testHistory.location.pathname).toBe('/six');
+        expect(testHistory.location.pathname).toBe("/six");
       });
     });
   });
 
-  describe('with user confirmation', () => {
-    it('calls response handler after the user confirms the navigation', done => {
+  describe("with user confirmation", () => {
+    it("calls response handler after the user confirms the navigation", done => {
       const testHistory = InMemory();
       let setup = false;
       const router = ignoreFirstCall(function(pending) {
@@ -141,8 +141,8 @@ describe('go', () => {
           return;
         }
         expect(testHistory.location).toMatchObject({
-          pathname: '/',
-          key: '0.0'
+          pathname: "/",
+          key: "0.0"
         });
         done();
       });
@@ -152,13 +152,13 @@ describe('go', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router);
 
-      testHistory.push('/two'); // 1.0
-      testHistory.push('/three'); // 2.0
+      testHistory.update("/two", "PUSH"); // 1.0
+      testHistory.update("/three", "PUSH"); // 2.0
       setup = true;
       testHistory.go(-2);
     });
 
-    it('does not call response handler when the user prevents the navigation', () => {
+    it("does not call response handler when the user prevents the navigation", () => {
       const testHistory = InMemory();
       const confirm = (info, confirm, prevent) => {
         prevent();
@@ -168,15 +168,15 @@ describe('go', () => {
       }
       testHistory.respondWith(router);
 
-      testHistory.push('/two'); // 1.0
-      testHistory.push('/three'); // 2.0
+      testHistory.update("/two", "PUSH"); // 1.0
+      testHistory.update("/three", "PUSH"); // 2.0
       // don't add function until we have setup the history
       testHistory.confirmWith(confirm);
       testHistory.go(-2);
 
       expect(testHistory.location).toMatchObject({
-        pathname: '/three',
-        key: '2.0'
+        pathname: "/three",
+        key: "2.0"
       });
     });
   });

--- a/packages/in-memory/tests/push.spec.ts
+++ b/packages/in-memory/tests/push.spec.ts
@@ -14,11 +14,11 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "PUSH")', () => {
+describe('navigate(..., "PUSH")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = InMemory();
-      testHistory.update("/two", "PUSH");
+      testHistory.navigate("/two", "PUSH");
       expect(testHistory.location.pathname).toBe("/");
     });
   });
@@ -28,7 +28,7 @@ describe('update(..., "PUSH")', () => {
       const testHistory = InMemory();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two", "PUSH");
+      testHistory.navigate("/two", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -42,7 +42,7 @@ describe('update(..., "PUSH")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing", "PUSH");
+        testHistory.navigate("/two?test=ing", "PUSH");
       });
 
       it("is a location object created from pushed object", () => {
@@ -54,7 +54,7 @@ describe('update(..., "PUSH")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" }, "PUSH");
+        testHistory.navigate({ pathname: "/two", hash: "test" }, "PUSH");
       });
 
       it("increments current major key value by 1, sets minor value to 0", () => {
@@ -67,7 +67,7 @@ describe('update(..., "PUSH")', () => {
         const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -87,7 +87,7 @@ describe('update(..., "PUSH")', () => {
             pending.action === "POP" &&
             pending.location.pathname === "/three"
           ) {
-            testHistory.update("/new-four", "PUSH");
+            testHistory.navigate("/new-four", "PUSH");
             afterPop = true;
           }
           if (afterPop) {
@@ -97,10 +97,10 @@ describe('update(..., "PUSH")', () => {
         }
         testHistory.respondWith(router); // calls router
         // just getting the history in the expected state
-        testHistory.update("/two", "PUSH"); // 1.0
-        testHistory.update("/three", "PUSH"); // 2.0
-        testHistory.update("/four", "PUSH"); // 3.0
-        testHistory.update("/five", "PUSH"); // 4.0
+        testHistory.navigate("/two", "PUSH"); // 1.0
+        testHistory.navigate("/three", "PUSH"); // 2.0
+        testHistory.navigate("/four", "PUSH"); // 3.0
+        testHistory.navigate("/five", "PUSH"); // 4.0
         testHistory.go(-2); // 2.0
       });
     });
@@ -113,12 +113,12 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
       });
     });
 
     describe("finish", () => {
-      it("updates InMemory history when finish function is called", () => {
+      it("navigates InMemory history when finish function is called", () => {
         const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
           expect(testHistory.location.pathname).toBe("/");
@@ -126,15 +126,15 @@ describe('update(..., "PUSH")', () => {
           expect(testHistory.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate is not called", () => {
         const testHistory = InMemory();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
         expect(testHistory.location.pathname).toBe("/");
       });
 
@@ -144,7 +144,7 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -156,7 +156,7 @@ describe('update(..., "PUSH")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "PUSH");
+        testHistory.navigate("/next", "PUSH");
         expect(testHistory.action).toBe("PUSH");
       });
     });
@@ -170,7 +170,7 @@ describe('update(..., "PUSH")', () => {
           expect(testHistory.location.pathname).toBe("/");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
 
       it("does not update the action value", () => {
@@ -181,7 +181,7 @@ describe('update(..., "PUSH")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "PUSH");
+        testHistory.navigate("/two", "PUSH");
       });
     });
   });
@@ -196,7 +196,7 @@ describe('update(..., "PUSH")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "PUSH");
+      testHistory.navigate("/next", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -209,7 +209,7 @@ describe('update(..., "PUSH")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "PUSH");
+      testHistory.navigate("/next", "PUSH");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/in-memory/tests/push.spec.ts
+++ b/packages/in-memory/tests/push.spec.ts
@@ -1,5 +1,5 @@
-import 'jest';
-import InMemory from '../src';
+import "jest";
+import InMemory from "../src";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -14,67 +14,67 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('push', () => {
-  describe('without a response handler', () => {
-    it('does nothing', () => {
+describe('update(..., "PUSH")', () => {
+  describe("without a response handler", () => {
+    it("does nothing", () => {
       const testHistory = InMemory();
-      testHistory.push('/two');
-      expect(testHistory.location.pathname).toBe('/');
+      testHistory.update("/two", "PUSH");
+      expect(testHistory.location.pathname).toBe("/");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
       const testHistory = InMemory();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.push('/two');
+      testHistory.update("/two", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
         const testHistory = InMemory();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.push('/two?test=ing');
+        testHistory.update("/two?test=ing", "PUSH");
       });
 
-      it('is a location object created from pushed object', () => {
+      it("is a location object created from pushed object", () => {
         const testHistory = InMemory();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.push({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" }, "PUSH");
       });
 
-      it('increments current major key value by 1, sets minor value to 0', () => {
+      it("increments current major key value by 1, sets minor value to 0", () => {
         const testHistory = InMemory();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor] = testHistory.location.key.split('.');
+        const [initMajor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
 
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
 
         expect(currentMajorNum).toEqual(initMajorNum + 1);
-        expect(currentMinor).toBe('0');
+        expect(currentMinor).toBe("0");
       });
 
       it("increments from current location's key when not at end of locations", done => {
@@ -84,69 +84,69 @@ describe('push', () => {
         function router(pending) {
           pending.finish();
           if (
-            pending.action === 'POP' &&
-            pending.location.pathname === '/three'
+            pending.action === "POP" &&
+            pending.location.pathname === "/three"
           ) {
-            testHistory.push('/new-four');
+            testHistory.update("/new-four", "PUSH");
             afterPop = true;
           }
           if (afterPop) {
-            expect(testHistory.location.key).toBe('3.0');
+            expect(testHistory.location.key).toBe("3.0");
             done();
           }
         }
         testHistory.respondWith(router); // calls router
         // just getting the history in the expected state
-        testHistory.push('/two'); // 1.0
-        testHistory.push('/three'); // 2.0
-        testHistory.push('/four'); // 3.0
-        testHistory.push('/five'); // 4.0
+        testHistory.update("/two", "PUSH"); // 1.0
+        testHistory.update("/three", "PUSH"); // 2.0
+        testHistory.update("/four", "PUSH"); // 3.0
+        testHistory.update("/five", "PUSH"); // 4.0
         testHistory.go(-2); // 2.0
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('is "PUSH"', () => {
         const testHistory = InMemory();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('PUSH');
+          expect(pending.action).toBe("PUSH");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
       });
     });
 
-    describe('finish', () => {
-      it('updates InMemory history when finish function is called', () => {
+    describe("finish", () => {
+      it("updates InMemory history when finish function is called", () => {
         const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.location.pathname).toBe('/');
+          expect(testHistory.location.pathname).toBe("/");
           pending.finish();
-          expect(testHistory.location.pathname).toBe('/two');
+          expect(testHistory.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
 
-      it('does nothing if update is not called', () => {
+      it("does nothing if update is not called", () => {
         const testHistory = InMemory();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
-        expect(testHistory.location.pathname).toBe('/');
+        testHistory.update("/two", "PUSH");
+        expect(testHistory.location.pathname).toBe("/");
       });
 
-      it('sets history.location to new location object', () => {
+      it("sets history.location to new location object", () => {
         const testHistory = InMemory();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
+        testHistory.update("/next", "PUSH");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
@@ -156,38 +156,38 @@ describe('push', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.push('/next');
-        expect(testHistory.action).toBe('PUSH');
+        testHistory.update("/next", "PUSH");
+        expect(testHistory.action).toBe("PUSH");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update InMemory history when cancel function is called', () => {
+    describe("cancel", () => {
+      it("does not update InMemory history when cancel function is called", () => {
         const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.location.pathname).toBe('/');
+          expect(testHistory.location.pathname).toBe("/");
           pending.cancel();
-          expect(testHistory.location.pathname).toBe('/');
+          expect(testHistory.location.pathname).toBe("/");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
 
-      it('does not update the action value', () => {
+      it("does not update the action value", () => {
         const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.push('/two');
+        testHistory.update("/two", "PUSH");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
       const testHistory = InMemory();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -196,11 +196,11 @@ describe('push', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.push('/next');
+      testHistory.update("/next", "PUSH");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
+    it("does not call response pending when the user prevents the navigation", () => {
       const testHistory = InMemory();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -209,7 +209,7 @@ describe('push', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.push('/next');
+      testHistory.update("/next", "PUSH");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/in-memory/tests/replace.spec.ts
+++ b/packages/in-memory/tests/replace.spec.ts
@@ -1,5 +1,5 @@
-import 'jest';
-import InMemory from '../src';
+import "jest";
+import InMemory from "../src";
 
 function ignoreFirstCall(fn) {
   let notCalled = true;
@@ -14,47 +14,47 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('replace', () => {
-  describe('without a response handler', () => {
-    it('does nothing', () => {
+describe('update(..., "REPLACE")', () => {
+  describe("without a response handler", () => {
+    it("does nothing", () => {
       const testHistory = InMemory();
-      testHistory.replace('/two');
-      expect(testHistory.location.pathname).toBe('/');
+      testHistory.update("/two", "REPLACE");
+      expect(testHistory.location.pathname).toBe("/");
     });
   });
 
-  describe('respondWith', () => {
-    it('triggers a response handler call', () => {
+  describe("respondWith", () => {
+    it("triggers a response handler call", () => {
       const testHistory = InMemory();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.replace('/two');
+      testHistory.update("/two", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    describe('location', () => {
-      it('is a location object created from pushed string', () => {
+    describe("location", () => {
+      it("is a location object created from pushed string", () => {
         const testHistory = InMemory();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            query: 'test=ing'
+            pathname: "/two",
+            query: "test=ing"
           });
         });
         testHistory.respondWith(router);
-        testHistory.replace('/two?test=ing');
+        testHistory.update("/two?test=ing", "REPLACE");
       });
 
-      it('is a location object created from pushed object', () => {
+      it("is a location object created from pushed object", () => {
         const testHistory = InMemory();
         const router = ignoreFirstCall(function(pending) {
           expect(pending.location).toMatchObject({
-            pathname: '/two',
-            hash: 'test'
+            pathname: "/two",
+            hash: "test"
           });
         });
         testHistory.respondWith(router);
-        testHistory.replace({ pathname: '/two', hash: 'test' });
+        testHistory.update({ pathname: "/two", hash: "test" }, "REPLACE");
       });
 
       it("key maintains current location's major value, increments the minor value", () => {
@@ -64,14 +64,14 @@ describe('replace', () => {
         }
         testHistory.respondWith(router); // calls router
 
-        const [initMajor, initMinor] = testHistory.location.key.split('.');
+        const [initMajor, initMinor] = testHistory.location.key.split(".");
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
 
         const current = testHistory.location;
-        const [currentMajor, currentMinor] = current.key.split('.');
+        const [currentMajor, currentMinor] = current.key.split(".");
         const currentMajorNum = parseInt(currentMajor, 10);
         const currentMinorNum = parseInt(currentMinor, 10);
 
@@ -80,48 +80,48 @@ describe('replace', () => {
       });
     });
 
-    describe('action', () => {
+    describe("action", () => {
       it('is "REPLACE"', () => {
         const testHistory = InMemory();
         const router = ignoreFirstCall(function router(pending) {
-          expect(pending.action).toBe('REPLACE');
+          expect(pending.action).toBe("REPLACE");
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
       });
     });
 
-    describe('finish', () => {
-      it('updates InMemory history when finish function is called', () => {
+    describe("finish", () => {
+      it("updates InMemory history when finish function is called", () => {
         const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.location.pathname).toBe('/');
+          expect(testHistory.location.pathname).toBe("/");
           pending.finish();
-          expect(testHistory.location.pathname).toBe('/two');
+          expect(testHistory.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
 
-      it('does nothing if update is not called', () => {
+      it("does nothing if update is not called", () => {
         const testHistory = InMemory();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
-        expect(testHistory.location.pathname).toBe('/');
+        testHistory.update("/two", "REPLACE");
+        expect(testHistory.location.pathname).toBe("/");
       });
 
-      it('sets history.location to new location object', () => {
+      it("sets history.location to new location object", () => {
         const testHistory = InMemory();
         function router(pending) {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
+        testHistory.update("/next", "REPLACE");
         expect(testHistory.location).toMatchObject({
-          pathname: '/next'
+          pathname: "/next"
         });
       });
 
@@ -131,38 +131,38 @@ describe('replace', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/next');
-        expect(testHistory.action).toBe('REPLACE');
+        testHistory.update("/next", "REPLACE");
+        expect(testHistory.action).toBe("REPLACE");
       });
     });
 
-    describe('cancel', () => {
-      it('does not update InMemory history when cancel function is called', () => {
+    describe("cancel", () => {
+      it("does not update InMemory history when cancel function is called", () => {
         const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.location.pathname).toBe('/');
+          expect(testHistory.location.pathname).toBe("/");
           pending.cancel();
-          expect(testHistory.location.pathname).toBe('/');
+          expect(testHistory.location.pathname).toBe("/");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
 
-      it('does not update the action value', () => {
+      it("does not update the action value", () => {
         const testHistory = InMemory();
         let router = ignoreFirstCall(function(pending) {
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
           pending.cancel();
-          expect(testHistory.action).toBe('PUSH');
+          expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.replace('/two');
+        testHistory.update("/two", "REPLACE");
       });
     });
   });
 
-  describe('with a confirmation function', () => {
-    it('calls response pending after the user confirms the navigation', () => {
+  describe("with a confirmation function", () => {
+    it("calls response pending after the user confirms the navigation", () => {
       const testHistory = InMemory();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -171,11 +171,11 @@ describe('replace', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.replace('/next');
+      testHistory.update("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
-    it('does not call response pending when the user prevents the navigation', () => {
+    it("does not call response pending when the user prevents the navigation", () => {
       const testHistory = InMemory();
       const router = jest.fn();
       const confirm = (info, confirm, prevent) => {
@@ -184,7 +184,7 @@ describe('replace', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.replace('/next');
+      testHistory.update("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/in-memory/tests/replace.spec.ts
+++ b/packages/in-memory/tests/replace.spec.ts
@@ -14,11 +14,11 @@ function ignoreFirstCall(fn) {
 
 // We create our own jsdom instead of using the one that Jest will create
 // so that we can reset the DOM between tests
-describe('update(..., "REPLACE")', () => {
+describe('navigate(..., "REPLACE")', () => {
   describe("without a response handler", () => {
     it("does nothing", () => {
       const testHistory = InMemory();
-      testHistory.update("/two", "REPLACE");
+      testHistory.navigate("/two", "REPLACE");
       expect(testHistory.location.pathname).toBe("/");
     });
   });
@@ -28,7 +28,7 @@ describe('update(..., "REPLACE")', () => {
       const testHistory = InMemory();
       const router = jest.fn();
       testHistory.respondWith(router); // calls router
-      testHistory.update("/two", "REPLACE");
+      testHistory.navigate("/two", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -42,7 +42,7 @@ describe('update(..., "REPLACE")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update("/two?test=ing", "REPLACE");
+        testHistory.navigate("/two?test=ing", "REPLACE");
       });
 
       it("is a location object created from pushed object", () => {
@@ -54,7 +54,7 @@ describe('update(..., "REPLACE")', () => {
           });
         });
         testHistory.respondWith(router);
-        testHistory.update({ pathname: "/two", hash: "test" }, "REPLACE");
+        testHistory.navigate({ pathname: "/two", hash: "test" }, "REPLACE");
       });
 
       it("key maintains current location's major value, increments the minor value", () => {
@@ -68,7 +68,7 @@ describe('update(..., "REPLACE")', () => {
         const initMajorNum = parseInt(initMajor, 10);
         const initMinorNum = parseInt(initMinor, 10);
 
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
 
         const current = testHistory.location;
         const [currentMajor, currentMinor] = current.key.split(".");
@@ -88,7 +88,7 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
       });
     });
 
@@ -101,15 +101,15 @@ describe('update(..., "REPLACE")', () => {
           expect(testHistory.location.pathname).toBe("/two");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
 
-      it("does nothing if update is not called", () => {
+      it("does nothing if navigate is not called", () => {
         const testHistory = InMemory();
         let call = 0;
         function router(pending) {}
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
         expect(testHistory.location.pathname).toBe("/");
       });
 
@@ -119,7 +119,7 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
         expect(testHistory.location).toMatchObject({
           pathname: "/next"
         });
@@ -131,7 +131,7 @@ describe('update(..., "REPLACE")', () => {
           pending.finish();
         }
         testHistory.respondWith(router); // calls router
-        testHistory.update("/next", "REPLACE");
+        testHistory.navigate("/next", "REPLACE");
         expect(testHistory.action).toBe("REPLACE");
       });
     });
@@ -145,7 +145,7 @@ describe('update(..., "REPLACE")', () => {
           expect(testHistory.location.pathname).toBe("/");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
 
       it("does not update the action value", () => {
@@ -156,7 +156,7 @@ describe('update(..., "REPLACE")', () => {
           expect(testHistory.action).toBe("PUSH");
         });
         testHistory.respondWith(router); // calls router
-        testHistory.update("/two", "REPLACE");
+        testHistory.navigate("/two", "REPLACE");
       });
     });
   });
@@ -171,7 +171,7 @@ describe('update(..., "REPLACE")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "REPLACE");
+      testHistory.navigate("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(2);
     });
 
@@ -184,7 +184,7 @@ describe('update(..., "REPLACE")', () => {
       testHistory.confirmWith(confirm);
       testHistory.respondWith(router); // calls router
 
-      testHistory.update("/next", "REPLACE");
+      testHistory.navigate("/next", "REPLACE");
       expect(router.mock.calls.length).toBe(1);
     });
   });

--- a/packages/in-memory/types/index.d.ts
+++ b/packages/in-memory/types/index.d.ts
@@ -1,24 +1,11 @@
-import {
-  History,
-  LocationDetails,
-  HickoryLocation,
-  PartialLocation,
-  AnyLocation,
-  Options as RootOptions
-} from "@hickory/root";
-export {
-  History,
-  HickoryLocation,
-  PartialLocation,
-  AnyLocation,
-  LocationDetails
-};
+import { History, LocationDetails, HickoryLocation, PartialLocation, AnyLocation, Options as RootOptions } from "@hickory/root";
+export { History, HickoryLocation, PartialLocation, AnyLocation, LocationDetails };
 export interface Options extends RootOptions {
-  locations?: Array<string | PartialLocation>;
-  index?: number;
+    locations?: Array<string | PartialLocation>;
+    index?: number;
 }
 export interface InMemoryHistory extends History {
-  locations: Array<HickoryLocation>;
-  index: number;
+    locations: Array<HickoryLocation>;
+    index: number;
 }
 export default function InMemory(options?: Options): InMemoryHistory;

--- a/packages/location-utils/package-lock.json
+++ b/packages/location-utils/package-lock.json
@@ -1,32 +1,26 @@
 {
-  "name": "@hickory/location-utils",
-  "version": "1.0.0-beta.1",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@types/jest": {
       "version": "22.1.1",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.1.1.tgz",
-      "integrity": "sha512-JSh6yk+GkeSkucPa3DllFtpDXe0BMxDTFqCxoryzGKvZiusdb97Sb7X5gnMiKdFGkHbTMjSH+HbE9wrBIzrUTA==",
-      "dev": true
+      "integrity": "sha512-JSh6yk+GkeSkucPa3DllFtpDXe0BMxDTFqCxoryzGKvZiusdb97Sb7X5gnMiKdFGkHbTMjSH+HbE9wrBIzrUTA=="
     },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-      "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
-      "dev": true
+      "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
     },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-      "dev": true
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
     },
     "acorn-globals": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "dev": true,
       "requires": {
         "acorn": "4.0.13"
       }
@@ -35,7 +29,6 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
       "requires": {
         "co": "4.6.0",
         "json-stable-stringify": "1.0.1"
@@ -45,7 +38,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -55,32 +47,27 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-      "dev": true
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true,
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
@@ -90,7 +77,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-      "dev": true,
       "requires": {
         "default-require-extensions": "1.0.0"
       }
@@ -99,7 +85,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -108,7 +93,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
       "requires": {
         "arr-flatten": "1.1.0"
       }
@@ -116,50 +100,42 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "dev": true
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -167,26 +143,22 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -197,7 +169,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
       "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.22.0",
         "babel-generator": "6.25.0",
@@ -224,7 +195,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "dev": true,
       "requires": {
         "babel-messages": "6.23.0",
         "babel-runtime": "6.25.0",
@@ -240,7 +210,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-template": "6.25.0"
@@ -250,7 +219,6 @@
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.0.2.tgz",
       "integrity": "sha512-7nF+URWcIVX3A9DiLRcuwq86a+Phl+wXN/fwlSO4boTP/GmLLVyIQTui3th7tbA8F3L5xkYEO0e3NSf7oB/BJQ==",
-      "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.4",
         "babel-preset-jest": "21.0.2"
@@ -260,7 +228,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -269,7 +236,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
       "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "istanbul-lib-instrument": "1.7.4",
@@ -279,14 +245,12 @@
     "babel-plugin-jest-hoist": {
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.0.2.tgz",
-      "integrity": "sha512-iQeYbiM0lr5TCW42qvGkBBoy0rTx6SPppRFT7NwvdnSwNOGMI8+1Oc27SF5wJbCvAY7x5KScP3f0TKtunl+NRw==",
-      "dev": true
+      "integrity": "sha512-iQeYbiM0lr5TCW42qvGkBBoy0rTx6SPppRFT7NwvdnSwNOGMI8+1Oc27SF5wJbCvAY7x5KScP3f0TKtunl+NRw=="
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -298,7 +262,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "esutils": "2.0.2",
@@ -309,7 +272,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
           "requires": {
             "core-js": "2.4.1",
             "regenerator-runtime": "0.11.0"
@@ -319,7 +281,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -332,7 +293,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "6.23.0",
@@ -349,7 +309,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
@@ -360,14 +319,12 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-          "dev": true
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
         }
       }
     },
@@ -375,7 +332,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
@@ -385,7 +341,6 @@
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.0.2.tgz",
       "integrity": "sha512-WyzCFIoU+ga307hPnobHL9eRrZlpZYHQf7M3yOtimAwrLAgNFoSfin7ZVw903+zz81ZLuowZMKWCd0w3PNpAhg==",
-      "dev": true,
       "requires": {
         "babel-plugin-jest-hoist": "21.0.2"
       }
@@ -394,7 +349,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "dev": true,
       "requires": {
         "babel-core": "6.25.0",
         "babel-runtime": "6.25.0",
@@ -409,7 +363,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
       "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
-      "dev": true,
       "requires": {
         "core-js": "2.4.1",
         "regenerator-runtime": "0.10.5"
@@ -419,7 +372,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-traverse": "6.25.0",
@@ -432,7 +384,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.22.0",
         "babel-messages": "6.23.0",
@@ -449,7 +400,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "esutils": "2.0.2",
@@ -460,20 +410,17 @@
     "babylon": {
       "version": "6.17.4",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
-      "dev": true
+      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -483,7 +430,6 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -492,7 +438,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -502,7 +447,6 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
       "requires": {
         "expand-range": "1.8.2",
         "preserve": "0.2.0",
@@ -513,7 +457,6 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       },
@@ -521,8 +464,7 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
     },
@@ -530,7 +472,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true,
       "requires": {
         "node-int64": "0.4.0"
       }
@@ -538,33 +479,28 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-      "dev": true
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
       "optional": true
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -575,7 +511,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
@@ -587,14 +522,12 @@
     "ci-info": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
-      "dev": true
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ=="
     },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
       "optional": true,
       "requires": {
         "center-align": "0.1.3",
@@ -606,7 +539,6 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
           "optional": true
         }
       }
@@ -614,20 +546,17 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -635,20 +564,17 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -656,38 +582,32 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-type-parser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
-      "dev": true
+      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
     },
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
-      "dev": true
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
     },
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-      "dev": true
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
@@ -698,7 +618,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
       "requires": {
         "boom": "2.10.1"
       }
@@ -706,14 +625,12 @@
     "cssom": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-      "dev": true
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
     },
     "cssstyle": {
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
       "requires": {
         "cssom": "0.3.2"
       }
@@ -722,7 +639,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -730,8 +646,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -739,7 +654,6 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -747,20 +661,17 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true,
       "requires": {
         "strip-bom": "2.0.0"
       }
@@ -768,14 +679,12 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -783,14 +692,12 @@
     "diff": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
-      "dev": true
+      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg=="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -800,7 +707,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true,
       "requires": {
         "prr": "0.0.0"
       }
@@ -809,7 +715,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
@@ -817,14 +722,12 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "dev": true,
       "requires": {
         "esprima": "2.7.3",
         "estraverse": "1.9.3",
@@ -836,14 +739,12 @@
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
         },
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
           "optional": true,
           "requires": {
             "amdefine": "1.0.1"
@@ -854,26 +755,22 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "estraverse": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-      "dev": true
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "exec-sh": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-      "dev": true,
       "requires": {
         "merge": "1.2.0"
       }
@@ -882,7 +779,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -897,7 +793,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
       "requires": {
         "is-posix-bracket": "0.1.1"
       }
@@ -906,7 +801,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
       "requires": {
         "fill-range": "2.2.3"
       }
@@ -914,14 +808,12 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -929,20 +821,17 @@
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-      "dev": true
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true,
       "requires": {
         "bser": "2.0.0"
       }
@@ -950,14 +839,12 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fileset": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2",
         "minimatch": "3.0.4"
@@ -967,7 +854,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
@@ -980,7 +866,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
       "requires": {
         "locate-path": "2.0.0"
       }
@@ -988,14 +873,12 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
       "requires": {
         "for-in": "1.0.2"
       }
@@ -1003,14 +886,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -1021,7 +902,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
       "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -1032,7 +912,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
           }
@@ -1042,14 +921,12 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.8.0",
@@ -1952,20 +1829,17 @@
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -1973,8 +1847,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -1982,7 +1855,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -1996,7 +1868,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
@@ -2006,7 +1877,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
       "requires": {
         "is-glob": "2.0.1"
       }
@@ -2014,20 +1884,17 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphlib": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.1.tgz",
       "integrity": "sha1-QjUsUrovTQNctWbrkfc5X3bryVE=",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -2035,14 +1902,12 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "handlebars": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -2053,14 +1918,12 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -2070,14 +1933,12 @@
     "har-schema": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-      "dev": true
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
     },
     "har-validator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true,
       "requires": {
         "ajv": "4.11.8",
         "har-schema": "1.0.5"
@@ -2087,7 +1948,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -2095,14 +1955,12 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
@@ -2113,14 +1971,12 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -2129,14 +1985,12 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "html-encoding-sniffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-      "dev": true,
       "requires": {
         "whatwg-encoding": "1.0.1"
       }
@@ -2145,7 +1999,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
       "requires": {
         "assert-plus": "0.2.0",
         "jsprim": "1.4.0",
@@ -2155,20 +2008,17 @@
     "iconv-lite": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-      "dev": true
+      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
     },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -2177,14 +2027,12 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -2192,26 +2040,22 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
@@ -2220,7 +2064,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-      "dev": true,
       "requires": {
         "ci-info": "1.1.1"
       }
@@ -2228,14 +2071,12 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
       "requires": {
         "is-primitive": "2.0.0"
       }
@@ -2243,20 +2084,17 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -2265,7 +2103,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -2274,7 +2111,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -2283,7 +2119,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -2291,50 +2126,42 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -2342,14 +2169,12 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
       "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
-      "dev": true,
       "requires": {
         "async": "2.5.0",
         "fileset": "2.0.3",
@@ -2367,14 +2192,12 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "istanbul-lib-instrument": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
           "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
-          "dev": true,
           "requires": {
             "babel-generator": "6.25.0",
             "babel-template": "6.25.0",
@@ -2390,14 +2213,12 @@
     "istanbul-lib-coverage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
-      "dev": true
+      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
     },
     "istanbul-lib-hook": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
       "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
-      "dev": true,
       "requires": {
         "append-transform": "0.4.0"
       }
@@ -2406,7 +2227,6 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
       "integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
-      "dev": true,
       "requires": {
         "babel-generator": "6.25.0",
         "babel-template": "6.25.0",
@@ -2421,7 +2241,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
-      "dev": true,
       "requires": {
         "istanbul-lib-coverage": "1.1.1",
         "mkdirp": "0.5.1",
@@ -2432,14 +2251,12 @@
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
           "requires": {
             "has-flag": "1.0.0"
           }
@@ -2450,7 +2267,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
       "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
-      "dev": true,
       "requires": {
         "debug": "2.6.8",
         "istanbul-lib-coverage": "1.1.1",
@@ -2463,7 +2279,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
-      "dev": true,
       "requires": {
         "handlebars": "4.0.10"
       }
@@ -2472,7 +2287,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-21.1.0.tgz",
       "integrity": "sha512-yPxhkAyxCymLkpZakAGm8VGNQB04HgD5bhYCQHBcIGCbH5oYHZDekkt/FBtFC2vPcyWG+dsKCqvmys/1kQYjKA==",
-      "dev": true,
       "requires": {
         "jest-cli": "21.1.0"
       },
@@ -2480,14 +2294,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2496,7 +2308,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2507,7 +2318,6 @@
           "version": "21.1.0",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.1.0.tgz",
           "integrity": "sha512-ISnDjHv9m0nCrSKFC+Cnr9SotaWHYRP+TK81vMtPwkV+/70JbfYJT6ZnuqgqyAnTYE4f/aCe6uyMPKHAVT1RpA==",
-          "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
             "chalk": "2.1.0",
@@ -2543,14 +2353,12 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -2559,7 +2367,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2570,7 +2377,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.1.0.tgz",
       "integrity": "sha512-OnjMoORBVG9Jko6Bc3UGJPx9G1PNsETiqpQXZ6wPU3fk1gtxhKYE4Mgdk28ER/CWeg7bzGUcaragLf1lf1tzbQ==",
-      "dev": true,
       "requires": {
         "throat": "4.1.0"
       }
@@ -2579,7 +2385,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.1.0.tgz",
       "integrity": "sha512-RQnWwHRSIRvtyJQeZTpXUmsNYVVr/qu3XWfV3FTFkDsxHQi6Sj5sfUK5FHCNUCXIuFTs+r3qbYoMz2q8rdm/EA==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "glob": "7.1.2",
@@ -2598,7 +2403,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2607,7 +2411,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2618,7 +2421,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2629,7 +2431,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.1.0.tgz",
       "integrity": "sha512-mGJinKrAB6hj1cpO1FOuDCfgILozGvYi4Zpk8GrxmNgdd9/9llIA2Xzu5879Fa4ayh7lb9ej2NdvuNLMCjbrMg==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "diff": "3.3.0",
@@ -2641,7 +2442,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2650,7 +2450,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2661,7 +2460,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2671,14 +2469,12 @@
     "jest-docblock": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.1.0.tgz",
-      "integrity": "sha512-ai3olFJ/3cSd60klaRIcC/Cb44/RsJ69qS8uXxfWXEbnbDqjcbl5K8Z5ekfY15hgVZGSAiLz7pOwfjIBE/yJVw==",
-      "dev": true
+      "integrity": "sha512-ai3olFJ/3cSd60klaRIcC/Cb44/RsJ69qS8uXxfWXEbnbDqjcbl5K8Z5ekfY15hgVZGSAiLz7pOwfjIBE/yJVw=="
     },
     "jest-environment-jsdom": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.1.0.tgz",
       "integrity": "sha512-sMcGlN11SnnuJKzR5oJ5LsDRzHEBLUeMRImDbvxyusNW9l17wAEsoLuAWbv0W8crZTTwjRO6/mitpNF3PmVsMg==",
-      "dev": true,
       "requires": {
         "jest-mock": "21.1.0",
         "jest-util": "21.1.0",
@@ -2689,7 +2485,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.1.0.tgz",
       "integrity": "sha512-Lv/pcK2zq2DZKL/q7+u8mrlSeXmaMGgmJOx0+Ew+FxYKdSzO0jpEUTEfzQOnMvpSWMqjKUYLDYkCPCBFcOX93w==",
-      "dev": true,
       "requires": {
         "jest-mock": "21.1.0",
         "jest-util": "21.1.0"
@@ -2698,14 +2493,12 @@
     "jest-get-type": {
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.0.2.tgz",
-      "integrity": "sha512-4KvNzzXMXeapGaMWd+SL5e47zcMn8KTWjom6Fl3avxVXnbKS7abD1p4xWe4ToAZfgNoYNsQ9Av/mnWMnZK/Z4A==",
-      "dev": true
+      "integrity": "sha512-4KvNzzXMXeapGaMWd+SL5e47zcMn8KTWjom6Fl3avxVXnbKS7abD1p4xWe4ToAZfgNoYNsQ9Av/mnWMnZK/Z4A=="
     },
     "jest-haste-map": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.1.0.tgz",
       "integrity": "sha512-a7chVtmpzRgRkYDL4eZgRuXZUlos1JOC7Dam3WryXGiD/1GNj+QONt6jcsAzDZohzs9XYg2EkjyGxIAXcNipBg==",
-      "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
@@ -2719,7 +2512,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.1.0.tgz",
       "integrity": "sha512-YjbAaXN6K5f8rtwPVxkMRIYNZGB5GiJcApcj/5ER7uGJrqJMqyCklMAPZR5Gq8XPzzuDVfoB2h7kxyOGVqaxrw==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "expect": "21.1.0",
@@ -2735,7 +2527,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2744,7 +2535,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2755,7 +2545,6 @@
           "version": "21.1.0",
           "resolved": "https://registry.npmjs.org/expect/-/expect-21.1.0.tgz",
           "integrity": "sha512-gBmUVy+A4+brj/MnuiwLe+MIMfSffWUmZMNjKHrMkB0cpkAjnFdwHAxs6MvYeh4+14ocp+SfKp4ebNEhkbV3YQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "jest-diff": "21.1.0",
@@ -2769,7 +2558,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2780,7 +2568,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.1.0.tgz",
       "integrity": "sha512-V/Xindf+VY5UM+oz9Nhsv0Ql93lRcKS7tHtVoXtlXkZXoXpydHwuezkLLCpZkH/Uew5y2OyDZpnlxPvEalJZng==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "jest-get-type": "21.0.2",
@@ -2791,7 +2578,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2800,7 +2586,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2811,7 +2596,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2822,7 +2606,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.1.0.tgz",
       "integrity": "sha512-BwKrjR4HvGoodYw3PFh95IU4qDk3nVOf3LqOKRaaR6486bJM8IZIlxWR8yfxhAN7nDGBDco/TR+U50WcPgzvgA==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "micromatch": "2.3.11",
@@ -2833,7 +2616,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2842,7 +2624,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2853,7 +2634,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2863,20 +2643,17 @@
     "jest-mock": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.1.0.tgz",
-      "integrity": "sha512-iwING4rMP1rhepAj/MVPHVxGltwwR+Lfmiy9ARevQ7XDZ/zF7h+KPFeOFMSMGvV5/dS05PHhwRjFzrjvkybNLw==",
-      "dev": true
+      "integrity": "sha512-iwING4rMP1rhepAj/MVPHVxGltwwR+Lfmiy9ARevQ7XDZ/zF7h+KPFeOFMSMGvV5/dS05PHhwRjFzrjvkybNLw=="
     },
     "jest-regex-util": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.1.0.tgz",
-      "integrity": "sha512-1QiJa6nvdzVgDhY1FTG3fl+2eYrCQGQoIeGaVPjt9+VmxsQ/BwZD6aglH0z6ZK/uEXZPAaj1XaemKM9tC6VVlQ==",
-      "dev": true
+      "integrity": "sha512-1QiJa6nvdzVgDhY1FTG3fl+2eYrCQGQoIeGaVPjt9+VmxsQ/BwZD6aglH0z6ZK/uEXZPAaj1XaemKM9tC6VVlQ=="
     },
     "jest-resolve": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.1.0.tgz",
       "integrity": "sha512-HKh0pnf2SwR3hDaToONjHrR9ds282QFkxCA9xMet3JpsdLL24oRYMLSQ7jtepZfA6EP+XycRE6RfcMBD8emetg==",
-      "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
         "chalk": "2.1.0",
@@ -2887,7 +2664,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2896,7 +2672,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2907,7 +2682,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2918,7 +2692,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.1.0.tgz",
       "integrity": "sha512-Xj0mzS+Gh6ERgf9ofr5/vuqtyvTh4pAp4aVe6OkiZ4cLxUl6zQ6wByXMX0CLq0hwojFYmwwt+v3+fOAV7PqHPg==",
-      "dev": true,
       "requires": {
         "jest-regex-util": "21.1.0"
       }
@@ -2927,7 +2700,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.1.0.tgz",
       "integrity": "sha512-EXFqEQRHSo6ksBrT+vRNoBRfIVVepQF56JfTczzXLs+dIKcq3DDKaiMkkehBc2LdHzm/e63qbhz2aeQn64qqlA==",
-      "dev": true,
       "requires": {
         "jest-config": "21.1.0",
         "jest-docblock": "21.1.0",
@@ -2944,8 +2716,7 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -2953,7 +2724,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.1.0.tgz",
       "integrity": "sha512-BNc1v8Cs6bjnti1JBCSGIJdSI/6MIGMMCiY+MpoyWXhoZGNLkUKGw7073lZtOo0PC/RZcXMDy1DcZXHH7YHKQw==",
-      "dev": true,
       "requires": {
         "babel-core": "6.25.0",
         "babel-jest": "21.0.2",
@@ -2978,7 +2748,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2987,7 +2756,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2997,14 +2765,12 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3015,7 +2781,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.1.0.tgz",
       "integrity": "sha512-oYASKqxO/Ghbdd96z/3KSQ1y4YUtqrQVzSKbnz3yjGsi1nu3AXMPmjRCM/CZXL+H+DAIgMirj5Uq0dZOxo6Bnw==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "jest-diff": "21.1.0",
@@ -3029,7 +2794,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3038,7 +2802,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -3049,7 +2812,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3060,7 +2822,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.1.0.tgz",
       "integrity": "sha512-PJxaShBieLpB55NV4+loIZHiOlfZHjAGzVRp9BDzrr2m70UxQViDJenNdz4edJMWXJLjp817t1QrWi+LjcRaKw==",
-      "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.1.0",
@@ -3075,7 +2836,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3084,7 +2844,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -3095,7 +2854,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3106,7 +2864,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.1.0.tgz",
       "integrity": "sha512-xS0cyErNWpsLFlGkn/b87pk/Mv7J+mCTs8hQ4KmtOIIoM1sHYobXII8AtkoN8FC7E3+Ptxjo+/3xWk6LK1dKcw==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "jest-get-type": "21.0.2",
@@ -3118,7 +2875,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3127,7 +2883,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -3138,7 +2893,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3148,14 +2902,12 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -3165,14 +2917,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "jsdom": {
       "version": "9.12.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
-      "dev": true,
       "requires": {
         "abab": "1.0.3",
         "acorn": "4.0.13",
@@ -3198,20 +2948,17 @@
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -3219,20 +2966,17 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -3240,14 +2984,12 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.0.2",
@@ -3258,8 +3000,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -3267,7 +3008,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "1.1.5"
       }
@@ -3276,14 +3016,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "optional": true
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -3291,14 +3029,12 @@
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-      "dev": true
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -3308,7 +3044,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
@@ -3321,7 +3056,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
@@ -3330,20 +3064,17 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -3352,7 +3083,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -3362,7 +3092,6 @@
       "version": "0.22.4",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
       "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
-      "dev": true,
       "requires": {
         "vlq": "0.2.2"
       }
@@ -3371,7 +3100,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
       "requires": {
         "tmpl": "1.0.4"
       }
@@ -3380,7 +3108,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -3388,14 +3115,12 @@
     "merge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
       "requires": {
         "arr-diff": "2.0.0",
         "array-unique": "0.2.1",
@@ -3415,14 +3140,12 @@
     "mime-db": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
-      "dev": true
+      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
     },
     "mime-types": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
-      "dev": true,
       "requires": {
         "mime-db": "1.29.0"
       }
@@ -3430,14 +3153,12 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -3445,14 +3166,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -3460,33 +3179,28 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "dev": true,
       "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-      "dev": true
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
     },
     "node-notifier": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
-      "dev": true,
       "requires": {
         "growly": "1.3.0",
         "semver": "5.4.1",
@@ -3498,7 +3212,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -3510,7 +3223,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "1.0.2"
       }
@@ -3519,7 +3231,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -3527,38 +3238,32 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
-      "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8=",
-      "dev": true
+      "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8="
     },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-hash": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.8.tgz",
-      "integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw=",
-      "dev": true
+      "integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw="
     },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
@@ -3568,7 +3273,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -3577,7 +3281,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8",
         "wordwrap": "0.0.3"
@@ -3587,7 +3290,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -3600,22 +3302,19 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
       "requires": {
         "execa": "0.7.0",
         "lcid": "1.0.0",
@@ -3625,32 +3324,27 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-      "dev": true
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
         "p-limit": "1.1.0"
       }
@@ -3659,7 +3353,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
       "requires": {
         "glob-base": "0.3.0",
         "is-dotfile": "1.0.3",
@@ -3671,7 +3364,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -3679,38 +3371,32 @@
     "parse5": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
-      "dev": true
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
     },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
@@ -3720,26 +3406,22 @@
     "performance-now": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-      "dev": true
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -3748,7 +3430,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0"
       }
@@ -3756,26 +3437,22 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
-      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
-      "dev": true
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw=="
     },
     "pretty-format": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.1.0.tgz",
       "integrity": "sha512-041BVxr2pp7uGG8slfw43ysRXSaBIVqo5Li03BwI3K1/9oENlhkEEYWPkHpDzj7NlJ3GZte+Tv/DId5g2PLduA==",
-      "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
         "ansi-styles": "3.2.0"
@@ -3784,14 +3461,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3801,38 +3476,32 @@
     "private": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
-      "dev": true
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
     },
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-      "dev": true
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-      "dev": true
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
     },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -3842,7 +3511,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -3851,7 +3519,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "1.1.5"
               }
@@ -3862,7 +3529,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.5"
           }
@@ -3873,7 +3539,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
       "requires": {
         "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
@@ -3884,7 +3549,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
       "requires": {
         "find-up": "1.1.2",
         "read-pkg": "1.1.0"
@@ -3894,7 +3558,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
           "requires": {
             "path-exists": "2.1.0",
             "pinkie-promise": "2.0.1"
@@ -3904,7 +3567,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
           }
@@ -3914,14 +3576,12 @@
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-      "dev": true
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3",
         "is-primitive": "2.0.0"
@@ -3930,26 +3590,22 @@
     "remove-trailing-separator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-      "dev": true
+      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
@@ -3958,7 +3614,6 @@
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true,
       "requires": {
         "aws-sign2": "0.6.0",
         "aws4": "1.6.0",
@@ -3987,20 +3642,17 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-      "dev": true,
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -4009,7 +3661,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -4019,7 +3670,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -4027,14 +3677,12 @@
     "rollup": {
       "version": "0.50.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.50.0.tgz",
-      "integrity": "sha512-7RqCBQ9iwsOBPkjYgoIaeUij606mSkDMExP0NT7QDI3bqkHYQHrQ83uoNIXwPcQm/vP2VbsUz3kiyZZ1qPlLTQ==",
-      "dev": true
+      "integrity": "sha512-7RqCBQ9iwsOBPkjYgoIaeUij606mSkDMExP0NT7QDI3bqkHYQHrQ83uoNIXwPcQm/vP2VbsUz3kiyZZ1qPlLTQ=="
     },
     "rollup-plugin-replace": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz",
       "integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
-      "dev": true,
       "requires": {
         "magic-string": "0.22.4",
         "minimatch": "3.0.4",
@@ -4044,14 +3692,12 @@
         "estree-walker": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
-          "dev": true
+          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
         },
         "rollup-pluginutils": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
           "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
-          "dev": true,
           "requires": {
             "estree-walker": "0.3.1",
             "micromatch": "2.3.11"
@@ -4063,7 +3709,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.5.2.tgz",
       "integrity": "sha1-kpLRnoTGN8OqatFzqw+cIOrNlwE=",
-      "dev": true,
       "requires": {
         "colors": "1.1.2",
         "fs-extra": "3.0.1",
@@ -4079,14 +3724,12 @@
         "estree-walker": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
-          "dev": true
+          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
         },
         "fs-extra": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "3.0.1",
@@ -4097,7 +3740,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
           "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
-          "dev": true,
           "requires": {
             "estree-walker": "0.3.1",
             "micromatch": "2.3.11"
@@ -4109,7 +3751,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz",
       "integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
-      "dev": true,
       "requires": {
         "uglify-js": "3.0.26"
       },
@@ -4118,7 +3759,6 @@
           "version": "3.0.26",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.26.tgz",
           "integrity": "sha512-+D/BjzuvT1oRMSkH0fuF3M/BCvDxDywmZasd1UTPPHsdsHZqJEAZSvrojgFlS7lrM3ZZWq5h7Bb5i96X1TbOJw==",
-          "dev": true,
           "requires": {
             "commander": "2.11.0",
             "source-map": "0.5.6"
@@ -4129,14 +3769,12 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sane": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-2.0.0.tgz",
       "integrity": "sha1-mct58h9KU6adTQzZV8LbBAJLjrI=",
-      "dev": true,
       "requires": {
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
@@ -4151,34 +3789,29 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -4186,32 +3819,27 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -4219,14 +3847,12 @@
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-      "dev": true
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
     },
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true,
       "requires": {
         "source-map": "0.5.6"
       }
@@ -4235,7 +3861,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -4243,26 +3868,22 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -4277,8 +3898,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -4286,7 +3906,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-      "dev": true,
       "requires": {
         "astral-regex": "1.0.0",
         "strip-ansi": "4.0.0"
@@ -4295,14 +3914,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -4313,7 +3930,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -4323,14 +3939,12 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -4339,7 +3953,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
       "requires": {
         "is-utf8": "0.2.1"
       }
@@ -4347,26 +3960,22 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-      "dev": true
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
     "test-exclude": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-      "dev": true,
       "requires": {
         "arrify": "1.0.1",
         "micromatch": "2.3.11",
@@ -4378,26 +3987,22 @@
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-      "dev": true
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
     },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-      "dev": true
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
@@ -4405,20 +4010,17 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "ts-jest": {
       "version": "21.0.1",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-21.0.1.tgz",
       "integrity": "sha512-MIX8uMMr7FSRT56GASXUxeorEs3x2iO+JwkVzUHwxjzld4+UtPMZ9EEUpX7JU7eFKDkXaD1aAIVnuNrg15Xnuw==",
-      "dev": true,
       "requires": {
         "babel-core": "6.25.0",
         "babel-plugin-istanbul": "4.1.4",
@@ -4435,20 +4037,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
           "requires": {
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
@@ -4459,7 +4058,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -4472,7 +4070,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -4484,7 +4081,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
           "requires": {
             "pify": "2.3.0"
           }
@@ -4493,7 +4089,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
           "requires": {
             "load-json-file": "2.0.0",
             "normalize-package-data": "2.4.0",
@@ -4504,7 +4099,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
@@ -4514,7 +4108,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -4523,14 +4116,12 @@
             "is-fullwidth-code-point": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -4540,14 +4131,12 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "yargs": {
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
           "requires": {
             "camelcase": "4.1.0",
             "cliui": "3.2.0",
@@ -4569,14 +4158,12 @@
     "tslib": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
-      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
-      "dev": true
+      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -4585,14 +4172,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }
@@ -4600,14 +4185,12 @@
     "typescript": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
-      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
-      "dev": true
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ="
     },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "0.5.6",
@@ -4619,7 +4202,6 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "1.2.1",
@@ -4634,26 +4216,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-      "dev": true
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -4663,7 +4241,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true,
       "requires": {
         "extsprintf": "1.0.2"
       }
@@ -4671,14 +4248,12 @@
     "vlq": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
-      "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE=",
-      "dev": true
+      "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE="
     },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
       "requires": {
         "makeerror": "1.0.11"
       }
@@ -4686,20 +4261,17 @@
     "watch": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
-      "dev": true
+      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
     },
     "webidl-conversions": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
-      "integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA=",
-      "dev": true
+      "integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA="
     },
     "whatwg-encoding": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.4.13"
       }
@@ -4708,7 +4280,6 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
-      "dev": true,
       "requires": {
         "tr46": "0.0.3",
         "webidl-conversions": "3.0.1"
@@ -4717,8 +4288,7 @@
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         }
       }
     },
@@ -4726,7 +4296,6 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -4734,27 +4303,23 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
       "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "worker-farm": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
       "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
-      "dev": true,
       "requires": {
         "errno": "0.1.4",
         "xtend": "4.0.1"
@@ -4764,7 +4329,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -4773,14 +4337,12 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
@@ -4790,32 +4352,27 @@
     "xml-name-validator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-      "dev": true
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
       "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-      "dev": true,
       "requires": {
         "camelcase": "4.1.0",
         "cliui": "3.2.0",
@@ -4835,20 +4392,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
           "requires": {
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
@@ -4859,7 +4413,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -4872,7 +4425,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -4884,7 +4436,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
           "requires": {
             "pify": "2.3.0"
           }
@@ -4893,7 +4444,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
           "requires": {
             "load-json-file": "2.0.0",
             "normalize-package-data": "2.4.0",
@@ -4904,7 +4454,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
@@ -4914,7 +4463,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -4923,14 +4471,12 @@
             "is-fullwidth-code-point": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -4940,8 +4486,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
@@ -4949,7 +4494,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "dev": true,
       "requires": {
         "camelcase": "4.1.0"
       },
@@ -4957,8 +4501,7 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         }
       }
     }

--- a/packages/root/package-lock.json
+++ b/packages/root/package-lock.json
@@ -1,37 +1,26 @@
 {
-  "name": "@hickory/root",
-  "version": "1.0.0-beta.6",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
-    "@hickory/location-utils": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-1.0.0-beta.1.tgz",
-      "integrity": "sha512-MswOL5R3ZRwcfQlAHBa5l5dbzhZbnXdrJTYTBNpZP26hbTKDMjKG2WSP/Iy8TE50KOeC4z1ciaDPRqURASmH4g=="
-    },
     "@types/jest": {
       "version": "20.0.8",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-20.0.8.tgz",
-      "integrity": "sha512-+vFMPCwOffrTy685X9Kj+Iz83I56Q8j0JK6xvsm6TA5qxbtPUJZcXtJY05WMGlhCKp/9qbpRCwyOp6GkMuyuLg==",
-      "dev": true
+      "integrity": "sha512-+vFMPCwOffrTy685X9Kj+Iz83I56Q8j0JK6xvsm6TA5qxbtPUJZcXtJY05WMGlhCKp/9qbpRCwyOp6GkMuyuLg=="
     },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-      "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
-      "dev": true
+      "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
     },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-      "dev": true
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
     },
     "acorn-globals": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "dev": true,
       "requires": {
         "acorn": "4.0.13"
       }
@@ -40,7 +29,6 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
       "requires": {
         "co": "4.6.0",
         "json-stable-stringify": "1.0.1"
@@ -50,7 +38,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -60,32 +47,27 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-      "dev": true
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true,
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
@@ -95,7 +77,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-      "dev": true,
       "requires": {
         "default-require-extensions": "1.0.0"
       }
@@ -104,7 +85,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -113,7 +93,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
       "requires": {
         "arr-flatten": "1.1.0"
       }
@@ -121,50 +100,42 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "dev": true
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -172,26 +143,22 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -202,7 +169,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
       "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.22.0",
         "babel-generator": "6.25.0",
@@ -229,7 +195,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "dev": true,
       "requires": {
         "babel-messages": "6.23.0",
         "babel-runtime": "6.23.0",
@@ -245,7 +210,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",
         "babel-template": "6.25.0"
@@ -255,7 +219,6 @@
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.0.2.tgz",
       "integrity": "sha512-7nF+URWcIVX3A9DiLRcuwq86a+Phl+wXN/fwlSO4boTP/GmLLVyIQTui3th7tbA8F3L5xkYEO0e3NSf7oB/BJQ==",
-      "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.4",
         "babel-preset-jest": "21.0.2"
@@ -265,7 +228,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.23.0"
       }
@@ -274,7 +236,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
       "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "istanbul-lib-instrument": "1.7.3",
@@ -284,14 +245,12 @@
     "babel-plugin-jest-hoist": {
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.0.2.tgz",
-      "integrity": "sha512-iQeYbiM0lr5TCW42qvGkBBoy0rTx6SPppRFT7NwvdnSwNOGMI8+1Oc27SF5wJbCvAY7x5KScP3f0TKtunl+NRw==",
-      "dev": true
+      "integrity": "sha512-iQeYbiM0lr5TCW42qvGkBBoy0rTx6SPppRFT7NwvdnSwNOGMI8+1Oc27SF5wJbCvAY7x5KScP3f0TKtunl+NRw=="
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -303,7 +262,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "esutils": "2.0.2",
@@ -314,7 +272,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
           "requires": {
             "core-js": "2.4.1",
             "regenerator-runtime": "0.11.0"
@@ -324,7 +281,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -337,7 +293,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "6.23.0",
@@ -354,7 +309,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
@@ -365,14 +319,12 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-          "dev": true
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
         }
       }
     },
@@ -380,7 +332,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",
         "babel-types": "6.25.0"
@@ -390,7 +341,6 @@
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.0.2.tgz",
       "integrity": "sha512-WyzCFIoU+ga307hPnobHL9eRrZlpZYHQf7M3yOtimAwrLAgNFoSfin7ZVw903+zz81ZLuowZMKWCd0w3PNpAhg==",
-      "dev": true,
       "requires": {
         "babel-plugin-jest-hoist": "21.0.2"
       }
@@ -399,7 +349,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "dev": true,
       "requires": {
         "babel-core": "6.25.0",
         "babel-runtime": "6.23.0",
@@ -414,7 +363,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true,
       "requires": {
         "core-js": "2.4.1",
         "regenerator-runtime": "0.10.5"
@@ -424,7 +372,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",
         "babel-traverse": "6.25.0",
@@ -437,7 +384,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.22.0",
         "babel-messages": "6.23.0",
@@ -454,7 +400,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",
         "esutils": "2.0.2",
@@ -465,20 +410,17 @@
     "babylon": {
       "version": "6.17.4",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
-      "dev": true
+      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -488,7 +430,6 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -497,7 +438,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -507,7 +447,6 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
       "requires": {
         "expand-range": "1.8.2",
         "preserve": "0.2.0",
@@ -518,7 +457,6 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       },
@@ -526,8 +464,7 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
     },
@@ -535,7 +472,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true,
       "requires": {
         "node-int64": "0.4.0"
       }
@@ -543,33 +479,28 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-      "dev": true
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
       "optional": true
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -580,7 +511,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
@@ -592,14 +522,12 @@
     "ci-info": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
-      "dev": true
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ=="
     },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
       "optional": true,
       "requires": {
         "center-align": "0.1.3",
@@ -611,7 +539,6 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
           "optional": true
         }
       }
@@ -619,20 +546,17 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.2"
       }
@@ -640,20 +564,17 @@
     "color-name": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
-      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
-      "dev": true
+      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
     },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -662,7 +583,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
       "requires": {
         "graceful-readlink": "1.0.1"
       }
@@ -670,32 +590,27 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-type-parser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
-      "dev": true
+      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
     },
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
-      "dev": true
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
     },
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-      "dev": true
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
@@ -706,7 +621,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
       "requires": {
         "boom": "2.10.1"
       }
@@ -714,14 +628,12 @@
     "cssom": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-      "dev": true
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
     },
     "cssstyle": {
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
       "requires": {
         "cssom": "0.3.2"
       }
@@ -730,7 +642,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -738,8 +649,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -747,7 +657,6 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -755,20 +664,17 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true,
       "requires": {
         "strip-bom": "2.0.0"
       }
@@ -776,14 +682,12 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -791,14 +695,12 @@
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-      "dev": true
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -808,7 +710,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true,
       "requires": {
         "prr": "0.0.0"
       }
@@ -817,7 +718,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
@@ -825,14 +725,12 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "dev": true,
       "requires": {
         "esprima": "2.7.3",
         "estraverse": "1.9.3",
@@ -844,14 +742,12 @@
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
         },
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
           "optional": true,
           "requires": {
             "amdefine": "1.0.1"
@@ -862,32 +758,27 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "estraverse": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-      "dev": true
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
     },
     "estree-walker": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-      "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
-      "dev": true
+      "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "exec-sh": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-      "dev": true,
       "requires": {
         "merge": "1.2.0"
       }
@@ -896,7 +787,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -911,7 +801,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
       "requires": {
         "is-posix-bracket": "0.1.1"
       }
@@ -920,7 +809,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
       "requires": {
         "fill-range": "2.2.3"
       }
@@ -928,14 +816,12 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -943,20 +829,17 @@
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-      "dev": true
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true,
       "requires": {
         "bser": "2.0.0"
       }
@@ -964,14 +847,12 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fileset": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2",
         "minimatch": "3.0.4"
@@ -981,7 +862,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
@@ -994,7 +874,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
       "requires": {
         "locate-path": "2.0.0"
       }
@@ -1002,14 +881,12 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
       "requires": {
         "for-in": "1.0.2"
       }
@@ -1017,14 +894,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -1035,7 +910,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "3.0.1",
@@ -1045,14 +919,12 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.8.0",
@@ -1955,20 +1827,17 @@
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -1976,8 +1845,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -1985,7 +1853,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -1999,7 +1866,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
@@ -2009,7 +1875,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
       "requires": {
         "is-glob": "2.0.1"
       }
@@ -2017,26 +1882,22 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "graphlib": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.1.tgz",
       "integrity": "sha1-QjUsUrovTQNctWbrkfc5X3bryVE=",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -2044,14 +1905,12 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "handlebars": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -2062,14 +1921,12 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -2079,14 +1936,12 @@
     "har-schema": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-      "dev": true
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
     },
     "har-validator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true,
       "requires": {
         "ajv": "4.11.8",
         "har-schema": "1.0.5"
@@ -2096,7 +1951,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -2104,14 +1958,12 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
@@ -2122,14 +1974,12 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -2138,14 +1988,12 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "html-encoding-sniffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-      "dev": true,
       "requires": {
         "whatwg-encoding": "1.0.1"
       }
@@ -2154,7 +2002,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
       "requires": {
         "assert-plus": "0.2.0",
         "jsprim": "1.4.0",
@@ -2164,20 +2011,17 @@
     "iconv-lite": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-      "dev": true
+      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
     },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -2186,14 +2030,12 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -2201,26 +2043,22 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
@@ -2229,7 +2067,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-      "dev": true,
       "requires": {
         "ci-info": "1.1.1"
       }
@@ -2237,14 +2074,12 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
       "requires": {
         "is-primitive": "2.0.0"
       }
@@ -2252,20 +2087,17 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -2274,7 +2106,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -2283,7 +2114,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -2291,14 +2121,12 @@
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-      "dev": true
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -2306,50 +2134,42 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -2357,14 +2177,12 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
       "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
-      "dev": true,
       "requires": {
         "async": "2.5.0",
         "fileset": "2.0.3",
@@ -2382,14 +2200,12 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "istanbul-lib-instrument": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
           "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
-          "dev": true,
           "requires": {
             "babel-generator": "6.25.0",
             "babel-template": "6.25.0",
@@ -2405,14 +2221,12 @@
     "istanbul-lib-coverage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
-      "dev": true
+      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
     },
     "istanbul-lib-hook": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
       "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
-      "dev": true,
       "requires": {
         "append-transform": "0.4.0"
       }
@@ -2421,7 +2235,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
       "integrity": "sha1-klsjkWPqvdaMxASPUsL6T4mez6c=",
-      "dev": true,
       "requires": {
         "babel-generator": "6.25.0",
         "babel-template": "6.25.0",
@@ -2436,7 +2249,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
-      "dev": true,
       "requires": {
         "istanbul-lib-coverage": "1.1.1",
         "mkdirp": "0.5.1",
@@ -2447,14 +2259,12 @@
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
           "requires": {
             "has-flag": "1.0.0"
           }
@@ -2465,7 +2275,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
       "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
-      "dev": true,
       "requires": {
         "debug": "2.6.8",
         "istanbul-lib-coverage": "1.1.1",
@@ -2478,7 +2287,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
-      "dev": true,
       "requires": {
         "handlebars": "4.0.10"
       }
@@ -2487,7 +2295,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-21.1.0.tgz",
       "integrity": "sha512-yPxhkAyxCymLkpZakAGm8VGNQB04HgD5bhYCQHBcIGCbH5oYHZDekkt/FBtFC2vPcyWG+dsKCqvmys/1kQYjKA==",
-      "dev": true,
       "requires": {
         "jest-cli": "21.1.0"
       },
@@ -2495,14 +2302,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2511,7 +2316,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2522,7 +2326,6 @@
           "version": "21.1.0",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.1.0.tgz",
           "integrity": "sha512-ISnDjHv9m0nCrSKFC+Cnr9SotaWHYRP+TK81vMtPwkV+/70JbfYJT6ZnuqgqyAnTYE4f/aCe6uyMPKHAVT1RpA==",
-          "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
             "chalk": "2.1.0",
@@ -2558,14 +2361,12 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -2574,7 +2375,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2585,7 +2385,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.1.0.tgz",
       "integrity": "sha512-OnjMoORBVG9Jko6Bc3UGJPx9G1PNsETiqpQXZ6wPU3fk1gtxhKYE4Mgdk28ER/CWeg7bzGUcaragLf1lf1tzbQ==",
-      "dev": true,
       "requires": {
         "throat": "4.1.0"
       }
@@ -2594,7 +2393,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.1.0.tgz",
       "integrity": "sha512-RQnWwHRSIRvtyJQeZTpXUmsNYVVr/qu3XWfV3FTFkDsxHQi6Sj5sfUK5FHCNUCXIuFTs+r3qbYoMz2q8rdm/EA==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "glob": "7.1.2",
@@ -2613,7 +2411,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2622,7 +2419,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2633,7 +2429,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2644,7 +2439,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.1.0.tgz",
       "integrity": "sha512-mGJinKrAB6hj1cpO1FOuDCfgILozGvYi4Zpk8GrxmNgdd9/9llIA2Xzu5879Fa4ayh7lb9ej2NdvuNLMCjbrMg==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "diff": "3.2.0",
@@ -2656,7 +2450,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2665,7 +2458,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2676,7 +2468,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2686,14 +2477,12 @@
     "jest-docblock": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.1.0.tgz",
-      "integrity": "sha512-ai3olFJ/3cSd60klaRIcC/Cb44/RsJ69qS8uXxfWXEbnbDqjcbl5K8Z5ekfY15hgVZGSAiLz7pOwfjIBE/yJVw==",
-      "dev": true
+      "integrity": "sha512-ai3olFJ/3cSd60klaRIcC/Cb44/RsJ69qS8uXxfWXEbnbDqjcbl5K8Z5ekfY15hgVZGSAiLz7pOwfjIBE/yJVw=="
     },
     "jest-environment-jsdom": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.1.0.tgz",
       "integrity": "sha512-sMcGlN11SnnuJKzR5oJ5LsDRzHEBLUeMRImDbvxyusNW9l17wAEsoLuAWbv0W8crZTTwjRO6/mitpNF3PmVsMg==",
-      "dev": true,
       "requires": {
         "jest-mock": "21.1.0",
         "jest-util": "21.1.0",
@@ -2704,7 +2493,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.1.0.tgz",
       "integrity": "sha512-Lv/pcK2zq2DZKL/q7+u8mrlSeXmaMGgmJOx0+Ew+FxYKdSzO0jpEUTEfzQOnMvpSWMqjKUYLDYkCPCBFcOX93w==",
-      "dev": true,
       "requires": {
         "jest-mock": "21.1.0",
         "jest-util": "21.1.0"
@@ -2713,14 +2501,12 @@
     "jest-get-type": {
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.0.2.tgz",
-      "integrity": "sha512-4KvNzzXMXeapGaMWd+SL5e47zcMn8KTWjom6Fl3avxVXnbKS7abD1p4xWe4ToAZfgNoYNsQ9Av/mnWMnZK/Z4A==",
-      "dev": true
+      "integrity": "sha512-4KvNzzXMXeapGaMWd+SL5e47zcMn8KTWjom6Fl3avxVXnbKS7abD1p4xWe4ToAZfgNoYNsQ9Av/mnWMnZK/Z4A=="
     },
     "jest-haste-map": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.1.0.tgz",
       "integrity": "sha512-a7chVtmpzRgRkYDL4eZgRuXZUlos1JOC7Dam3WryXGiD/1GNj+QONt6jcsAzDZohzs9XYg2EkjyGxIAXcNipBg==",
-      "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
@@ -2734,7 +2520,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.1.0.tgz",
       "integrity": "sha512-YjbAaXN6K5f8rtwPVxkMRIYNZGB5GiJcApcj/5ER7uGJrqJMqyCklMAPZR5Gq8XPzzuDVfoB2h7kxyOGVqaxrw==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "expect": "21.1.0",
@@ -2750,7 +2535,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2759,7 +2543,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2770,7 +2553,6 @@
           "version": "21.1.0",
           "resolved": "https://registry.npmjs.org/expect/-/expect-21.1.0.tgz",
           "integrity": "sha512-gBmUVy+A4+brj/MnuiwLe+MIMfSffWUmZMNjKHrMkB0cpkAjnFdwHAxs6MvYeh4+14ocp+SfKp4ebNEhkbV3YQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "jest-diff": "21.1.0",
@@ -2784,7 +2566,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2795,7 +2576,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.1.0.tgz",
       "integrity": "sha512-V/Xindf+VY5UM+oz9Nhsv0Ql93lRcKS7tHtVoXtlXkZXoXpydHwuezkLLCpZkH/Uew5y2OyDZpnlxPvEalJZng==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "jest-get-type": "21.0.2",
@@ -2806,7 +2586,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2815,7 +2594,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2826,7 +2604,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2837,7 +2614,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.1.0.tgz",
       "integrity": "sha512-BwKrjR4HvGoodYw3PFh95IU4qDk3nVOf3LqOKRaaR6486bJM8IZIlxWR8yfxhAN7nDGBDco/TR+U50WcPgzvgA==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "micromatch": "2.3.11",
@@ -2848,7 +2624,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2857,7 +2632,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2868,7 +2642,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2878,20 +2651,17 @@
     "jest-mock": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.1.0.tgz",
-      "integrity": "sha512-iwING4rMP1rhepAj/MVPHVxGltwwR+Lfmiy9ARevQ7XDZ/zF7h+KPFeOFMSMGvV5/dS05PHhwRjFzrjvkybNLw==",
-      "dev": true
+      "integrity": "sha512-iwING4rMP1rhepAj/MVPHVxGltwwR+Lfmiy9ARevQ7XDZ/zF7h+KPFeOFMSMGvV5/dS05PHhwRjFzrjvkybNLw=="
     },
     "jest-regex-util": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.1.0.tgz",
-      "integrity": "sha512-1QiJa6nvdzVgDhY1FTG3fl+2eYrCQGQoIeGaVPjt9+VmxsQ/BwZD6aglH0z6ZK/uEXZPAaj1XaemKM9tC6VVlQ==",
-      "dev": true
+      "integrity": "sha512-1QiJa6nvdzVgDhY1FTG3fl+2eYrCQGQoIeGaVPjt9+VmxsQ/BwZD6aglH0z6ZK/uEXZPAaj1XaemKM9tC6VVlQ=="
     },
     "jest-resolve": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.1.0.tgz",
       "integrity": "sha512-HKh0pnf2SwR3hDaToONjHrR9ds282QFkxCA9xMet3JpsdLL24oRYMLSQ7jtepZfA6EP+XycRE6RfcMBD8emetg==",
-      "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
         "chalk": "2.1.0",
@@ -2902,7 +2672,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2911,7 +2680,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -2922,7 +2690,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2933,7 +2700,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.1.0.tgz",
       "integrity": "sha512-Xj0mzS+Gh6ERgf9ofr5/vuqtyvTh4pAp4aVe6OkiZ4cLxUl6zQ6wByXMX0CLq0hwojFYmwwt+v3+fOAV7PqHPg==",
-      "dev": true,
       "requires": {
         "jest-regex-util": "21.1.0"
       }
@@ -2942,7 +2708,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.1.0.tgz",
       "integrity": "sha512-EXFqEQRHSo6ksBrT+vRNoBRfIVVepQF56JfTczzXLs+dIKcq3DDKaiMkkehBc2LdHzm/e63qbhz2aeQn64qqlA==",
-      "dev": true,
       "requires": {
         "jest-config": "21.1.0",
         "jest-docblock": "21.1.0",
@@ -2959,8 +2724,7 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -2968,7 +2732,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.1.0.tgz",
       "integrity": "sha512-BNc1v8Cs6bjnti1JBCSGIJdSI/6MIGMMCiY+MpoyWXhoZGNLkUKGw7073lZtOo0PC/RZcXMDy1DcZXHH7YHKQw==",
-      "dev": true,
       "requires": {
         "babel-core": "6.25.0",
         "babel-jest": "21.0.2",
@@ -2993,7 +2756,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3002,7 +2764,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -3012,14 +2773,12 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3030,7 +2789,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.1.0.tgz",
       "integrity": "sha512-oYASKqxO/Ghbdd96z/3KSQ1y4YUtqrQVzSKbnz3yjGsi1nu3AXMPmjRCM/CZXL+H+DAIgMirj5Uq0dZOxo6Bnw==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "jest-diff": "21.1.0",
@@ -3044,7 +2802,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3053,7 +2810,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -3064,7 +2820,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3075,7 +2830,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.1.0.tgz",
       "integrity": "sha512-PJxaShBieLpB55NV4+loIZHiOlfZHjAGzVRp9BDzrr2m70UxQViDJenNdz4edJMWXJLjp817t1QrWi+LjcRaKw==",
-      "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.1.0",
@@ -3090,7 +2844,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3099,7 +2852,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -3110,7 +2862,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3121,7 +2872,6 @@
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.1.0.tgz",
       "integrity": "sha512-xS0cyErNWpsLFlGkn/b87pk/Mv7J+mCTs8hQ4KmtOIIoM1sHYobXII8AtkoN8FC7E3+Ptxjo+/3xWk6LK1dKcw==",
-      "dev": true,
       "requires": {
         "chalk": "2.1.0",
         "jest-get-type": "21.0.2",
@@ -3133,7 +2883,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3142,7 +2891,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -3153,7 +2901,6 @@
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3163,14 +2910,12 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -3180,14 +2925,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "jsdom": {
       "version": "9.12.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
-      "dev": true,
       "requires": {
         "abab": "1.0.3",
         "acorn": "4.0.13",
@@ -3213,20 +2956,17 @@
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -3234,20 +2974,17 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -3255,14 +2992,12 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.0.2",
@@ -3273,8 +3008,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -3282,7 +3016,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "1.1.5"
       }
@@ -3291,14 +3024,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "optional": true
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -3306,14 +3037,12 @@
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-      "dev": true
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -3323,7 +3052,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
@@ -3336,7 +3064,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
@@ -3345,20 +3072,17 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -3367,7 +3091,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -3377,7 +3100,6 @@
       "version": "0.22.4",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
       "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
-      "dev": true,
       "requires": {
         "vlq": "0.2.2"
       }
@@ -3386,7 +3108,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
       "requires": {
         "tmpl": "1.0.4"
       }
@@ -3395,7 +3116,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -3403,14 +3123,12 @@
     "merge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
       "requires": {
         "arr-diff": "2.0.0",
         "array-unique": "0.2.1",
@@ -3430,14 +3148,12 @@
     "mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-      "dev": true
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
     },
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true,
       "requires": {
         "mime-db": "1.27.0"
       }
@@ -3445,14 +3161,12 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -3460,14 +3174,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -3475,33 +3187,28 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "dev": true,
       "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-      "dev": true
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
     },
     "node-notifier": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
-      "dev": true,
       "requires": {
         "growly": "1.3.0",
         "semver": "5.3.0",
@@ -3513,7 +3220,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -3525,7 +3231,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "1.0.2"
       }
@@ -3534,7 +3239,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -3542,38 +3246,32 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
-      "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8=",
-      "dev": true
+      "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8="
     },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-hash": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.8.tgz",
-      "integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw=",
-      "dev": true
+      "integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw="
     },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
@@ -3583,7 +3281,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -3592,7 +3289,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8",
         "wordwrap": "0.0.3"
@@ -3602,7 +3298,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -3615,22 +3310,19 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
       "requires": {
         "execa": "0.7.0",
         "lcid": "1.0.0",
@@ -3640,32 +3332,27 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-      "dev": true
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
         "p-limit": "1.1.0"
       }
@@ -3674,7 +3361,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
       "requires": {
         "glob-base": "0.3.0",
         "is-dotfile": "1.0.3",
@@ -3686,7 +3372,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -3694,38 +3379,32 @@
     "parse5": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
-      "dev": true
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
     },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
@@ -3735,26 +3414,22 @@
     "performance-now": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-      "dev": true
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -3763,7 +3438,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0"
       }
@@ -3771,26 +3445,22 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
-      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
-      "dev": true
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw=="
     },
     "pretty-format": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.1.0.tgz",
       "integrity": "sha512-041BVxr2pp7uGG8slfw43ysRXSaBIVqo5Li03BwI3K1/9oENlhkEEYWPkHpDzj7NlJ3GZte+Tv/DId5g2PLduA==",
-      "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
         "ansi-styles": "3.2.0"
@@ -3799,14 +3469,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -3816,38 +3484,32 @@
     "private": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
-      "dev": true
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
     },
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-      "dev": true
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
-      "dev": true
+      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
     },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -3857,7 +3519,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -3866,7 +3527,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "1.1.5"
               }
@@ -3877,7 +3537,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.5"
           }
@@ -3888,7 +3547,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
       "requires": {
         "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
@@ -3899,7 +3557,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
       "requires": {
         "find-up": "1.1.2",
         "read-pkg": "1.1.0"
@@ -3909,7 +3566,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
           "requires": {
             "path-exists": "2.1.0",
             "pinkie-promise": "2.0.1"
@@ -3919,7 +3575,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
           }
@@ -3929,14 +3584,12 @@
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-      "dev": true
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3",
         "is-primitive": "2.0.0"
@@ -3945,26 +3598,22 @@
     "remove-trailing-separator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-      "dev": true
+      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
@@ -3973,7 +3622,6 @@
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true,
       "requires": {
         "aws-sign2": "0.6.0",
         "aws4": "1.6.0",
@@ -4002,28 +3650,24 @@
         "qs": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
         }
       }
     },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true,
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -4032,7 +3676,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -4042,7 +3685,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -4050,14 +3692,12 @@
     "rollup": {
       "version": "0.50.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.50.0.tgz",
-      "integrity": "sha512-7RqCBQ9iwsOBPkjYgoIaeUij606mSkDMExP0NT7QDI3bqkHYQHrQ83uoNIXwPcQm/vP2VbsUz3kiyZZ1qPlLTQ==",
-      "dev": true
+      "integrity": "sha512-7RqCBQ9iwsOBPkjYgoIaeUij606mSkDMExP0NT7QDI3bqkHYQHrQ83uoNIXwPcQm/vP2VbsUz3kiyZZ1qPlLTQ=="
     },
     "rollup-plugin-node-resolve": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
       "integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
-      "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
         "builtin-modules": "1.1.1",
@@ -4069,7 +3709,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz",
       "integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
-      "dev": true,
       "requires": {
         "magic-string": "0.22.4",
         "minimatch": "3.0.4",
@@ -4080,7 +3719,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.5.2.tgz",
       "integrity": "sha1-kpLRnoTGN8OqatFzqw+cIOrNlwE=",
-      "dev": true,
       "requires": {
         "colors": "1.1.2",
         "fs-extra": "3.0.1",
@@ -4096,14 +3734,12 @@
         "estree-walker": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
-          "dev": true
+          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
         },
         "rollup-pluginutils": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
           "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
-          "dev": true,
           "requires": {
             "estree-walker": "0.3.1",
             "micromatch": "2.3.11"
@@ -4115,7 +3751,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz",
       "integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
-      "dev": true,
       "requires": {
         "uglify-js": "3.0.23"
       },
@@ -4124,7 +3759,6 @@
           "version": "3.0.23",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.23.tgz",
           "integrity": "sha512-miLHbO2QcdQGxL/q1wLcUr6TGIRHhMnpKyywUbAdZRkJMqCeZCDmBsgYu1Wlj26xHBXN+sU5tHaWh38QsN208g==",
-          "dev": true,
           "requires": {
             "commander": "2.9.0",
             "source-map": "0.5.6"
@@ -4136,7 +3770,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
       "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
-      "dev": true,
       "requires": {
         "estree-walker": "0.3.1",
         "micromatch": "2.3.11"
@@ -4145,14 +3778,12 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sane": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-2.0.0.tgz",
       "integrity": "sha1-mct58h9KU6adTQzZV8LbBAJLjrI=",
-      "dev": true,
       "requires": {
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
@@ -4167,34 +3798,29 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -4202,32 +3828,27 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -4235,14 +3856,12 @@
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-      "dev": true
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
     },
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true,
       "requires": {
         "source-map": "0.5.6"
       }
@@ -4251,7 +3870,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -4259,26 +3877,22 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -4293,8 +3907,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -4302,7 +3915,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-      "dev": true,
       "requires": {
         "astral-regex": "1.0.0",
         "strip-ansi": "4.0.0"
@@ -4311,14 +3923,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -4329,7 +3939,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -4339,14 +3948,12 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -4355,7 +3962,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
       "requires": {
         "is-utf8": "0.2.1"
       }
@@ -4363,26 +3969,22 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-      "dev": true
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
     "test-exclude": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-      "dev": true,
       "requires": {
         "arrify": "1.0.1",
         "micromatch": "2.3.11",
@@ -4394,26 +3996,22 @@
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-      "dev": true
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
     },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-      "dev": true
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
@@ -4421,20 +4019,17 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "ts-jest": {
       "version": "21.0.1",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-21.0.1.tgz",
       "integrity": "sha512-MIX8uMMr7FSRT56GASXUxeorEs3x2iO+JwkVzUHwxjzld4+UtPMZ9EEUpX7JU7eFKDkXaD1aAIVnuNrg15Xnuw==",
-      "dev": true,
       "requires": {
         "babel-core": "6.25.0",
         "babel-plugin-istanbul": "4.1.4",
@@ -4451,20 +4046,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
           "requires": {
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
@@ -4475,7 +4067,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -4488,7 +4079,6 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
           "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "4.0.0",
@@ -4499,7 +4089,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
           }
@@ -4508,7 +4097,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -4520,7 +4108,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
           "requires": {
             "pify": "2.3.0"
           }
@@ -4529,7 +4116,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
           "requires": {
             "load-json-file": "2.0.0",
             "normalize-package-data": "2.4.0",
@@ -4540,7 +4126,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
@@ -4550,7 +4135,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -4559,14 +4143,12 @@
             "is-fullwidth-code-point": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -4576,14 +4158,12 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "yargs": {
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
           "requires": {
             "camelcase": "4.1.0",
             "cliui": "3.2.0",
@@ -4605,14 +4185,12 @@
     "tslib": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
-      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
-      "dev": true
+      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -4621,14 +4199,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }
@@ -4636,14 +4212,12 @@
     "typescript": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
-      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
-      "dev": true
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ="
     },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "0.5.6",
@@ -4655,7 +4229,6 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "1.2.1",
@@ -4670,26 +4243,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-      "dev": true
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -4699,7 +4268,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true,
       "requires": {
         "extsprintf": "1.0.2"
       }
@@ -4707,14 +4275,12 @@
     "vlq": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
-      "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE=",
-      "dev": true
+      "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE="
     },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
       "requires": {
         "makeerror": "1.0.11"
       }
@@ -4722,20 +4288,17 @@
     "watch": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
-      "dev": true
+      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
     },
     "webidl-conversions": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
-      "integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA=",
-      "dev": true
+      "integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA="
     },
     "whatwg-encoding": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.4.13"
       }
@@ -4744,7 +4307,6 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
-      "dev": true,
       "requires": {
         "tr46": "0.0.3",
         "webidl-conversions": "3.0.1"
@@ -4753,8 +4315,7 @@
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         }
       }
     },
@@ -4762,7 +4323,6 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -4770,27 +4330,23 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
       "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "worker-farm": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
       "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
-      "dev": true,
       "requires": {
         "errno": "0.1.4",
         "xtend": "4.0.1"
@@ -4800,7 +4356,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -4809,14 +4364,12 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
@@ -4826,32 +4379,27 @@
     "xml-name-validator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-      "dev": true
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
       "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-      "dev": true,
       "requires": {
         "camelcase": "4.1.0",
         "cliui": "3.2.0",
@@ -4871,20 +4419,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
           "requires": {
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
@@ -4895,7 +4440,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -4908,7 +4452,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -4920,7 +4463,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
           "requires": {
             "pify": "2.3.0"
           }
@@ -4929,7 +4471,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
           "requires": {
             "load-json-file": "2.0.0",
             "normalize-package-data": "2.4.0",
@@ -4940,7 +4481,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
@@ -4950,7 +4490,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -4959,14 +4498,12 @@
             "is-fullwidth-code-point": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -4976,8 +4513,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
@@ -4985,7 +4521,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "dev": true,
       "requires": {
         "camelcase": "4.1.0"
       },
@@ -4993,8 +4528,7 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         }
       }
     }

--- a/packages/root/src/locationFactory.ts
+++ b/packages/root/src/locationFactory.ts
@@ -126,8 +126,6 @@ export default function locationFactory(
       rawPathname: raw(partial.pathname)
     };
 
-    location.key = key;
-
     location.rawPathname = raw(location.pathname);
 
     // it can be more convenient to interact with the decoded pathname,

--- a/packages/root/src/types/hickory.ts
+++ b/packages/root/src/types/hickory.ts
@@ -28,7 +28,7 @@ export interface History {
   confirmWith(fn?: ConfirmationFunction): void;
   removeConfirmation(): void;
   destroy(): void;
-  update(to: ToArgument, navType?: NavType): void;
+  navigate(to: ToArgument, navType?: NavType): void;
   go(num?: number): void;
 }
 

--- a/packages/root/src/types/hickory.ts
+++ b/packages/root/src/types/hickory.ts
@@ -1,13 +1,14 @@
-import { HickoryLocation, AnyLocation, PartialLocation } from './location';
-import { LocationFactoryOptions, LocationMethods } from './locationFactory';
-import { KeyMethods } from './keygen';
+import { HickoryLocation, AnyLocation, PartialLocation } from "./location";
+import { LocationFactoryOptions, LocationMethods } from "./locationFactory";
+import { KeyMethods } from "./keygen";
 import {
   ConfirmationFunction,
   ConfirmationMethods
-} from './navigationConfirmation';
+} from "./navigationConfirmation";
 
 export type ToArgument = string | PartialLocation;
-export type Action = 'PUSH' | 'REPLACE' | 'POP';
+export type Action = "PUSH" | "REPLACE" | "POP";
+export type NavType = "ANCHOR" | "PUSH" | "REPLACE";
 
 export interface PendingNavigation {
   location: HickoryLocation;
@@ -16,7 +17,7 @@ export interface PendingNavigation {
   cancel(nextAction?: Action): void;
   cancelled?: boolean;
 }
-export type NavFn = (to: ToArgument) => void;
+
 export type ResponseHandler = (resp: PendingNavigation) => void;
 
 export interface History {
@@ -27,9 +28,7 @@ export interface History {
   confirmWith(fn?: ConfirmationFunction): void;
   removeConfirmation(): void;
   destroy(): void;
-  navigate: NavFn;
-  push: NavFn;
-  replace: NavFn;
+  update(to: ToArgument, navType?: NavType): void;
   go(num?: number): void;
 }
 

--- a/packages/root/src/types/index.ts
+++ b/packages/root/src/types/index.ts
@@ -9,8 +9,8 @@ export {
   History,
   ToArgument,
   Action,
+  NavType,
   PendingNavigation,
-  NavFn,
   ResponseHandler,
   Options,
   CommonHistory

--- a/packages/root/src/types/location.ts
+++ b/packages/root/src/types/location.ts
@@ -16,7 +16,7 @@ export interface HickoryLocation {
   query: any;
   hash: string;
   state?: any;
-  key: string;
+  key: string | undefined;
   rawPathname: string;
 }
 

--- a/packages/root/src/types/locationFactory.ts
+++ b/packages/root/src/types/locationFactory.ts
@@ -1,4 +1,4 @@
-import { HickoryLocation, PartialLocation } from './location';
+import { HickoryLocation, PartialLocation } from "./location";
 
 export interface QueryFunctions {
   parse: (query?: string) => any;

--- a/packages/root/tests/locationFactory.spec.ts
+++ b/packages/root/tests/locationFactory.spec.ts
@@ -1,11 +1,11 @@
-import 'jest';
-import locationFactory from '../src/locationFactory';
-import * as qs from 'qs';
+import "jest";
+import locationFactory from "../src/locationFactory";
+import * as qs from "qs";
 
-describe('locationFactory', () => {
-  describe('constructor', () => {
-    it('throws when attempting to use an invalid baseSegment', () => {
-      const badValues = ['does-not-start-with-a-slash', '/ends-with-slash/'];
+describe("locationFactory", () => {
+  describe("constructor", () => {
+    it("throws when attempting to use an invalid baseSegment", () => {
+      const badValues = ["does-not-start-with-a-slash", "/ends-with-slash/"];
       badValues.forEach(value => {
         expect(() => {
           const creators = locationFactory({
@@ -15,7 +15,7 @@ describe('locationFactory', () => {
       });
     });
 
-    describe('query option', () => {
+    describe("query option", () => {
       const consoleWarn = console.warn;
 
       beforeEach(() => {
@@ -26,73 +26,73 @@ describe('locationFactory', () => {
         console.warn = consoleWarn;
       });
 
-      describe('undefined', () => {
-        it('returns object with default parse/stringify fns', () => {
+      describe("undefined", () => {
+        it("returns object with default parse/stringify fns", () => {
           const creator = locationFactory();
-          const parsed = creator.createLocation('/test?one=two');
-          expect(parsed.query).toBe('one=two');
+          const parsed = creator.createLocation("/test?one=two");
+          expect(parsed.query).toBe("one=two");
           const stringified = creator.createPath({
-            pathname: '/test',
-            query: '?three=four'
+            pathname: "/test",
+            query: "?three=four"
           });
-          expect(stringified).toBe('/test?three=four');
+          expect(stringified).toBe("/test?three=four");
         });
       });
 
-      describe('valid query option', () => {
-        it('calls parse when creating a location', () => {
+      describe("valid query option", () => {
+        it("calls parse when creating a location", () => {
           const parse = jest.fn();
           const stringify = jest.fn();
           const creators = locationFactory({
             query: { parse, stringify }
           });
-          const location = creators.createLocation('/test?two=dos');
+          const location = creators.createLocation("/test?two=dos");
           expect(parse.mock.calls.length).toBe(1);
         });
 
-        it('calls stringify when creating a path', () => {
+        it("calls stringify when creating a path", () => {
           const parse = jest.fn();
           const stringify = jest.fn();
           const creators = locationFactory({
             query: { parse, stringify }
           });
-          const path = creators.createPath({ pathname: '/test' });
+          const path = creators.createPath({ pathname: "/test" });
           expect(stringify.mock.calls.length).toBe(1);
         });
       });
     });
   });
 
-  describe('createLocation', () => {
+  describe("createLocation", () => {
     const { createLocation } = locationFactory();
 
-    describe('from a string', () => {
-      it('returns an object with expected properties', () => {
-        const loc = createLocation('/pathname?query=this#hash', '10.9');
-        expect(loc.pathname).toBe('/pathname');
-        expect(loc.query).toBe('query=this');
-        expect(loc.hash).toBe('hash');
-        expect(loc.key).toBe('10.9');
+    describe("from a string", () => {
+      it("returns an object with expected properties", () => {
+        const loc = createLocation("/pathname?query=this#hash", "10.9");
+        expect(loc.pathname).toBe("/pathname");
+        expect(loc.query).toBe("query=this");
+        expect(loc.hash).toBe("hash");
+        expect(loc.key).toBe("10.9");
       });
     });
 
-    describe('from an object', () => {
-      it('returns a new object', () => {
+    describe("from an object", () => {
+      it("returns a new object", () => {
         const input = {
-          pathname: '/test',
-          query: 'one=two',
-          hash: 'hello'
+          pathname: "/test",
+          query: "one=two",
+          hash: "hello"
         };
         const output = createLocation(input);
-        input.pathname = '/not-a-test';
-        expect(output.pathname).toBe('/test');
+        input.pathname = "/not-a-test";
+        expect(output.pathname).toBe("/test");
       });
 
-      it('uses provided properties', () => {
+      it("uses provided properties", () => {
         const input = {
-          pathname: '/test',
-          query: 'one=two',
-          hash: 'hello'
+          pathname: "/test",
+          query: "one=two",
+          hash: "hello"
         };
         const output = createLocation(input);
         Object.keys(input).forEach(key => {
@@ -103,131 +103,131 @@ describe('locationFactory', () => {
       it('sets pathname to "/" if none is provided', () => {
         const input = {};
         const output = createLocation(input);
-        expect(output.pathname).toBe('/');
+        expect(output.pathname).toBe("/");
       });
 
-      it('sets default query value if none is provided', () => {
+      it("sets default query value if none is provided", () => {
         const input = {
-          pathname: '/test',
-          hash: 'hello'
+          pathname: "/test",
+          hash: "hello"
         };
         const output = createLocation(input);
-        expect(output.query).toBe('');
+        expect(output.query).toBe("");
       });
 
-      it('sets hash to empty string if none is provided', () => {
+      it("sets hash to empty string if none is provided", () => {
         const input = {
-          pathname: '/test',
-          search: 'one=two'
+          pathname: "/test",
+          search: "one=two"
         };
         const output = createLocation(input);
-        expect(output.hash).toBe('');
+        expect(output.hash).toBe("");
       });
 
-      it('adds provided key to the location', () => {
+      it("adds provided key to the location", () => {
         const input = {
-          pathname: '/test',
-          query: 'one=two',
-          hash: 'hello'
+          pathname: "/test",
+          query: "one=two",
+          hash: "hello"
         };
-        const key = '3.22';
+        const key = "3.22";
         const output = createLocation(input, key);
         expect(output.key).toBe(key);
       });
 
-      it('adds state if provided', () => {
+      it("adds state if provided", () => {
         const input = {
-          pathname: '/'
+          pathname: "/"
         };
         const state = {
-          omg: 'bff'
+          omg: "bff"
         };
-        const output = createLocation(input, '1.0', state);
+        const output = createLocation(input, "1.0", state);
         expect(output.state).toBeDefined();
         expect(output.state).toEqual(state);
       });
 
-      it('prefers location.state over state', () => {
+      it("prefers location.state over state", () => {
         const locState = { fromLocation: true };
         const justState = { fromLocation: false };
         const output = createLocation(
-          { pathname: '/', state: locState },
-          '1.2',
+          { pathname: "/", state: locState },
+          "1.2",
           justState
         );
         expect(output.state).toEqual(locState);
       });
     });
 
-    describe('using raw option fn to set location.rawPathname', () => {
-      it('calls user provided option', () => {
+    describe("using raw option fn to set location.rawPathname", () => {
+      it("calls user provided option", () => {
         const { createLocation } = locationFactory({
           raw: path =>
             path
-              .split('')
+              .split("")
               .reverse()
-              .join('')
+              .join("")
         });
-        const output = createLocation({ pathname: '/test' });
-        expect(output.rawPathname).toBe('tset/');
+        const output = createLocation({ pathname: "/test" });
+        expect(output.rawPathname).toBe("tset/");
       });
 
-      it('uses default fn if raw option is not provided', () => {
-        const output = createLocation({ pathname: '/test%20ing' });
-        expect(output.pathname).toBe('/test ing');
-        expect(output.rawPathname).toBe('/test%20ing');
+      it("uses default fn if raw option is not provided", () => {
+        const output = createLocation({ pathname: "/test%20ing" });
+        expect(output.pathname).toBe("/test ing");
+        expect(output.rawPathname).toBe("/test%20ing");
       });
     });
 
-    describe('query.parse option', () => {
-      it('uses the provided query parsing function to make the query value', () => {
+    describe("query.parse option", () => {
+      it("uses the provided query parsing function to make the query value", () => {
         const { createLocation } = locationFactory({
           query: {
             parse: qs.parse,
             stringify: qs.stringify
           }
         });
-        const loc = createLocation('/pathname?query=this#hash');
-        expect(loc.query).toEqual({ query: 'this' });
+        const loc = createLocation("/pathname?query=this#hash");
+        expect(loc.query).toEqual({ query: "this" });
       });
     });
 
-    describe('decode option', () => {
-      it('decodes the pathname by default', () => {
+    describe("decode option", () => {
+      it("decodes the pathname by default", () => {
         const input = {
-          pathname: '/t%C3%B6rt%C3%A9nelem'
+          pathname: "/t%C3%B6rt%C3%A9nelem"
         };
         const output = createLocation(input);
-        expect(output.pathname).toBe('/történelem');
+        expect(output.pathname).toBe("/történelem");
       });
 
-      it('does not decode when decode=false', () => {
+      it("does not decode when decode=false", () => {
         const { createLocation } = locationFactory({ decode: false });
         const input = {
-          pathname: '/t%C3%B6rt%C3%A9nelem'
+          pathname: "/t%C3%B6rt%C3%A9nelem"
         };
         const output = createLocation(input);
-        expect(output.pathname).toBe('/t%C3%B6rt%C3%A9nelem');
+        expect(output.pathname).toBe("/t%C3%B6rt%C3%A9nelem");
       });
 
-      describe('bad encoding', () => {
-        it('throws URIError with clearer message when decoding fails', () => {
+      describe("bad encoding", () => {
+        it("throws URIError with clearer message when decoding fails", () => {
           const input = {
-            pathname: '/bad%'
+            pathname: "/bad%"
           };
           expect(() => {
             const output = createLocation(input);
           }).toThrow(
             'Pathname "/bad%" could not be decoded. ' +
-              'This is most likely due to a bad percent-encoding. For more information, ' +
-              'see the third paragraph here https://tools.ietf.org/html/rfc3986#section-2.4'
+              "This is most likely due to a bad percent-encoding. For more information, " +
+              "see the third paragraph here https://tools.ietf.org/html/rfc3986#section-2.4"
           );
         });
 
-        it('does not throw URIError when decode=false', () => {
+        it("does not throw URIError when decode=false", () => {
           const { createLocation } = locationFactory({ decode: false });
           const input = {
-            pathname: '/bad%'
+            pathname: "/bad%"
           };
           expect(() => {
             const output = createLocation(input);
@@ -236,118 +236,118 @@ describe('locationFactory', () => {
       });
     });
 
-    describe('baseSegment', () => {
-      const { createLocation } = locationFactory({ baseSegment: '/prefix' });
-      it('strips the baseSegment off of the path before creating a location', () => {
-        const location = createLocation('/prefix/this/is/the/rest');
-        expect(location.pathname).toBe('/this/is/the/rest');
+    describe("baseSegment", () => {
+      const { createLocation } = locationFactory({ baseSegment: "/prefix" });
+      it("strips the baseSegment off of the path before creating a location", () => {
+        const location = createLocation("/prefix/this/is/the/rest");
+        expect(location.pathname).toBe("/this/is/the/rest");
       });
     });
   });
 
-  describe('createPath', () => {
+  describe("createPath", () => {
     const { createPath } = locationFactory();
 
-    describe('pathname', () => {
-      it('begins the returned URI with the pathname', () => {
+    describe("pathname", () => {
+      it("begins the returned URI with the pathname", () => {
         const input = {
-          pathname: '/test'
+          pathname: "/test"
         };
         const output = createPath(input);
-        expect(output).toBe('/test');
+        expect(output).toBe("/test");
       });
 
-      it('uses rawPathname is pathname not provided', () => {
+      it("uses rawPathname is pathname not provided", () => {
         const input = {
-          rawPathname: '/test'
+          rawPathname: "/test"
         };
         const output = createPath(input);
-        expect(output).toBe('/test');
+        expect(output).toBe("/test");
       });
 
-      it('uses empty string for pathname if neither pathname or rawPathname provided', () => {
-        const input = { hash: 'test' };
+      it("uses empty string for pathname if neither pathname or rawPathname provided", () => {
+        const input = { hash: "test" };
         const output = createPath(input);
-        expect(output).toBe('#test');
+        expect(output).toBe("#test");
       });
 
-      it('prepends forward slash if pathname does not have one', () => {
+      it("prepends forward slash if pathname does not have one", () => {
         const input = {
-          pathname: 'test'
+          pathname: "test"
         };
         const output = createPath(input);
-        expect(output).toBe('/test');
+        expect(output).toBe("/test");
       });
     });
 
-    describe('query', () => {
-      it('adds a question mark to the beginning of the query string (if not empty)', () => {
+    describe("query", () => {
+      it("adds a question mark to the beginning of the query string (if not empty)", () => {
         const input = {
-          pathname: '/',
-          query: 'one=two'
+          pathname: "/",
+          query: "one=two"
         };
         const output = createPath(input);
-        expect(output).toBe('/?one=two');
+        expect(output).toBe("/?one=two");
       });
 
-      it('does not add question mark if it already exists', () => {
+      it("does not add question mark if it already exists", () => {
         const input = {
-          pathname: '/',
-          query: '?one=two'
+          pathname: "/",
+          query: "?one=two"
         };
         const output = createPath(input);
-        expect(output).toBe('/?one=two');
+        expect(output).toBe("/?one=two");
       });
 
-      it('does not include the query if stringified version is empty string', () => {
+      it("does not include the query if stringified version is empty string", () => {
         const input = {
-          pathname: '/'
+          pathname: "/"
         };
         const output = createPath(input);
-        expect(output.indexOf('?')).toBe(-1);
+        expect(output.indexOf("?")).toBe(-1);
       });
     });
 
-    describe('hash', () => {
-      it('adds a pound sign to the beginning of the hash (if not empty)', () => {
+    describe("hash", () => {
+      it("adds a pound sign to the beginning of the hash (if not empty)", () => {
         const input = {
-          pathname: '/',
-          hash: 'yes'
+          pathname: "/",
+          hash: "yes"
         };
         const output = createPath(input);
-        expect(output).toBe('/#yes');
+        expect(output).toBe("/#yes");
       });
 
-      it('does not add pound sign if it already exists', () => {
+      it("does not add pound sign if it already exists", () => {
         const input = {
-          pathname: '/',
-          hash: '#no'
+          pathname: "/",
+          hash: "#no"
         };
         const output = createPath(input);
-        expect(output).toBe('/#no');
+        expect(output).toBe("/#no");
       });
 
-      it('does not include the hash if it is falsy', () => {
-        const falsyValues = ['', null, undefined];
+      it("does not include the hash if it is falsy", () => {
+        const falsyValues = ["", null, undefined];
         falsyValues.forEach(v => {
-          const output = createPath({ pathname: '/', hash: v });
-          expect(output.indexOf('#')).toBe(-1);
+          const output = createPath({ pathname: "/", hash: v });
+          expect(output.indexOf("#")).toBe(-1);
         });
       });
 
-      it('places the hash after the query string', () => {
+      it("places the hash after the query string", () => {
         const input = {
-          pathname: '/',
-          query: 'before=true',
-          hash: 'after'
+          pathname: "/",
+          query: "before=true",
+          hash: "after"
         };
         const output = createPath(input);
-        expect(output.indexOf('?')).toBeLessThan(output.indexOf('#'));
+        expect(output.indexOf("?")).toBeLessThan(output.indexOf("#"));
       });
     });
 
-    describe('query.stringify option', () => {
-      it('uses the provided stringify function to turn query into a string', () => {
+    describe("query.stringify option", () => {
+      it("uses the provided stringify function to turn query into a string", () => {
         const { createPath } = locationFactory({
           query: {
             parse: qs.parse,
@@ -355,24 +355,24 @@ describe('locationFactory', () => {
           }
         });
         const input = {
-          pathname: '/',
-          query: { one: 'two' }
+          pathname: "/",
+          query: { one: "two" }
         };
         const output = createPath(input);
-        expect(output).toBe('/?one=two');
+        expect(output).toBe("/?one=two");
       });
     });
 
-    describe('baseSegment', () => {
-      it('adds the baseSegment to the path generated from a location', () => {
-        const { createPath } = locationFactory({ baseSegment: '/prefix' });
+    describe("baseSegment", () => {
+      it("adds the baseSegment to the path generated from a location", () => {
+        const { createPath } = locationFactory({ baseSegment: "/prefix" });
         const location = {
-          pathname: '/one/two/three',
-          search: '',
-          hash: 'four'
+          pathname: "/one/two/three",
+          search: "",
+          hash: "four"
         };
         const path = createPath(location);
-        expect(path).toBe('/prefix/one/two/three#four');
+        expect(path).toBe("/prefix/one/two/three#four");
       });
     });
   });

--- a/packages/root/types/locationFactory.d.ts
+++ b/packages/root/types/locationFactory.d.ts
@@ -1,7 +1,2 @@
-import {
-  LocationFactoryOptions,
-  LocationMethods
-} from "./types/locationFactory";
-export default function locationFactory(
-  options?: LocationFactoryOptions
-): LocationMethods;
+import { LocationFactoryOptions, LocationMethods } from "./types/locationFactory";
+export default function locationFactory(options?: LocationFactoryOptions): LocationMethods;

--- a/packages/root/types/types/hickory.d.ts
+++ b/packages/root/types/types/hickory.d.ts
@@ -21,7 +21,7 @@ export interface History {
     confirmWith(fn?: ConfirmationFunction): void;
     removeConfirmation(): void;
     destroy(): void;
-    update(to: ToArgument, navType?: NavType): void;
+    navigate(to: ToArgument, navType?: NavType): void;
     go(num?: number): void;
 }
 export declare type Options = LocationFactoryOptions;

--- a/packages/root/types/types/hickory.d.ts
+++ b/packages/root/types/types/hickory.d.ts
@@ -1,35 +1,28 @@
 import { HickoryLocation, AnyLocation, PartialLocation } from "./location";
 import { LocationFactoryOptions, LocationMethods } from "./locationFactory";
 import { KeyMethods } from "./keygen";
-import {
-  ConfirmationFunction,
-  ConfirmationMethods
-} from "./navigationConfirmation";
+import { ConfirmationFunction, ConfirmationMethods } from "./navigationConfirmation";
 export declare type ToArgument = string | PartialLocation;
 export declare type Action = "PUSH" | "REPLACE" | "POP";
+export declare type NavType = "ANCHOR" | "PUSH" | "REPLACE";
 export interface PendingNavigation {
-  location: HickoryLocation;
-  action: Action;
-  finish(): void;
-  cancel(nextAction?: Action): void;
-  cancelled?: boolean;
+    location: HickoryLocation;
+    action: Action;
+    finish(): void;
+    cancel(nextAction?: Action): void;
+    cancelled?: boolean;
 }
-export declare type NavFn = (to: ToArgument) => void;
 export declare type ResponseHandler = (resp: PendingNavigation) => void;
 export interface History {
-  location: HickoryLocation;
-  action: Action;
-  toHref(to: AnyLocation): string;
-  respondWith(fn: ResponseHandler): void;
-  confirmWith(fn?: ConfirmationFunction): void;
-  removeConfirmation(): void;
-  destroy(): void;
-  navigate: NavFn;
-  push: NavFn;
-  replace: NavFn;
-  go(num?: number): void;
+    location: HickoryLocation;
+    action: Action;
+    toHref(to: AnyLocation): string;
+    respondWith(fn: ResponseHandler): void;
+    confirmWith(fn?: ConfirmationFunction): void;
+    removeConfirmation(): void;
+    destroy(): void;
+    update(to: ToArgument, navType?: NavType): void;
+    go(num?: number): void;
 }
 export declare type Options = LocationFactoryOptions;
-export declare type CommonHistory = LocationMethods &
-  ConfirmationMethods &
-  KeyMethods;
+export declare type CommonHistory = LocationMethods & ConfirmationMethods & KeyMethods;

--- a/packages/root/types/types/index.d.ts
+++ b/packages/root/types/types/index.d.ts
@@ -1,27 +1,5 @@
-export {
-  LocationDetails,
-  PartialLocation,
-  HickoryLocation,
-  AnyLocation
-} from "./location";
-export {
-  History,
-  ToArgument,
-  Action,
-  PendingNavigation,
-  NavFn,
-  ResponseHandler,
-  Options,
-  CommonHistory
-} from "./hickory";
+export { LocationDetails, PartialLocation, HickoryLocation, AnyLocation } from "./location";
+export { History, ToArgument, Action, NavType, PendingNavigation, ResponseHandler, Options, CommonHistory } from "./hickory";
 export { KeyMethods, KeyFns } from "./keygen";
-export {
-  QueryFunctions,
-  LocationFactoryOptions,
-  LocationMethods
-} from "./locationFactory";
-export {
-  NavigationInfo,
-  ConfirmationFunction,
-  ConfirmationMethods
-} from "./navigationConfirmation";
+export { QueryFunctions, LocationFactoryOptions, LocationMethods } from "./locationFactory";
+export { NavigationInfo, ConfirmationFunction, ConfirmationMethods } from "./navigationConfirmation";

--- a/packages/root/types/types/keygen.d.ts
+++ b/packages/root/types/types/keygen.d.ts
@@ -1,8 +1,8 @@
 export interface KeyMethods {
-  keygen: KeyFns;
+    keygen: KeyFns;
 }
 export interface KeyFns {
-  major(previous?: string): string;
-  minor(current: string): string;
-  diff(first: string, second: string): number;
+    major(previous?: string): string;
+    minor(current: string): string;
+    diff(first: string, second: string): number;
 }

--- a/packages/root/types/types/location.d.ts
+++ b/packages/root/types/types/location.d.ts
@@ -1,18 +1,18 @@
 export interface LocationDetails {
-  query?: any;
-  hash?: string;
-  state?: any;
+    query?: any;
+    hash?: string;
+    state?: any;
 }
 export interface PartialLocation extends LocationDetails {
-  pathname?: string;
-  rawPathname?: string;
+    pathname?: string;
+    rawPathname?: string;
 }
 export interface HickoryLocation {
-  pathname: string;
-  query: any;
-  hash: string;
-  state?: any;
-  key: string;
-  rawPathname: string;
+    pathname: string;
+    query: any;
+    hash: string;
+    state?: any;
+    key: string | undefined;
+    rawPathname: string;
 }
 export declare type AnyLocation = HickoryLocation | PartialLocation;

--- a/packages/root/types/types/locationFactory.d.ts
+++ b/packages/root/types/types/locationFactory.d.ts
@@ -1,4 +1,4 @@
-import { HickoryLocation, PartialLocation } from './location';
+import { HickoryLocation, PartialLocation } from "./location";
 export interface QueryFunctions {
     parse: (query?: string) => any;
     stringify: (query?: any) => string;

--- a/packages/root/types/types/navigationConfirmation.d.ts
+++ b/packages/root/types/types/navigationConfirmation.d.ts
@@ -1,21 +1,13 @@
 import { HickoryLocation } from "./location";
 import { Action } from "./hickory";
 export interface NavigationInfo {
-  to: HickoryLocation;
-  from: HickoryLocation;
-  action: Action;
+    to: HickoryLocation;
+    from: HickoryLocation;
+    action: Action;
 }
-export declare type ConfirmationFunction = (
-  info: NavigationInfo,
-  confirm: () => void,
-  prevent?: () => void
-) => void;
+export declare type ConfirmationFunction = (info: NavigationInfo, confirm: () => void, prevent?: () => void) => void;
 export interface ConfirmationMethods {
-  confirmNavigation(
-    info: NavigationInfo,
-    confirm: () => void,
-    prevent?: () => void
-  ): void;
-  confirmWith(fn?: ConfirmationFunction): void;
-  removeConfirmation(): void;
+    confirmNavigation(info: NavigationInfo, confirm: () => void, prevent?: () => void): void;
+    confirmWith(fn?: ConfirmationFunction): void;
+    removeConfirmation(): void;
 }


### PR DESCRIPTION
Instead of having three methods (`history.navigate()`, `history.push()`, and `history.replace()`) that do nearly the same thing, these are now grouped under one `history.navigate()` method.

The first argument is a `ToArgument`, which is either a string or a partial location object. The second agument is the navigation type: `"ANCHOR"`, `"PUSH"`, or `"REPLACE"`. `"ANCHOR"` behaves like clicking an anchor (i.e. push for new URLs, replace for the same URL). If the second argument is not provided, `navigate()` defaults to using `"ANCHOR"`.

```js
history.navigate({ pathname: '/somewhere' }); // default to "ANCHOR"
history.navigate({ pathname: '/new' }, "PUSH");
history.navigate({ pathname: '/same' }, "REPLACE");
history.navigate({ pathname: '/to-be-decided', "ANCHOR");
```

The browser and hash histories also just use native `window.history.go()` behavior now.