### PR TITLE
Move navigate() prep to @hickory/root

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 7018,
-    "minified": 2356,
-    "gzipped": 937,
+    "bundled": 6066,
+    "minified": 2136,
+    "gzipped": 861,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 7081,
-    "minified": 2414,
-    "gzipped": 990
+    "bundled": 6120,
+    "minified": 2186,
+    "gzipped": 914
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 17208,
-    "minified": 4996,
-    "gzipped": 2061
+    "bundled": 17447,
+    "minified": 5286,
+    "gzipped": 2142
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 17208,
-    "minified": 4996,
-    "gzipped": 2061
+    "bundled": 17447,
+    "minified": 5286,
+    "gzipped": 2142
   }
 }

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 9219,
-    "minified": 3189,
-    "gzipped": 1157,
+    "bundled": 8273,
+    "minified": 2969,
+    "gzipped": 1091,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 9431,
-    "minified": 3391,
-    "gzipped": 1217
+    "bundled": 8476,
+    "minified": 3163,
+    "gzipped": 1148
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 19335,
-    "minified": 5521,
-    "gzipped": 2212
+    "bundled": 19580,
+    "minified": 5811,
+    "gzipped": 2292
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 19335,
-    "minified": 5521,
-    "gzipped": 2212
+    "bundled": 19580,
+    "minified": 5811,
+    "gzipped": 2292
   }
 }

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 6980,
-    "minified": 2092,
-    "gzipped": 792,
+    "bundled": 5986,
+    "minified": 1872,
+    "gzipped": 695,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 7069,
-    "minified": 2174,
-    "gzipped": 846
+    "bundled": 6066,
+    "minified": 1946,
+    "gzipped": 745
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 16384,
-    "minified": 4659,
-    "gzipped": 1883
+    "bundled": 16581,
+    "minified": 4949,
+    "gzipped": 1949
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 16384,
-    "minified": 4659,
-    "gzipped": 1883
+    "bundled": 16581,
+    "minified": 4949,
+    "gzipped": 1949
   }
 }

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 7027,
-    "minified": 2712,
-    "gzipped": 1217,
+    "bundled": 8238,
+    "minified": 3273,
+    "gzipped": 1395,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 7117,
-    "minified": 2794,
-    "gzipped": 1253
+    "bundled": 8351,
+    "minified": 3376,
+    "gzipped": 1439
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 8725,
-    "minified": 2648,
-    "gzipped": 1274
+    "bundled": 10091,
+    "minified": 3199,
+    "gzipped": 1458
   },
   "dist/hickory-root.min.js": {
-    "bundled": 8725,
-    "minified": 2648,
-    "gzipped": 1274
+    "bundled": 10091,
+    "minified": 3199,
+    "gzipped": 1458
   }
 }

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- Export `prepNavigate` method for history `navigate` methods.
 - Remove `location.url`
 - `strict` types
 - Rename `LocationDetails` to `LocationComponents`

--- a/packages/root/src/common.ts
+++ b/packages/root/src/common.ts
@@ -6,8 +6,8 @@ import { CommonHistory, Options } from "./types/hickory";
 
 export default function Common<Q>(options?: Options<Q>): CommonHistory<Q> {
   return {
+    keygen: createKeyGenerator(),
     ...createLocationUtils<Q>(options),
-    ...createNavigationConfirmation(),
-    ...createKeyGenerator()
+    ...createNavigationConfirmation()
   };
 }

--- a/packages/root/src/index.ts
+++ b/packages/root/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
 
 import Common from "./common";
-export { Common };
+import prepNavigate from "./prepNavigate";
+export { Common, prepNavigate };

