### PR TITLE
Use generic query type

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -28,7 +28,7 @@ export {
   LocationDetails
 };
 
-export interface Options extends RootOptions {
+export interface Options<Q> extends RootOptions<Q> {
   raw?: (pathname: string) => string;
 }
 
@@ -39,7 +39,7 @@ interface NavSetup {
 
 function noop() {}
 
-function Browser(options: Options = {}): History {
+function Browser<Q = string>(options: Options<Q> = {}): History<Q> {
   if (!domExists()) {
     return;
   }
@@ -55,7 +55,7 @@ function Browser(options: Options = {}): History {
     confirmWith,
     removeConfirmation,
     keygen
-  } = Common(options);
+  } = Common<Q>(options);
 
   const removeEvents = createEventCoordinator({
     popstate: (event: PopStateEvent) => {
@@ -69,7 +69,7 @@ function Browser(options: Options = {}): History {
   // when true, pop will run without attempting to get user confirmation
   let reverting = false;
 
-  function locationFromBrowser(providedState?: object): HickoryLocation {
+  function locationFromBrowser(providedState?: object): HickoryLocation<Q> {
     const { pathname, search, hash } = window.location;
     const path = pathname + search + hash;
     let { key, state } = providedState || getStateFromHistory();
@@ -80,11 +80,11 @@ function Browser(options: Options = {}): History {
     return createLocation(path, key, state);
   }
 
-  function toHref(location: AnyLocation): string {
+  function toHref(location: AnyLocation<Q>): string {
     return createPath(location);
   }
 
-  function setupReplace(location: HickoryLocation): NavSetup {
+  function setupReplace(location: HickoryLocation<Q>): NavSetup {
     location.key = keygen.minor(browserHistory.location.key);
     return {
       action: "replace",
@@ -92,7 +92,7 @@ function Browser(options: Options = {}): History {
     };
   }
 
-  function setupPush(location: HickoryLocation): NavSetup {
+  function setupPush(location: HickoryLocation<Q>): NavSetup {
     location.key = keygen.major(browserHistory.location.key);
     return {
       action: "push",
@@ -100,7 +100,7 @@ function Browser(options: Options = {}): History {
     };
   }
 
-  function finalizePush(location: HickoryLocation) {
+  function finalizePush(location: HickoryLocation<Q>) {
     return () => {
       const path = toHref(location);
       const { key, state } = location;
@@ -114,7 +114,7 @@ function Browser(options: Options = {}): History {
     };
   }
 
-  function finalizeReplace(location: HickoryLocation) {
+  function finalizeReplace(location: HickoryLocation<Q>) {
     return () => {
       const path = toHref(location);
       const { key, state } = location;
@@ -128,13 +128,13 @@ function Browser(options: Options = {}): History {
     };
   }
 
-  let responseHandler: ResponseHandler;
-  const browserHistory: History = {
+  let responseHandler: ResponseHandler<Q>;
+  const browserHistory: History<Q> = {
     // set action before location because locationFromBrowser enforces that the location has a key
     action: getStateFromHistory().key !== undefined ? "pop" : "push",
     location: locationFromBrowser(),
     // set response handler
-    respondWith(fn: ResponseHandler) {
+    respondWith(fn: ResponseHandler<Q>) {
       responseHandler = fn;
       // immediately invoke
       fn({
@@ -151,7 +151,7 @@ function Browser(options: Options = {}): History {
     destroy() {
       removeEvents();
     },
-    navigate(to: ToArgument, navType: NavType = "anchor"): void {
+    navigate(to: ToArgument<Q>, navType: NavType = "anchor"): void {
       let setup: NavSetup;
       const location = createLocation(to);
       switch (navType) {

--- a/packages/browser/types/index.d.ts
+++ b/packages/browser/types/index.d.ts
@@ -1,7 +1,7 @@
 import { History, LocationDetails, PartialLocation, HickoryLocation, AnyLocation, Options as RootOptions } from "@hickory/root";
 export { History, HickoryLocation, PartialLocation, AnyLocation, LocationDetails };
-export interface Options extends RootOptions {
+export interface Options<Q> extends RootOptions<Q> {
     raw?: (pathname: string) => string;
 }
-declare function Browser(options?: Options): History;
+declare function Browser<Q = string>(options?: Options<Q>): History<Q>;
 export { Browser };

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -34,7 +34,7 @@ function ensureHash(encode: (path: string) => string): void {
   }
 }
 
-export interface Options extends RootOptions {
+export interface Options<Q> extends RootOptions<Q> {
   raw?: (pathname: string) => string;
   hashType?: string;
 }
@@ -46,7 +46,7 @@ interface NavSetup {
 
 function noop() {}
 
-function Hash(options: Options = {}): History {
+function Hash<Q>(options: Options<Q> = {}): History<Q> {
   if (!domExists()) {
     return;
   }
@@ -62,7 +62,7 @@ function Hash(options: Options = {}): History {
     confirmWith,
     removeConfirmation,
     keygen
-  } = Common(options);
+  } = Common<Q>(options);
 
   const {
     decode: decodeHashPath,
@@ -80,7 +80,7 @@ function Hash(options: Options = {}): History {
 
   ensureHash(encodeHashPath);
 
-  function locationFromBrowser(providedState?: object): HickoryLocation {
+  function locationFromBrowser(providedState?: object): HickoryLocation<Q> {
     let { hash } = window.location;
     const path = decodeHashPath(hash);
     let { key, state } = providedState || getStateFromHistory();
@@ -92,11 +92,11 @@ function Hash(options: Options = {}): History {
     return createLocation(path, key);
   }
 
-  function toHref(location: AnyLocation): string {
+  function toHref(location: AnyLocation<Q>): string {
     return encodeHashPath(createPath(location));
   }
 
-  function setupReplace(location: HickoryLocation): NavSetup {
+  function setupReplace(location: HickoryLocation<Q>): NavSetup {
     location.key = keygen.minor(hashHistory.location.key);
     return {
       action: "replace",
@@ -104,7 +104,7 @@ function Hash(options: Options = {}): History {
     };
   }
 
-  function setupPush(location: HickoryLocation): NavSetup {
+  function setupPush(location: HickoryLocation<Q>): NavSetup {
     location.key = keygen.major(hashHistory.location.key);
     return {
       action: "push",
@@ -112,7 +112,7 @@ function Hash(options: Options = {}): History {
     };
   }
 
-  function finalizePush(location: HickoryLocation) {
+  function finalizePush(location: HickoryLocation<Q>) {
     return () => {
       const path = toHref(location);
       const { key, state } = location;
@@ -126,7 +126,7 @@ function Hash(options: Options = {}): History {
     };
   }
 
-  function finalizeReplace(location: HickoryLocation) {
+  function finalizeReplace(location: HickoryLocation<Q>) {
     return () => {
       const path = toHref(location);
       const { key, state } = location;
@@ -140,13 +140,13 @@ function Hash(options: Options = {}): History {
     };
   }
 
-  let responseHandler: ResponseHandler;
-  const hashHistory: History = {
+  let responseHandler: ResponseHandler<Q>;
+  const hashHistory: History<Q> = {
     // location
     action: getStateFromHistory().key !== undefined ? "pop" : "push",
     location: locationFromBrowser(),
     // set response handler
-    respondWith(fn: ResponseHandler) {
+    respondWith(fn: ResponseHandler<Q>) {
       responseHandler = fn;
       responseHandler({
         location: hashHistory.location,
@@ -162,7 +162,7 @@ function Hash(options: Options = {}): History {
     destroy() {
       removeEvents();
     },
-    navigate(to: ToArgument, navType: NavType = "anchor"): void {
+    navigate(to: ToArgument<Q>, navType: NavType = "anchor"): void {
       let setup: NavSetup;
       const location = createLocation(to);
       switch (navType) {
@@ -213,7 +213,7 @@ function Hash(options: Options = {}): History {
       reverting = false;
       return;
     }
-    const location: HickoryLocation = locationFromBrowser(state);
+    const location: HickoryLocation<Q> = locationFromBrowser(state);
     const currentKey: string = hashHistory.location.key;
     const diff: number = keygen.diff(currentKey, location.key);
     confirmNavigation(

--- a/packages/hash/types/index.d.ts
+++ b/packages/hash/types/index.d.ts
@@ -1,8 +1,8 @@
 import { History, LocationDetails, HickoryLocation, PartialLocation, AnyLocation, Options as RootOptions } from "@hickory/root";
 export { History, HickoryLocation, PartialLocation, AnyLocation, LocationDetails };
-export interface Options extends RootOptions {
+export interface Options<Q> extends RootOptions<Q> {
     raw?: (pathname: string) => string;
     hashType?: string;
 }
-declare function Hash(options?: Options): History;
+declare function Hash<Q>(options?: Options<Q>): History<Q>;
 export { Hash };

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -21,22 +21,22 @@ export {
   LocationDetails
 };
 
-export type InputLocations = Array<string | PartialLocation>;
+export type InputLocations<Q> = Array<string | PartialLocation<Q>>;
 
-export interface Options extends RootOptions {
-  locations?: InputLocations;
+export interface Options<Q> extends RootOptions<Q> {
+  locations?: InputLocations<Q>;
   index?: number;
 }
 
-export interface ResetOptions {
-  locations?: InputLocations;
+export interface ResetOptions<Q> {
+  locations?: InputLocations<Q>;
   index?: number;
 }
 
-export interface InMemoryHistory extends History {
-  locations: Array<HickoryLocation>;
+export interface InMemoryHistory<Q> extends History<Q> {
+  locations: Array<HickoryLocation<Q>>;
   index: number;
-  reset(options?: ResetOptions): void;
+  reset(options?: ResetOptions<Q>): void;
 }
 
 interface NavSetup {
@@ -46,7 +46,7 @@ interface NavSetup {
 
 function noop() {}
 
-function InMemory(options: Options = {}): InMemoryHistory {
+function InMemory<Q = string>(options: Options<Q> = {}): InMemoryHistory<Q> {
   const {
     createLocation,
     createPath,
@@ -54,14 +54,14 @@ function InMemory(options: Options = {}): InMemoryHistory {
     confirmWith,
     removeConfirmation,
     keygen
-  } = Common(options);
+  } = Common<Q>(options);
 
   const destroyLocations = () => {
     memoryHistory.locations = [];
     memoryHistory.index = undefined;
   };
 
-  let initialLocations: Array<HickoryLocation> = (
+  let initialLocations: Array<HickoryLocation<Q>> = (
     options.locations || ["/"]
   ).map(loc => createLocation(loc, keygen.major()));
   let initialIndex = 0;
@@ -73,11 +73,11 @@ function InMemory(options: Options = {}): InMemoryHistory {
     initialIndex = options.index;
   }
 
-  function toHref(location: AnyLocation): string {
+  function toHref(location: AnyLocation<Q>): string {
     return createPath(location);
   }
 
-  function setupReplace(location: HickoryLocation): NavSetup {
+  function setupReplace(location: HickoryLocation<Q>): NavSetup {
     location.key = keygen.minor(memoryHistory.location.key);
     return {
       action: "replace",
@@ -85,7 +85,7 @@ function InMemory(options: Options = {}): InMemoryHistory {
     };
   }
 
-  function setupPush(location: HickoryLocation): NavSetup {
+  function setupPush(location: HickoryLocation<Q>): NavSetup {
     location.key = keygen.major(memoryHistory.location.key);
     return {
       action: "push",
@@ -93,7 +93,7 @@ function InMemory(options: Options = {}): InMemoryHistory {
     };
   }
 
-  function finalizePush(location: HickoryLocation) {
+  function finalizePush(location: HickoryLocation<Q>) {
     return () => {
       memoryHistory.location = location;
       memoryHistory.index++;
@@ -105,7 +105,7 @@ function InMemory(options: Options = {}): InMemoryHistory {
     };
   }
 
-  function finalizeReplace(location: HickoryLocation) {
+  function finalizeReplace(location: HickoryLocation<Q>) {
     return () => {
       memoryHistory.location = location;
       memoryHistory.locations[memoryHistory.index] = memoryHistory.location;
@@ -113,15 +113,15 @@ function InMemory(options: Options = {}): InMemoryHistory {
     };
   }
 
-  let responseHandler: ResponseHandler;
-  const memoryHistory: InMemoryHistory = {
+  let responseHandler: ResponseHandler<Q>;
+  const memoryHistory: InMemoryHistory<Q> = {
     // location
     location: initialLocations[initialIndex],
     locations: initialLocations,
     index: initialIndex,
     action: "push",
     // set response handler
-    respondWith(fn: ResponseHandler) {
+    respondWith(fn: ResponseHandler<Q>) {
       responseHandler = fn;
       responseHandler({
         location: memoryHistory.location,
@@ -137,7 +137,7 @@ function InMemory(options: Options = {}): InMemoryHistory {
     destroy(): void {
       destroyLocations();
     },
-    navigate(to: ToArgument, navType: NavType = "anchor"): void {
+    navigate(to: ToArgument<Q>, navType: NavType = "anchor"): void {
       let setup: NavSetup;
       const location = createLocation(to);
       switch (navType) {
@@ -193,7 +193,8 @@ function InMemory(options: Options = {}): InMemoryHistory {
         if (newIndex < 0 || newIndex >= memoryHistory.locations.length) {
           return;
         } else {
-          const location: HickoryLocation = memoryHistory.locations[newIndex];
+          const location: HickoryLocation<Q> =
+            memoryHistory.locations[newIndex];
           confirmNavigation(
             {
               to: location,
@@ -219,7 +220,7 @@ function InMemory(options: Options = {}): InMemoryHistory {
         }
       }
     },
-    reset(options?: ResetOptions) {
+    reset(options?: ResetOptions<Q>) {
       memoryHistory.locations = ((options && options.locations) || ["/"]).map(
         loc => createLocation(loc, keygen.major())
       );

--- a/packages/in-memory/types/index.d.ts
+++ b/packages/in-memory/types/index.d.ts
@@ -1,18 +1,18 @@
 import { History, LocationDetails, HickoryLocation, PartialLocation, AnyLocation, Options as RootOptions } from "@hickory/root";
 export { History, HickoryLocation, PartialLocation, AnyLocation, LocationDetails };
-export declare type InputLocations = Array<string | PartialLocation>;
-export interface Options extends RootOptions {
-    locations?: InputLocations;
+export declare type InputLocations<Q> = Array<string | PartialLocation<Q>>;
+export interface Options<Q> extends RootOptions<Q> {
+    locations?: InputLocations<Q>;
     index?: number;
 }
-export interface ResetOptions {
-    locations?: InputLocations;
+export interface ResetOptions<Q> {
+    locations?: InputLocations<Q>;
     index?: number;
 }
-export interface InMemoryHistory extends History {
-    locations: Array<HickoryLocation>;
+export interface InMemoryHistory<Q> extends History<Q> {
+    locations: Array<HickoryLocation<Q>>;
     index: number;
-    reset(options?: ResetOptions): void;
+    reset(options?: ResetOptions<Q>): void;
 }
-declare function InMemory(options?: Options): InMemoryHistory;
+declare function InMemory<Q = string>(options?: Options<Q>): InMemoryHistory<Q>;
 export { InMemory };

--- a/packages/root/src/common.ts
+++ b/packages/root/src/common.ts
@@ -4,9 +4,9 @@ import createKeyGenerator from "./keygen";
 
 import { CommonHistory, Options } from "./types/hickory";
 
-export default function Common(options?: Options): CommonHistory {
+export default function Common<Q>(options?: Options<Q>): CommonHistory<Q> {
   return {
-    ...createLocationUtils(options),
+    ...createLocationUtils<Q>(options),
     ...createNavigationConfirmation(),
     ...createKeyGenerator()
   };

--- a/packages/root/src/locationFactory.ts
+++ b/packages/root/src/locationFactory.ts
@@ -33,9 +33,9 @@ function isValidBase(baseSegment: string): boolean {
   );
 }
 
-export default function locationFactory(
-  options: LocationFactoryOptions = {}
-): LocationMethods {
+export default function locationFactory<Q>(
+  options: LocationFactoryOptions<Q> = {}
+): LocationMethods<Q> {
   const {
     query: {
       parse: parseQuery = defaultParseQuery,
@@ -56,7 +56,7 @@ export default function locationFactory(
     );
   }
 
-  function parsePath(value: string, state: any): LocationDetails {
+  function parsePath(value: string, state: any): LocationDetails<Q> {
     // hash is always after query, so split it off first
     const hashIndex = value.indexOf("#");
     let hash;
@@ -78,7 +78,7 @@ export default function locationFactory(
 
     const pathname = stripBaseSegment(value, baseSegment);
 
-    const details: LocationDetails = {
+    const details: LocationDetails<Q> = {
       hash,
       query,
       pathname
@@ -91,8 +91,11 @@ export default function locationFactory(
     return details;
   }
 
-  function getDetails(partial: PartialLocation, state: any): LocationDetails {
-    const details: LocationDetails = {
+  function getDetails(
+    partial: PartialLocation<Q>,
+    state: any
+  ): LocationDetails<Q> {
+    const details: LocationDetails<Q> = {
       pathname: partial.pathname == null ? "/" : partial.pathname,
       hash: partial.hash == null ? "" : partial.hash,
       query: partial.query == null ? parseQuery() : partial.query
@@ -108,10 +111,10 @@ export default function locationFactory(
   }
 
   function createLocation(
-    value: ToArgument,
+    value: ToArgument<Q>,
     key?: string,
     state?: any
-  ): HickoryLocation {
+  ): HickoryLocation<Q> {
     if (state === undefined) {
       state = null;
     }
@@ -150,13 +153,13 @@ export default function locationFactory(
     };
   }
 
-  function createPath(location: AnyLocation): string {
+  function createPath(location: AnyLocation<Q>): string {
     // ensure that pathname begins with a forward slash, query begins
     // with a question mark, and hash begins with a pound sign
     return (
       baseSegment +
       completePathname(
-        (location as HickoryLocation).rawPathname || location.pathname || ""
+        (location as HickoryLocation<Q>).rawPathname || location.pathname || ""
       ) +
       completeQuery(stringifyQuery(location.query)) +
       completeHash(location.hash)

--- a/packages/root/src/types/hickory.ts
+++ b/packages/root/src/types/hickory.ts
@@ -6,33 +6,35 @@ import {
   ConfirmationMethods
 } from "./navigationConfirmation";
 
-export type ToArgument = string | PartialLocation;
+export type ToArgument<Q> = string | PartialLocation<Q>;
 
 export type Action = "push" | "replace" | "pop";
 export type NavType = "anchor" | "push" | "replace";
 
-export interface PendingNavigation {
-  location: HickoryLocation;
+export interface PendingNavigation<Q> {
+  location: HickoryLocation<Q>;
   action: Action;
   finish(): void;
   cancel(nextAction?: Action): void;
   cancelled?: boolean;
 }
 
-export type ResponseHandler = (resp: PendingNavigation) => void;
+export type ResponseHandler<Q> = (resp: PendingNavigation<Q>) => void;
 
-export interface History {
-  location: HickoryLocation;
+export interface History<Q> {
+  location: HickoryLocation<Q>;
   action: Action;
-  toHref(to: AnyLocation): string;
-  respondWith(fn: ResponseHandler): void;
+  toHref(to: AnyLocation<Q>): string;
+  respondWith(fn: ResponseHandler<Q>): void;
   confirmWith(fn?: ConfirmationFunction): void;
   removeConfirmation(): void;
   destroy(): void;
-  navigate(to: ToArgument, navType?: NavType): void;
+  navigate(to: ToArgument<Q>, navType?: NavType): void;
   go(num?: number): void;
 }
 
-export type Options = LocationFactoryOptions;
+export type Options<Q> = LocationFactoryOptions<Q>;
 
-export type CommonHistory = LocationMethods & ConfirmationMethods & KeyMethods;
+export type CommonHistory<Q> = LocationMethods<Q> &
+  ConfirmationMethods &
+  KeyMethods;

--- a/packages/root/src/types/location.ts
+++ b/packages/root/src/types/location.ts
@@ -1,18 +1,18 @@
-export interface LocationDetails {
+export interface LocationDetails<Q> {
   pathname: string;
-  query: any;
+  query: Q;
   hash: string;
   state?: any;
 }
 
-export type PartialLocation = Partial<LocationDetails>;
+export type PartialLocation<Q> = Partial<LocationDetails<Q>>;
 
 // use HickoryLocation instead of Location to prevent
 // errors from colliding with window.Location interface
-export interface HickoryLocation extends LocationDetails {
+export interface HickoryLocation<Q> extends LocationDetails<Q> {
   key: string | undefined;
   rawPathname: string;
   url: string;
 }
 
-export type AnyLocation = HickoryLocation | PartialLocation;
+export type AnyLocation<Q> = HickoryLocation<Q> | PartialLocation<Q>;

--- a/packages/root/src/types/locationFactory.ts
+++ b/packages/root/src/types/locationFactory.ts
@@ -1,23 +1,23 @@
 import { HickoryLocation, PartialLocation } from "./location";
 
-export interface QueryFunctions {
-  parse: (query?: string) => any;
-  stringify: (query?: any) => string;
+export interface QueryFunctions<Q> {
+  parse: (query?: string) => Q;
+  stringify: (query?: Q) => string;
 }
 
-export interface LocationFactoryOptions {
-  query?: QueryFunctions;
+export interface LocationFactoryOptions<Q> {
+  query?: QueryFunctions<Q>;
   decode?: boolean;
   baseSegment?: string;
   raw?: (pathname: string) => string;
 }
 
-export interface LocationMethods {
+export interface LocationMethods<Q> {
   createLocation(
     value: string | object,
     key?: string,
     state?: any
-  ): HickoryLocation;
-  createPath(location: HickoryLocation): string;
-  createPath(location: PartialLocation): string;
+  ): HickoryLocation<Q>;
+  createPath(location: HickoryLocation<Q>): string;
+  createPath(location: PartialLocation<Q>): string;
 }

--- a/packages/root/tests/locationFactory.spec.ts
+++ b/packages/root/tests/locationFactory.spec.ts
@@ -342,7 +342,7 @@ describe("locationFactory", () => {
         const input = {
           rawPathname: "/rawPathname",
           pathname: "/pathname"
-        } as HickoryLocation;
+        } as HickoryLocation<any>;
         const output = createPath(input);
         expect(output).toBe("/rawPathname");
       });

--- a/packages/root/tests/navigationConfirmation.spec.ts
+++ b/packages/root/tests/navigationConfirmation.spec.ts
@@ -46,8 +46,8 @@ describe("createNavigationConfirmation", () => {
 
       confirmNavigation(
         {
-          to: { pathname: "/this-is-only-a-test" } as HickoryLocation,
-          from: { pathname: "/this-was-not-a-test" } as HickoryLocation,
+          to: { pathname: "/this-is-only-a-test" } as HickoryLocation<any>,
+          from: { pathname: "/this-was-not-a-test" } as HickoryLocation<any>,
           action: "push"
         },
         confirm,
@@ -70,8 +70,8 @@ describe("createNavigationConfirmation", () => {
       confirmWith(allowNavigation);
       confirmNavigation(
         {
-          to: toLoc as HickoryLocation,
-          from: fromLoc as HickoryLocation,
+          to: toLoc as HickoryLocation<any>,
+          from: fromLoc as HickoryLocation<any>,
           action
         },
         confirm,
@@ -103,8 +103,8 @@ describe("createNavigationConfirmation", () => {
       expect(() => {
         confirmNavigation(
           {
-            to: toLoc as HickoryLocation,
-            from: fromLoc as HickoryLocation,
+            to: toLoc as HickoryLocation<any>,
+            from: fromLoc as HickoryLocation<any>,
             action
           },
           confirm

--- a/packages/root/types/common.d.ts
+++ b/packages/root/types/common.d.ts
@@ -1,2 +1,2 @@
 import { CommonHistory, Options } from "./types/hickory";
-export default function Common(options?: Options): CommonHistory;
+export default function Common<Q>(options?: Options<Q>): CommonHistory<Q>;

--- a/packages/root/types/locationFactory.d.ts
+++ b/packages/root/types/locationFactory.d.ts
@@ -1,2 +1,2 @@
 import { LocationFactoryOptions, LocationMethods } from "./types/locationFactory";
-export default function locationFactory(options?: LocationFactoryOptions): LocationMethods;
+export default function locationFactory<Q>(options?: LocationFactoryOptions<Q>): LocationMethods<Q>;

--- a/packages/root/types/types/hickory.d.ts
+++ b/packages/root/types/types/hickory.d.ts
@@ -2,27 +2,27 @@ import { HickoryLocation, AnyLocation, PartialLocation } from "./location";
 import { LocationFactoryOptions, LocationMethods } from "./locationFactory";
 import { KeyMethods } from "./keygen";
 import { ConfirmationFunction, ConfirmationMethods } from "./navigationConfirmation";
-export declare type ToArgument = string | PartialLocation;
+export declare type ToArgument<Q> = string | PartialLocation<Q>;
 export declare type Action = "push" | "replace" | "pop";
 export declare type NavType = "anchor" | "push" | "replace";
-export interface PendingNavigation {
-    location: HickoryLocation;
+export interface PendingNavigation<Q> {
+    location: HickoryLocation<Q>;
     action: Action;
     finish(): void;
     cancel(nextAction?: Action): void;
     cancelled?: boolean;
 }
-export declare type ResponseHandler = (resp: PendingNavigation) => void;
-export interface History {
-    location: HickoryLocation;
+export declare type ResponseHandler<Q> = (resp: PendingNavigation<Q>) => void;
+export interface History<Q> {
+    location: HickoryLocation<Q>;
     action: Action;
-    toHref(to: AnyLocation): string;
-    respondWith(fn: ResponseHandler): void;
+    toHref(to: AnyLocation<Q>): string;
+    respondWith(fn: ResponseHandler<Q>): void;
     confirmWith(fn?: ConfirmationFunction): void;
     removeConfirmation(): void;
     destroy(): void;
-    navigate(to: ToArgument, navType?: NavType): void;
+    navigate(to: ToArgument<Q>, navType?: NavType): void;
     go(num?: number): void;
 }
-export declare type Options = LocationFactoryOptions;
-export declare type CommonHistory = LocationMethods & ConfirmationMethods & KeyMethods;
+export declare type Options<Q> = LocationFactoryOptions<Q>;
+export declare type CommonHistory<Q> = LocationMethods<Q> & ConfirmationMethods & KeyMethods;

--- a/packages/root/types/types/location.d.ts
+++ b/packages/root/types/types/location.d.ts
@@ -1,13 +1,13 @@
-export interface LocationDetails {
+export interface LocationDetails<Q> {
     pathname: string;
-    query: any;
+    query: Q;
     hash: string;
     state?: any;
 }
-export declare type PartialLocation = Partial<LocationDetails>;
-export interface HickoryLocation extends LocationDetails {
+export declare type PartialLocation<Q> = Partial<LocationDetails<Q>>;
+export interface HickoryLocation<Q> extends LocationDetails<Q> {
     key: string | undefined;
     rawPathname: string;
     url: string;
 }
-export declare type AnyLocation = HickoryLocation | PartialLocation;
+export declare type AnyLocation<Q> = HickoryLocation<Q> | PartialLocation<Q>;

--- a/packages/root/types/types/locationFactory.d.ts
+++ b/packages/root/types/types/locationFactory.d.ts
@@ -1,16 +1,16 @@
 import { HickoryLocation, PartialLocation } from "./location";
-export interface QueryFunctions {
-    parse: (query?: string) => any;
-    stringify: (query?: any) => string;
+export interface QueryFunctions<Q> {
+    parse: (query?: string) => Q;
+    stringify: (query?: Q) => string;
 }
-export interface LocationFactoryOptions {
-    query?: QueryFunctions;
+export interface LocationFactoryOptions<Q> {
+    query?: QueryFunctions<Q>;
     decode?: boolean;
     baseSegment?: string;
     raw?: (pathname: string) => string;
 }
-export interface LocationMethods {
-    createLocation(value: string | object, key?: string, state?: any): HickoryLocation;
-    createPath(location: HickoryLocation): string;
-    createPath(location: PartialLocation): string;
+export interface LocationMethods<Q> {
+    createLocation(value: string | object, key?: string, state?: any): HickoryLocation<Q>;
+    createPath(location: HickoryLocation<Q>): string;
+    createPath(location: PartialLocation<Q>): string;
 }


### PR DESCRIPTION
Enforce that all location `query` values are the same type. Each history creator defaults to `string` queries.