### PR TITLE
Simplify integration tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,6 @@ module.exports = function(config) {
     reporters: ["progress", "BrowserStack"],
     plugins: [
       "karma-jasmine",
-      "karma-chrome-launcher",
       "karma-rollup-preprocessor",
       "karma-browserstack-launcher"
     ],

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -30,54 +30,32 @@ describe("browser integration tests", () => {
   });
 
   describe("navigate()", () => {
-    describe("ANCHOR (default)", () => {
-      beforeEach(() => {
-        spyOn(window.history, "pushState").and.callThrough();
-        spyOn(window.history, "replaceState").and.callThrough();
-      });
-
-      afterEach(() => {
-        (window.history.pushState as jasmine.Spy).calls.reset();
-        (window.history.replaceState as jasmine.Spy).calls.reset();
-      });
-
-      it("can navigate with navigate", () => {
-        testHistory.navigate("/the-new-location");
-        expect(window.location.pathname).toEqual("/the-new-location");
-      });
-
-      it("sets the state", () => {
-        const providedState = { isSet: true };
-        testHistory.navigate({
-          pathname: "/next",
-          state: providedState
-        });
-        const { state, key } = testHistory.location;
-        expect(window.history.state.state).toEqual(state);
-        expect(window.history.state.key).toBe(key);
-      });
-
-      it("calls history.pushState when navigating to a new location", () => {
-        testHistory.navigate("/new-location");
-        expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(1);
-        expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
-          0
-        );
-      });
-
-      it("calls history.replaceState when navigating to the same location", () => {
-        testHistory.navigate("/");
-        expect((window.history.pushState as jasmine.Spy).calls.count()).toBe(0);
-        expect((window.history.replaceState as jasmine.Spy).calls.count()).toBe(
-          1
-        );
-      });
+    beforeEach(() => {
+      spyOn(window.history, "pushState").and.callThrough();
+      spyOn(window.history, "replaceState").and.callThrough();
     });
 
-    describe(PUSH, () => {
-      it("can navigate with push", () => {
+    afterEach(() => {
+      (<jasmine.Spy>window.history.pushState).calls.reset();
+      (<jasmine.Spy>window.history.replaceState).calls.reset();
+    });
+
+    it("new URL uses rawPathname, not pathname", () => {
+      testHistory.navigate({
+        pathname: "/encoded-percent%25"
+      });
+      expect(window.location.pathname).toEqual("/encoded-percent%25");
+      expect(testHistory.location.pathname).toEqual("/encoded-percent%");
+    });
+
+    describe("push navigation", () => {
+      it("uses history.pushState", () => {
         testHistory.navigate("/the-new-location", PUSH);
         expect(window.location.pathname).toEqual("/the-new-location");
+        expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(1);
+        expect((<jasmine.Spy>window.history.replaceState).calls.count()).toBe(
+          0
+        );
       });
 
       it("sets the state", () => {
@@ -93,23 +71,16 @@ describe("browser integration tests", () => {
         expect(window.history.state.state).toEqual(state);
         expect(window.history.state.key).toBe(key);
       });
-
-      it("pushes URL using rawPathname, not pathname", () => {
-        testHistory.navigate(
-          {
-            pathname: "/encoded-percent%25"
-          },
-          PUSH
-        );
-        expect(window.location.pathname).toEqual("/encoded-percent%25");
-        expect(testHistory.location.pathname).toEqual("/encoded-percent%");
-      });
     });
 
-    describe(REPLACE, () => {
-      it("can navigate with replace", () => {
+    describe("replace navigation", () => {
+      it("uses history.replaceState", () => {
         testHistory.navigate("/the-same-location", REPLACE);
         expect(window.location.pathname).toEqual("/the-same-location");
+        expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(0);
+        expect((<jasmine.Spy>window.history.replaceState).calls.count()).toBe(
+          1
+        );
       });
 
       it("sets the state", () => {
@@ -129,7 +100,7 @@ describe("browser integration tests", () => {
   });
 
   describe("go", () => {
-    it("can navigate with go", done => {
+    it("is detectable through a popstate listener", done => {
       testHistory.navigate("/one", PUSH);
       testHistory.navigate("/two", PUSH);
       testHistory.navigate("/three", PUSH);


### PR DESCRIPTION
Only need to test browser functionality, unit tests cover hickory functionality.