### PR TITLE
Remove generic query

### DIFF
--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Remove generic `query` type.
+
 ## 2.0.0-alpha.2
 
 - Remove navigation blocking from `Browser`

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -20,9 +20,7 @@ export * from "./types";
 
 function noop() {}
 
-export function Browser<Q = string>(
-  options: Options<Q> = {}
-): BrowserHistory<Q> {
+export function Browser(options: Options = {}): BrowserHistory {
   if (!domExists()) {
     throw new Error("Cannot use @hickory/browser without a DOM");
   }
@@ -38,7 +36,7 @@ export function Browser<Q = string>(
     locationUtils: locationUtilities,
     keygen,
     current: () => browserHistory.location,
-    push(location: SessionLocation<Q>) {
+    push(location: SessionLocation) {
       return () => {
         const path = toHref(location);
         const { key, state } = location;
@@ -51,7 +49,7 @@ export function Browser<Q = string>(
         browserHistory.action = "push";
       };
     },
-    replace(location: SessionLocation<Q>) {
+    replace(location: SessionLocation) {
       return () => {
         const path = toHref(location);
         const { key, state } = location;
@@ -75,7 +73,7 @@ export function Browser<Q = string>(
 
   window.addEventListener("popstate", popstate, false);
 
-  function locationFromBrowser(providedState?: object): SessionLocation<Q> {
+  function locationFromBrowser(providedState?: object): SessionLocation {
     const { pathname, search, hash } = window.location;
     const path = pathname + search + hash;
     let { key, state } = providedState || getStateFromHistory();
@@ -87,17 +85,17 @@ export function Browser<Q = string>(
     return locationUtilities.keyed(location, key);
   }
 
-  function toHref(location: AnyLocation<Q>): string {
+  function toHref(location: AnyLocation): string {
     return locationUtilities.stringifyLocation(location);
   }
 
-  let responseHandler: ResponseHandler<Q> | undefined;
-  const browserHistory: BrowserHistory<Q> = {
+  let responseHandler: ResponseHandler | undefined;
+  const browserHistory: BrowserHistory = {
     // set action before location because locationFromBrowser enforces that the location has a key
     action: getStateFromHistory().key !== undefined ? "pop" : "push",
     location: locationFromBrowser(),
     // set response handler
-    respondWith(fn: ResponseHandler<Q>) {
+    respondWith(fn: ResponseHandler) {
       responseHandler = fn;
       // immediately invoke
       responseHandler({
@@ -112,7 +110,7 @@ export function Browser<Q = string>(
     destroy() {
       window.removeEventListener("popstate", popstate);
     },
-    navigate(to: ToArgument<Q>, navType: NavType = "anchor"): void {
+    navigate(to: ToArgument, navType: NavType = "anchor"): void {
       const next = prepare(to, navType);
 
       if (!responseHandler) {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -17,5 +17,5 @@ export {
   LocationComponents
 };
 
-export type Options<Q> = LocationUtilOptions<Q>;
-export type BrowserHistory<Q> = History<Q>;
+export type Options = LocationUtilOptions;
+export type BrowserHistory = History;

--- a/packages/browser/types/index.d.ts
+++ b/packages/browser/types/index.d.ts
@@ -1,3 +1,3 @@
 import { BrowserHistory, Options } from "./types";
 export * from "./types";
-export declare function Browser<Q = string>(options?: Options<Q>): BrowserHistory<Q>;
+export declare function Browser(options?: Options): BrowserHistory;

--- a/packages/browser/types/types.d.ts
+++ b/packages/browser/types/types.d.ts
@@ -1,4 +1,4 @@
 import { History, LocationComponents, PartialLocation, SessionLocation, AnyLocation, Location, LocationUtilOptions } from "@hickory/root";
 export { History, SessionLocation, PartialLocation, AnyLocation, Location, LocationComponents };
-export declare type Options<Q> = LocationUtilOptions<Q>;
-export declare type BrowserHistory<Q> = History<Q>;
+export declare type Options = LocationUtilOptions;
+export declare type BrowserHistory = History;

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Remove generic `query` type.
+
 ## 2.0.0-alpha.2
 
 - Remove navigation blocking from `Hash`

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -26,7 +26,7 @@ function ensureHash(encode: (path: string) => string): void {
 
 function noop() {}
 
-export function Hash<Q>(options: Options<Q> = {}): HashHistory<Q> {
+export function Hash(options: Options = {}): HashHistory {
   if (!domExists()) {
     throw new Error("Cannot use @hickory/hash without a DOM");
   }
@@ -41,7 +41,7 @@ export function Hash<Q>(options: Options<Q> = {}): HashHistory<Q> {
     locationUtils: locationUtilities,
     keygen,
     current: () => hashHistory.location,
-    push(location: SessionLocation<Q>) {
+    push(location: SessionLocation) {
       return () => {
         const path = toHref(location);
         const { key, state } = location;
@@ -54,7 +54,7 @@ export function Hash<Q>(options: Options<Q> = {}): HashHistory<Q> {
         hashHistory.action = "push";
       };
     },
-    replace(location: SessionLocation<Q>) {
+    replace(location: SessionLocation) {
       return () => {
         const path = toHref(location);
         const { key, state } = location;
@@ -85,7 +85,7 @@ export function Hash<Q>(options: Options<Q> = {}): HashHistory<Q> {
 
   ensureHash(encodeHashPath);
 
-  function locationFromBrowser(providedState?: object): SessionLocation<Q> {
+  function locationFromBrowser(providedState?: object): SessionLocation {
     let { hash } = window.location;
     const path = decodeHashPath(hash);
     let { key, state } = providedState || getStateFromHistory();
@@ -100,17 +100,17 @@ export function Hash<Q>(options: Options<Q> = {}): HashHistory<Q> {
     );
   }
 
-  function toHref(location: AnyLocation<Q>): string {
+  function toHref(location: AnyLocation): string {
     return encodeHashPath(locationUtilities.stringifyLocation(location));
   }
 
-  let responseHandler: ResponseHandler<Q> | undefined;
-  const hashHistory: HashHistory<Q> = {
+  let responseHandler: ResponseHandler | undefined;
+  const hashHistory: HashHistory = {
     // location
     action: getStateFromHistory().key !== undefined ? "pop" : "push",
     location: locationFromBrowser(),
     // set response handler
-    respondWith(fn: ResponseHandler<Q>) {
+    respondWith(fn: ResponseHandler) {
       responseHandler = fn;
       responseHandler({
         location: hashHistory.location,
@@ -124,7 +124,7 @@ export function Hash<Q>(options: Options<Q> = {}): HashHistory<Q> {
     destroy() {
       window.removeEventListener("popstate", popstate);
     },
-    navigate(to: ToArgument<Q>, navType: NavType = "anchor"): void {
+    navigate(to: ToArgument, navType: NavType = "anchor"): void {
       const next = prep(to, navType);
       if (!responseHandler) {
         return;
@@ -149,7 +149,7 @@ export function Hash<Q>(options: Options<Q> = {}): HashHistory<Q> {
       reverting = false;
       return;
     }
-    const location: SessionLocation<Q> = locationFromBrowser(state);
+    const location: SessionLocation = locationFromBrowser(state);
     const currentKey: string = hashHistory.location.key;
     const diff: number = keygen.diff(currentKey, location.key);
     if (!responseHandler) {

--- a/packages/hash/src/types.ts
+++ b/packages/hash/src/types.ts
@@ -20,5 +20,5 @@ export {
 export interface HashOptions {
   hashType?: string;
 }
-export type Options<Q> = LocationUtilOptions<Q> & HashOptions;
-export type HashHistory<Q> = History<Q>;
+export type Options = LocationUtilOptions & HashOptions;
+export type HashHistory = History;

--- a/packages/hash/types/index.d.ts
+++ b/packages/hash/types/index.d.ts
@@ -1,3 +1,3 @@
 import { Options, HashHistory } from "./types";
 export * from "./types";
-export declare function Hash<Q>(options?: Options<Q>): HashHistory<Q>;
+export declare function Hash(options?: Options): HashHistory;

--- a/packages/hash/types/types.d.ts
+++ b/packages/hash/types/types.d.ts
@@ -3,5 +3,5 @@ export { History, SessionLocation, PartialLocation, AnyLocation, Location, Locat
 export interface HashOptions {
     hashType?: string;
 }
-export declare type Options<Q> = LocationUtilOptions<Q> & HashOptions;
-export declare type HashHistory<Q> = History<Q>;
+export declare type Options = LocationUtilOptions & HashOptions;
+export declare type HashHistory = History;

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Remove generic `query` type.
+
 ## 2.0.0-alpha.2
 
 - Remove navigation blocking from `InMemory`

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -19,16 +19,14 @@ function noop() {}
 
 export * from "./types";
 
-export function InMemory<Q = string>(
-  options: Options<Q> = {}
-): InMemoryHistory<Q> {
+export function InMemory(options: Options = {}): InMemoryHistory {
   const locationUtilities = locationUtils(options);
   const keygen = keyGenerator();
   const prep = prepareNavigate({
     locationUtils: locationUtilities,
     keygen,
     current: () => memoryHistory.location,
-    push(location: SessionLocation<Q>) {
+    push(location: SessionLocation) {
       return () => {
         memoryHistory.location = location;
         memoryHistory.index++;
@@ -39,7 +37,7 @@ export function InMemory<Q = string>(
         memoryHistory.action = "push";
       };
     },
-    replace(location: SessionLocation<Q>) {
+    replace(location: SessionLocation) {
       return () => {
         memoryHistory.location = location;
         memoryHistory.locations[memoryHistory.index] = memoryHistory.location;
@@ -53,9 +51,9 @@ export function InMemory<Q = string>(
     memoryHistory.index = -1;
   };
 
-  let initialLocations: Array<SessionLocation<Q>> = (
+  let initialLocations: Array<SessionLocation> = (
     options.locations || ["/"]
-  ).map((loc: InputLocation<Q>) =>
+  ).map((loc: InputLocation) =>
     locationUtilities.keyed(
       locationUtilities.genericLocation(loc),
       keygen.major()
@@ -70,19 +68,19 @@ export function InMemory<Q = string>(
     initialIndex = options.index;
   }
 
-  function toHref(location: AnyLocation<Q>): string {
+  function toHref(location: AnyLocation): string {
     return locationUtilities.stringifyLocation(location);
   }
 
-  let responseHandler: ResponseHandler<Q> | undefined;
-  const memoryHistory: InMemoryHistory<Q> = {
+  let responseHandler: ResponseHandler | undefined;
+  const memoryHistory: InMemoryHistory = {
     // location
     location: initialLocations[initialIndex],
     locations: initialLocations,
     index: initialIndex,
     action: "push",
     // set response handler
-    respondWith(fn: ResponseHandler<Q>) {
+    respondWith(fn: ResponseHandler) {
       responseHandler = fn;
       responseHandler({
         location: memoryHistory.location,
@@ -96,7 +94,7 @@ export function InMemory<Q = string>(
     destroy(): void {
       destroyLocations();
     },
-    navigate(to: ToArgument<Q>, navType: NavType = "anchor"): void {
+    navigate(to: ToArgument, navType: NavType = "anchor"): void {
       const next = prep(to, navType);
       if (!responseHandler) {
         return;
@@ -126,8 +124,7 @@ export function InMemory<Q = string>(
         if (newIndex < 0 || newIndex >= memoryHistory.locations.length) {
           return;
         } else {
-          const location: SessionLocation<Q> =
-            memoryHistory.locations[newIndex];
+          const location: SessionLocation = memoryHistory.locations[newIndex];
           if (!responseHandler) {
             return;
           }
@@ -144,7 +141,7 @@ export function InMemory<Q = string>(
         }
       }
     },
-    reset(options?: SessionOptions<Q>) {
+    reset(options?: SessionOptions) {
       memoryHistory.locations = ((options && options.locations) || ["/"]).map(
         loc =>
           locationUtilities.keyed(

--- a/packages/in-memory/src/types.ts
+++ b/packages/in-memory/src/types.ts
@@ -17,20 +17,20 @@ export {
   LocationComponents
 };
 
-export type InputLocation<Q> = string | PartialLocation<Q>;
-export type InputLocations<Q> = Array<InputLocation<Q>>;
+export type InputLocation = string | PartialLocation;
+export type InputLocations = Array<InputLocation>;
 
-export interface SessionOptions<Q> {
-  locations?: InputLocations<Q>;
+export interface SessionOptions {
+  locations?: InputLocations;
   index?: number;
 }
 
-export type Options<Q> = LocationUtilOptions<Q> & SessionOptions<Q>;
+export type Options = LocationUtilOptions & SessionOptions;
 
-export interface SessionHistory<Q> {
-  locations: Array<SessionLocation<Q>>;
+export interface SessionHistory {
+  locations: Array<SessionLocation>;
   index: number;
-  reset(options?: SessionOptions<Q>): void;
+  reset(options?: SessionOptions): void;
 }
 
-export type InMemoryHistory<Q> = History<Q> & SessionHistory<Q>;
+export type InMemoryHistory = History & SessionHistory;

--- a/packages/in-memory/types/index.d.ts
+++ b/packages/in-memory/types/index.d.ts
@@ -1,3 +1,3 @@
 import { Options, InMemoryHistory } from "./types";
 export * from "./types";
-export declare function InMemory<Q = string>(options?: Options<Q>): InMemoryHistory<Q>;
+export declare function InMemory(options?: Options): InMemoryHistory;

--- a/packages/in-memory/types/types.d.ts
+++ b/packages/in-memory/types/types.d.ts
@@ -1,15 +1,15 @@
 import { History, LocationComponents, PartialLocation, SessionLocation, AnyLocation, Location, LocationUtilOptions } from "@hickory/root";
 export { History, SessionLocation, PartialLocation, AnyLocation, Location, LocationComponents };
-export declare type InputLocation<Q> = string | PartialLocation<Q>;
-export declare type InputLocations<Q> = Array<InputLocation<Q>>;
-export interface SessionOptions<Q> {
-    locations?: InputLocations<Q>;
+export declare type InputLocation = string | PartialLocation;
+export declare type InputLocations = Array<InputLocation>;
+export interface SessionOptions {
+    locations?: InputLocations;
     index?: number;
 }
-export declare type Options<Q> = LocationUtilOptions<Q> & SessionOptions<Q>;
-export interface SessionHistory<Q> {
-    locations: Array<SessionLocation<Q>>;
+export declare type Options = LocationUtilOptions & SessionOptions;
+export interface SessionHistory {
+    locations: Array<SessionLocation>;
     index: number;
-    reset(options?: SessionOptions<Q>): void;
+    reset(options?: SessionOptions): void;
 }
-export declare type InMemoryHistory<Q> = History<Q> & SessionHistory<Q>;
+export declare type InMemoryHistory = History & SessionHistory;

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Remove generic `query` type.
+
 ## 2.0.0-alpha.2
 
 - Export `locationUtils` function for creating a history's location utility functions

--- a/packages/root/src/locationUtils.ts
+++ b/packages/root/src/locationUtils.ts
@@ -35,9 +35,9 @@ function defaultRaw(p: string): string {
   return p;
 }
 
-export default function locationFactory<Q>(
-  options: LocationUtilOptions<Q> = {}
-): LocationUtils<Q> {
+export default function locationFactory(
+  options: LocationUtilOptions = {}
+): LocationUtils {
   const {
     query: {
       parse: parseQuery = defaultParseQuery,
@@ -58,7 +58,7 @@ export default function locationFactory<Q>(
     );
   }
 
-  function parsePath(value: string, state: any): LocationComponents<Q> {
+  function parsePath(value: string, state: any): LocationComponents {
     // hash is always after query, so split it off first
     const hashIndex = value.indexOf("#");
     let hash;
@@ -80,7 +80,7 @@ export default function locationFactory<Q>(
 
     const pathname = stripBaseSegment(value, baseSegment);
 
-    const details: LocationComponents<Q> = {
+    const details: LocationComponents = {
       hash,
       query,
       pathname
@@ -94,10 +94,10 @@ export default function locationFactory<Q>(
   }
 
   function getDetails(
-    partial: PartialLocation<Q>,
+    partial: PartialLocation,
     state: any
-  ): LocationComponents<Q> {
-    const details: LocationComponents<Q> = {
+  ): LocationComponents {
+    const details: LocationComponents = {
       pathname: partial.pathname == null ? "/" : partial.pathname,
       hash: partial.hash == null ? "" : partial.hash,
       query: partial.query == null ? parseQuery() : partial.query
@@ -112,7 +112,7 @@ export default function locationFactory<Q>(
     return details;
   }
 
-  function genericLocation(value: ToArgument<Q>, state?: any): Location<Q> {
+  function genericLocation(value: ToArgument, state?: any): Location {
     if (state === undefined) {
       state = null;
     }
@@ -143,20 +143,20 @@ export default function locationFactory<Q>(
     };
   }
 
-  function keyed(location: Location<Q>, key: string): SessionLocation<Q> {
+  function keyed(location: Location, key: string): SessionLocation {
     return {
       ...location,
       key
     };
   }
 
-  function stringifyLocation(location: AnyLocation<Q>): string {
+  function stringifyLocation(location: AnyLocation): string {
     // ensure that pathname begins with a forward slash, query begins
     // with a question mark, and hash begins with a pound sign
     return (
       baseSegment +
       completePathname(
-        (location as SessionLocation<Q>).rawPathname || location.pathname || ""
+        (location as SessionLocation).rawPathname || location.pathname || ""
       ) +
       completeQuery(stringifyQuery(location.query)) +
       completeHash(location.hash)

--- a/packages/root/src/navigationConfirmation.ts
+++ b/packages/root/src/navigationConfirmation.ts
@@ -6,14 +6,12 @@ import {
 
 function noop(): void {}
 
-export default function createNavigationConfirmation<Q>(): ConfirmationMethods<
-  Q
-> {
-  let confirmFunction: ConfirmationFunction<Q> | null;
+export default function createNavigationConfirmation(): ConfirmationMethods {
+  let confirmFunction: ConfirmationFunction | null;
 
   return {
     confirmNavigation(
-      info: NavigationInfo<Q>,
+      info: NavigationInfo,
       confirm: () => void,
       prevent?: () => void
     ): void {
@@ -24,7 +22,7 @@ export default function createNavigationConfirmation<Q>(): ConfirmationMethods<
       }
     },
 
-    confirmWith(fn: ConfirmationFunction<Q>): void {
+    confirmWith(fn: ConfirmationFunction): void {
       if (typeof fn !== "function") {
         throw new Error("confirmWith can only be passed a function");
       }

--- a/packages/root/src/prepareNavigate.ts
+++ b/packages/root/src/prepareNavigate.ts
@@ -6,10 +6,8 @@ import {
 import { ToArgument, NavType } from "./types/navigation";
 import { Location } from "./types/location";
 
-export default function prepareNavigate<Q>(
-  args: PrepNavigateArgs<Q>
-): Preparer<Q> {
-  function prepReplace(location: Location<Q>): PreppedNavigation<Q> {
+export default function prepareNavigate(args: PrepNavigateArgs): Preparer {
+  function prepReplace(location: Location): PreppedNavigation {
     const keyedLocation = args.locationUtils.keyed(
       location,
       args.keygen.minor(args.current().key)
@@ -21,7 +19,7 @@ export default function prepareNavigate<Q>(
     };
   }
 
-  function prepPush(location: Location<Q>): PreppedNavigation<Q> {
+  function prepPush(location: Location): PreppedNavigation {
     const keyedLocation = args.locationUtils.keyed(
       location,
       args.keygen.major(args.current().key)
@@ -33,7 +31,7 @@ export default function prepareNavigate<Q>(
     };
   }
 
-  return function prep(to: ToArgument<Q>, navType: NavType) {
+  return function prep(to: ToArgument, navType: NavType) {
     const location = args.locationUtils.genericLocation(to);
     switch (navType) {
       case "anchor":

--- a/packages/root/src/types/hickory.ts
+++ b/packages/root/src/types/hickory.ts
@@ -1,12 +1,12 @@
 import { SessionLocation, AnyLocation } from "./location";
 import { Action, ResponseHandler, ToArgument, NavType } from "./navigation";
 
-export interface History<Q> {
-  location: SessionLocation<Q>;
+export interface History {
+  location: SessionLocation;
   action: Action;
-  toHref(to: AnyLocation<Q>): string;
-  respondWith(fn: ResponseHandler<Q>): void;
+  toHref(to: AnyLocation): string;
+  respondWith(fn: ResponseHandler): void;
   destroy(): void;
-  navigate(to: ToArgument<Q>, navType?: NavType): void;
+  navigate(to: ToArgument, navType?: NavType): void;
   go(num?: number): void;
 }

--- a/packages/root/src/types/location.ts
+++ b/packages/root/src/types/location.ts
@@ -1,20 +1,20 @@
-export interface LocationComponents<Q> {
+export interface LocationComponents {
   pathname: string;
-  query: Q;
+  query: any;
   hash: string;
   state?: any;
 }
 
-export type PartialLocation<Q> = Partial<LocationComponents<Q>>;
+export type PartialLocation = Partial<LocationComponents>;
 
-export interface Location<Q> extends LocationComponents<Q> {
+export interface Location extends LocationComponents {
   rawPathname: string;
 }
 
 // use SessionLocation instead of Location to prevent
 // errors from colliding with window.Location interface
-export interface SessionLocation<Q> extends Location<Q> {
+export interface SessionLocation extends Location {
   key: string;
 }
 
-export type AnyLocation<Q> = SessionLocation<Q> | PartialLocation<Q>;
+export type AnyLocation = SessionLocation | PartialLocation;

--- a/packages/root/src/types/locationUtils.ts
+++ b/packages/root/src/types/locationUtils.ts
@@ -1,22 +1,22 @@
 import { Location, SessionLocation, PartialLocation } from "./location";
 
-export interface QueryFunctions<Q> {
+export interface QueryFunctions {
   parse: (query?: string) => Q;
   stringify: (query?: Q) => string;
 }
 
 export type RawPathname = (pathname: string) => string;
 
-export interface LocationUtilOptions<Q> {
-  query?: QueryFunctions<Q>;
+export interface LocationUtilOptions {
+  query?: QueryFunctions;
   decode?: boolean;
   baseSegment?: string;
   raw?: RawPathname;
 }
 
-export interface LocationUtils<Q> {
-  keyed(location: Location<Q>, key: string): SessionLocation<Q>;
-  genericLocation(value: string | object, state?: any): Location<Q>;
-  stringifyLocation(location: SessionLocation<Q>): string;
-  stringifyLocation(location: PartialLocation<Q>): string;
+export interface LocationUtils {
+  keyed(location: Location, key: string): SessionLocation;
+  genericLocation(value: string | object, state?: any): Location;
+  stringifyLocation(location: SessionLocation): string;
+  stringifyLocation(location: PartialLocation): string;
 }

--- a/packages/root/src/types/navigation.ts
+++ b/packages/root/src/types/navigation.ts
@@ -1,16 +1,16 @@
 import { PartialLocation, SessionLocation } from "./location";
 
-export type ToArgument<Q> = string | PartialLocation<Q>;
+export type ToArgument = string | PartialLocation;
 
 export type Action = "push" | "replace" | "pop";
 export type NavType = "anchor" | "push" | "replace";
 
-export interface PendingNavigation<Q> {
-  location: SessionLocation<Q>;
+export interface PendingNavigation {
+  location: SessionLocation;
   action: Action;
   finish(): void;
   cancel(nextAction?: Action): void;
   cancelled?: boolean;
 }
 
-export type ResponseHandler<Q> = (resp: PendingNavigation<Q>) => void;
+export type ResponseHandler = (resp: PendingNavigation) => void;

--- a/packages/root/src/types/navigationConfirmation.ts
+++ b/packages/root/src/types/navigationConfirmation.ts
@@ -1,29 +1,29 @@
 import { SessionLocation } from "./location";
 import { Action } from "./navigation";
 
-export interface NavigationInfo<Q> {
-  to: SessionLocation<Q>;
-  from: SessionLocation<Q>;
+export interface NavigationInfo {
+  to: SessionLocation;
+  from: SessionLocation;
   action: Action;
 }
 
-export type ConfirmationFunction<Q> = (
-  info: NavigationInfo<Q>,
+export type ConfirmationFunction = (
+  info: NavigationInfo,
   confirm: () => void,
   prevent?: () => void
 ) => void;
 
-export interface ConfirmationMethods<Q> {
+export interface ConfirmationMethods {
   confirmNavigation(
-    info: NavigationInfo<Q>,
+    info: NavigationInfo,
     confirm: () => void,
     prevent?: () => void
   ): void;
-  confirmWith(fn?: ConfirmationFunction<Q>): void;
+  confirmWith(fn?: ConfirmationFunction): void;
   removeConfirmation(): void;
 }
 
-export interface BlockingHistory<Q> {
-  confirmWith(fn?: ConfirmationFunction<Q>): void;
+export interface BlockingHistory {
+  confirmWith(fn?: ConfirmationFunction): void;
   removeConfirmation(): void;
 }

--- a/packages/root/src/types/prepareNavigate.ts
+++ b/packages/root/src/types/prepareNavigate.ts
@@ -3,21 +3,18 @@ import { SessionLocation } from "./location";
 import { LocationUtils } from "./locationUtils";
 import { KeyFns } from "./keyGenerator";
 
-export interface PreppedNavigation<Q> {
+export interface PreppedNavigation {
   action: Action;
   finish(): void;
-  location: SessionLocation<Q>;
+  location: SessionLocation;
 }
 
-export type Preparer<Q> = (
-  to: ToArgument<Q>,
-  navType: NavType
-) => PreppedNavigation<Q>;
+export type Preparer = (to: ToArgument, navType: NavType) => PreppedNavigation;
 
-export interface PrepNavigateArgs<Q> {
-  locationUtils: LocationUtils<Q>;
+export interface PrepNavigateArgs {
+  locationUtils: LocationUtils;
   keygen: KeyFns;
-  current(): SessionLocation<Q>;
-  push(l: SessionLocation<Q>): () => void;
-  replace(l: SessionLocation<Q>): () => void;
+  current(): SessionLocation;
+  push(l: SessionLocation): () => void;
+  replace(l: SessionLocation): () => void;
 }

--- a/packages/root/tests/locationUtils.spec.ts
+++ b/packages/root/tests/locationUtils.spec.ts
@@ -313,7 +313,7 @@ describe("locationFactory", () => {
         const input = {
           rawPathname: "/rawPathname",
           pathname: "/pathname"
-        } as SessionLocation<any>;
+        } as SessionLocation;
         const output = stringifyLocation(input);
         expect(output).toBe("/rawPathname");
       });

--- a/packages/root/tests/navigationConfirmation.spec.ts
+++ b/packages/root/tests/navigationConfirmation.spec.ts
@@ -50,8 +50,8 @@ describe("navigationConfirmation", () => {
 
       confirmNavigation(
         {
-          to: { pathname: "/this-is-only-a-test" } as SessionLocation<any>,
-          from: { pathname: "/this-was-not-a-test" } as SessionLocation<any>,
+          to: { pathname: "/this-is-only-a-test" } as SessionLocation,
+          from: { pathname: "/this-was-not-a-test" } as SessionLocation,
           action: "push"
         },
         confirm,
@@ -74,8 +74,8 @@ describe("navigationConfirmation", () => {
       confirmWith(allowNavigation);
       confirmNavigation(
         {
-          to: toLoc as SessionLocation<any>,
-          from: fromLoc as SessionLocation<any>,
+          to: toLoc as SessionLocation,
+          from: fromLoc as SessionLocation,
           action
         },
         confirm,
@@ -107,8 +107,8 @@ describe("navigationConfirmation", () => {
       expect(() => {
         confirmNavigation(
           {
-            to: toLoc as SessionLocation<any>,
-            from: fromLoc as SessionLocation<any>,
+            to: toLoc as SessionLocation,
+            from: fromLoc as SessionLocation,
             action
           },
           confirm

--- a/packages/root/types/locationUtils.d.ts
+++ b/packages/root/types/locationUtils.d.ts
@@ -1,2 +1,2 @@
 import { LocationUtilOptions, LocationUtils } from "./types/locationUtils";
-export default function locationFactory<Q>(options?: LocationUtilOptions<Q>): LocationUtils<Q>;
+export default function locationFactory(options?: LocationUtilOptions): LocationUtils;

--- a/packages/root/types/navigationConfirmation.d.ts
+++ b/packages/root/types/navigationConfirmation.d.ts
@@ -1,2 +1,2 @@
 import { ConfirmationMethods } from "./types/navigationConfirmation";
-export default function createNavigationConfirmation<Q>(): ConfirmationMethods<Q>;
+export default function createNavigationConfirmation(): ConfirmationMethods;

--- a/packages/root/types/prepareNavigate.d.ts
+++ b/packages/root/types/prepareNavigate.d.ts
@@ -1,2 +1,2 @@
 import { PrepNavigateArgs, Preparer } from "./types/prepareNavigate";
-export default function prepareNavigate<Q>(args: PrepNavigateArgs<Q>): Preparer<Q>;
+export default function prepareNavigate(args: PrepNavigateArgs): Preparer;

--- a/packages/root/types/types/hickory.d.ts
+++ b/packages/root/types/types/hickory.d.ts
@@ -1,11 +1,11 @@
 import { SessionLocation, AnyLocation } from "./location";
 import { Action, ResponseHandler, ToArgument, NavType } from "./navigation";
-export interface History<Q> {
-    location: SessionLocation<Q>;
+export interface History {
+    location: SessionLocation;
     action: Action;
-    toHref(to: AnyLocation<Q>): string;
-    respondWith(fn: ResponseHandler<Q>): void;
+    toHref(to: AnyLocation): string;
+    respondWith(fn: ResponseHandler): void;
     destroy(): void;
-    navigate(to: ToArgument<Q>, navType?: NavType): void;
+    navigate(to: ToArgument, navType?: NavType): void;
     go(num?: number): void;
 }

--- a/packages/root/types/types/location.d.ts
+++ b/packages/root/types/types/location.d.ts
@@ -1,14 +1,14 @@
-export interface LocationComponents<Q> {
+export interface LocationComponents {
     pathname: string;
-    query: Q;
+    query: any;
     hash: string;
     state?: any;
 }
-export declare type PartialLocation<Q> = Partial<LocationComponents<Q>>;
-export interface Location<Q> extends LocationComponents<Q> {
+export declare type PartialLocation = Partial<LocationComponents>;
+export interface Location extends LocationComponents {
     rawPathname: string;
 }
-export interface SessionLocation<Q> extends Location<Q> {
+export interface SessionLocation extends Location {
     key: string;
 }
-export declare type AnyLocation<Q> = SessionLocation<Q> | PartialLocation<Q>;
+export declare type AnyLocation = SessionLocation | PartialLocation;

--- a/packages/root/types/types/locationUtils.d.ts
+++ b/packages/root/types/types/locationUtils.d.ts
@@ -1,18 +1,18 @@
 import { Location, SessionLocation, PartialLocation } from "./location";
-export interface QueryFunctions<Q> {
+export interface QueryFunctions {
     parse: (query?: string) => Q;
     stringify: (query?: Q) => string;
 }
 export declare type RawPathname = (pathname: string) => string;
-export interface LocationUtilOptions<Q> {
-    query?: QueryFunctions<Q>;
+export interface LocationUtilOptions {
+    query?: QueryFunctions;
     decode?: boolean;
     baseSegment?: string;
     raw?: RawPathname;
 }
-export interface LocationUtils<Q> {
-    keyed(location: Location<Q>, key: string): SessionLocation<Q>;
-    genericLocation(value: string | object, state?: any): Location<Q>;
-    stringifyLocation(location: SessionLocation<Q>): string;
-    stringifyLocation(location: PartialLocation<Q>): string;
+export interface LocationUtils {
+    keyed(location: Location, key: string): SessionLocation;
+    genericLocation(value: string | object, state?: any): Location;
+    stringifyLocation(location: SessionLocation): string;
+    stringifyLocation(location: PartialLocation): string;
 }

--- a/packages/root/types/types/navigation.d.ts
+++ b/packages/root/types/types/navigation.d.ts
@@ -1,12 +1,12 @@
 import { PartialLocation, SessionLocation } from "./location";
-export declare type ToArgument<Q> = string | PartialLocation<Q>;
+export declare type ToArgument = string | PartialLocation;
 export declare type Action = "push" | "replace" | "pop";
 export declare type NavType = "anchor" | "push" | "replace";
-export interface PendingNavigation<Q> {
-    location: SessionLocation<Q>;
+export interface PendingNavigation {
+    location: SessionLocation;
     action: Action;
     finish(): void;
     cancel(nextAction?: Action): void;
     cancelled?: boolean;
 }
-export declare type ResponseHandler<Q> = (resp: PendingNavigation<Q>) => void;
+export declare type ResponseHandler = (resp: PendingNavigation) => void;

--- a/packages/root/types/types/navigationConfirmation.d.ts
+++ b/packages/root/types/types/navigationConfirmation.d.ts
@@ -1,17 +1,17 @@
 import { SessionLocation } from "./location";
 import { Action } from "./navigation";
-export interface NavigationInfo<Q> {
-    to: SessionLocation<Q>;
-    from: SessionLocation<Q>;
+export interface NavigationInfo {
+    to: SessionLocation;
+    from: SessionLocation;
     action: Action;
 }
-export declare type ConfirmationFunction<Q> = (info: NavigationInfo<Q>, confirm: () => void, prevent?: () => void) => void;
-export interface ConfirmationMethods<Q> {
-    confirmNavigation(info: NavigationInfo<Q>, confirm: () => void, prevent?: () => void): void;
-    confirmWith(fn?: ConfirmationFunction<Q>): void;
+export declare type ConfirmationFunction = (info: NavigationInfo, confirm: () => void, prevent?: () => void) => void;
+export interface ConfirmationMethods {
+    confirmNavigation(info: NavigationInfo, confirm: () => void, prevent?: () => void): void;
+    confirmWith(fn?: ConfirmationFunction): void;
     removeConfirmation(): void;
 }
-export interface BlockingHistory<Q> {
-    confirmWith(fn?: ConfirmationFunction<Q>): void;
+export interface BlockingHistory {
+    confirmWith(fn?: ConfirmationFunction): void;
     removeConfirmation(): void;
 }

--- a/packages/root/types/types/prepareNavigate.d.ts
+++ b/packages/root/types/types/prepareNavigate.d.ts
@@ -2,16 +2,16 @@ import { Action, ToArgument, NavType } from "./navigation";
 import { SessionLocation } from "./location";
 import { LocationUtils } from "./locationUtils";
 import { KeyFns } from "./keyGenerator";
-export interface PreppedNavigation<Q> {
+export interface PreppedNavigation {
     action: Action;
     finish(): void;
-    location: SessionLocation<Q>;
+    location: SessionLocation;
 }
-export declare type Preparer<Q> = (to: ToArgument<Q>, navType: NavType) => PreppedNavigation<Q>;
-export interface PrepNavigateArgs<Q> {
-    locationUtils: LocationUtils<Q>;
+export declare type Preparer = (to: ToArgument, navType: NavType) => PreppedNavigation;
+export interface PrepNavigateArgs {
+    locationUtils: LocationUtils;
     keygen: KeyFns;
-    current(): SessionLocation<Q>;
-    push(l: SessionLocation<Q>): () => void;
-    replace(l: SessionLocation<Q>): () => void;
+    current(): SessionLocation;
+    push(l: SessionLocation): () => void;
+    replace(l: SessionLocation): () => void;
 }


### PR DESCRIPTION
I would like to make `query` generic, but it make things awfully complicated, especially with link components. Maybe in the future this will get revisited, but for now `location.query` will be the unsafe `any` type.