--- a/packages/root/src/keygen.ts
+++ b/packages/root/src/keygen.ts
@@ -1,4 +1,4 @@
-import { KeyMethods } from "./types/keygen";
+import { KeyFns } from "./types/keygen";
 
 function parse(key: string): Array<number> {
   return key.split(".").map((value: string): number => parseInt(value, 10));
@@ -13,19 +13,17 @@ function minor(current: string): string {
   return `${major}.${minor + 1}`;
 }
 
-export default function createKeyGenerator(): KeyMethods {
+export default function createKeyGenerator(): KeyFns {
   let currentMajor: number = 0;
 
   return {
-    keygen: {
-      major: function(previous?: string): string {
-        if (previous) {
-          currentMajor = parse(previous)[0] + 1;
-        }
-        return `${currentMajor++}.0`;
-      },
-      minor,
-      diff
-    }
+    major: function(previous?: string): string {
+      if (previous) {
+        currentMajor = parse(previous)[0] + 1;
+      }
+      return `${currentMajor++}.0`;
+    },
+    minor,
+    diff
   };
 }

--- a/packages/root/src/prepNavigate.ts
+++ b/packages/root/src/prepNavigate.ts
@@ -1,0 +1,52 @@
+import {
+  PrepNavigateArgs,
+  Preparer,
+  PreppedNavigation
+} from "./types/prepNavigate";
+import { ToArgument, NavType } from "./types/hickory";
+import { Location } from "./types/location";
+
+export default function prepNavigate<Q>(
+  args: PrepNavigateArgs<Q>
+): Preparer<Q> {
+  function prepReplace(location: Location<Q>): PreppedNavigation<Q> {
+    const keyedLocation = args.utils.keyed(
+      location,
+      args.utils.keygen.minor(args.current().key)
+    );
+    return {
+      action: "replace",
+      finish: args.replace(keyedLocation),
+      location: keyedLocation
+    };
+  }
+
+  function prepPush(location: Location<Q>): PreppedNavigation<Q> {
+    const keyedLocation = args.utils.keyed(
+      location,
+      args.utils.keygen.major(args.current().key)
+    );
+    return {
+      action: "push",
+      finish: args.push(keyedLocation),
+      location: keyedLocation
+    };
+  }
+
+  return function prep(to: ToArgument<Q>, navType: NavType) {
+    const location = args.utils.genericLocation(to);
+    switch (navType) {
+      case "anchor":
+        return args.utils.stringifyLocation(location) ===
+          args.utils.stringifyLocation(args.current())
+          ? prepReplace(location)
+          : prepPush(location);
+      case "push":
+        return prepPush(location);
+      case "replace":
+        return prepReplace(location);
+      default:
+        throw new Error(`Invalid navigation type: ${navType}`);
+    }
+  };
+}

--- a/packages/root/src/types/index.ts
+++ b/packages/root/src/types/index.ts
@@ -30,3 +30,5 @@ export {
   ConfirmationFunction,
   ConfirmationMethods
 } from "./navigationConfirmation";
+
+export { PreppedNavigation, Preparer, PrepNavigateArgs } from "./prepNavigate";

--- a/packages/root/src/types/prepNavigate.ts
+++ b/packages/root/src/types/prepNavigate.ts
@@ -1,0 +1,22 @@
+import { Action, ToArgument, NavType } from "./hickory";
+import { SessionLocation } from "./location";
+import { LocationMethods } from "./locationFactory";
+import { KeyMethods } from "./keygen";
+
+export interface PreppedNavigation<Q> {
+  action: Action;
+  finish(): void;
+  location: SessionLocation<Q>;
+}
+
+export type Preparer<Q> = (
+  to: ToArgument<Q>,
+  navType: NavType
+) => PreppedNavigation<Q>;
+
+export interface PrepNavigateArgs<Q> {
+  utils: LocationMethods<Q> & KeyMethods;
+  current(): SessionLocation<Q>;
+  push(l: SessionLocation<Q>): () => void;
+  replace(l: SessionLocation<Q>): () => void;
+}

--- a/packages/root/types/index.d.ts
+++ b/packages/root/types/index.d.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 import Common from "./common";
-export { Common };
+import prepNavigate from "./prepNavigate";
+export { Common, prepNavigate };

--- a/packages/root/types/keygen.d.ts
+++ b/packages/root/types/keygen.d.ts
@@ -1,2 +1,2 @@
-import { KeyMethods } from "./types/keygen";
-export default function createKeyGenerator(): KeyMethods;
+import { KeyFns } from "./types/keygen";
+export default function createKeyGenerator(): KeyFns;

--- a/packages/root/types/prepNavigate.d.ts
+++ b/packages/root/types/prepNavigate.d.ts
@@ -1,0 +1,2 @@
+import { PrepNavigateArgs, Preparer } from "./types/prepNavigate";
+export default function prepNavigate<Q>(args: PrepNavigateArgs<Q>): Preparer<Q>;

--- a/packages/root/types/types/index.d.ts
+++ b/packages/root/types/types/index.d.ts
@@ -3,3 +3,4 @@ export { History, ToArgument, Action, NavType, PendingNavigation, ResponseHandle
 export { KeyMethods, KeyFns } from "./keygen";
 export { QueryFunctions, LocationFactoryOptions, LocationMethods } from "./locationFactory";
 export { NavigationInfo, ConfirmationFunction, ConfirmationMethods } from "./navigationConfirmation";
+export { PreppedNavigation, Preparer, PrepNavigateArgs } from "./prepNavigate";

--- a/packages/root/types/types/prepNavigate.d.ts
+++ b/packages/root/types/types/prepNavigate.d.ts
@@ -1,0 +1,16 @@
+import { Action, ToArgument, NavType } from "./hickory";
+import { SessionLocation } from "./location";
+import { LocationMethods } from "./locationFactory";
+import { KeyMethods } from "./keygen";
+export interface PreppedNavigation<Q> {
+    action: Action;
+    finish(): void;
+    location: SessionLocation<Q>;
+}
+export declare type Preparer<Q> = (to: ToArgument<Q>, navType: NavType) => PreppedNavigation<Q>;
+export interface PrepNavigateArgs<Q> {
+    utils: LocationMethods<Q> & KeyMethods;
+    current(): SessionLocation<Q>;
+    push(l: SessionLocation<Q>): () => void;
+    replace(l: SessionLocation<Q>): () => void;
+}


### PR DESCRIPTION
De-duplicates code from the `browser`, `hash`, and `in-memory` packages.