### PR TITLE
Auto-cancelling & history.cancel()

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 5224,
-    "minified": 1847,
-    "gzipped": 785,
+    "bundled": 5615,
+    "minified": 1970,
+    "gzipped": 825,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 5259,
-    "minified": 1879,
-    "gzipped": 832
+    "bundled": 5650,
+    "minified": 2002,
+    "gzipped": 872
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 15660,
-    "minified": 4705,
-    "gzipped": 1950
+    "bundled": 16127,
+    "minified": 4855,
+    "gzipped": 2003
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 15660,
-    "minified": 4705,
-    "gzipped": 1950
+    "bundled": 16127,
+    "minified": 4855,
+    "gzipped": 2003
   }
 }

--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 5536,
-    "minified": 1994,
-    "gzipped": 844,
+    "bundled": 5006,
+    "minified": 1955,
+    "gzipped": 823,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 5557,
-    "minified": 2013,
-    "gzipped": 889
+    "bundled": 5027,
+    "minified": 1974,
+    "gzipped": 870
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 16979,
-    "minified": 5063,
-    "gzipped": 2093
+    "bundled": 17009,
+    "minified": 5157,
+    "gzipped": 2105
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 16979,
-    "minified": 5063,
-    "gzipped": 2093
+    "bundled": 17009,
+    "minified": 5157,
+    "gzipped": 2105
   }
 }

--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 5289,
-    "minified": 1962,
-    "gzipped": 827,
+    "bundled": 5536,
+    "minified": 1994,
+    "gzipped": 844,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 5310,
-    "minified": 1981,
-    "gzipped": 871
+    "bundled": 5557,
+    "minified": 2013,
+    "gzipped": 889
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 16593,
-    "minified": 4992,
-    "gzipped": 2056
+    "bundled": 16979,
+    "minified": 5063,
+    "gzipped": 2093
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 16593,
-    "minified": 4992,
-    "gzipped": 2056
+    "bundled": 16979,
+    "minified": 5063,
+    "gzipped": 2093
   }
 }

--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 5615,
-    "minified": 1970,
-    "gzipped": 825,
+    "bundled": 5289,
+    "minified": 1962,
+    "gzipped": 827,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 5650,
-    "minified": 2002,
-    "gzipped": 872
+    "bundled": 5310,
+    "minified": 1981,
+    "gzipped": 871
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 16127,
-    "minified": 4855,
-    "gzipped": 2003
+    "bundled": 16593,
+    "minified": 4992,
+    "gzipped": 2056
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 16127,
-    "minified": 4855,
-    "gzipped": 2003
+    "bundled": 16593,
+    "minified": 4992,
+    "gzipped": 2056
   }
 }

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+- Add `history.cancel` function for cancelling the active navigation.
+- The history object will automatically cancel the pending navigation when another navigation happens.
+
 ## 2.0.0-alpha.3
 
 - Remove generic `query` type.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -174,7 +174,7 @@ export function Browser(options: Options = {}): BrowserHistory {
         browserHistory.location = location;
         lastAction = "pop";
       },
-      cancel: (nextAction: Action | undefined) => {
+      cancel: (nextAction?: Action) => {
         clearPending();
 
         // popping while already popping is cumulative,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -47,7 +47,10 @@ export function Browser(options: Options = {}): BrowserHistory {
     current: () => browserHistory.location,
     push(location: SessionLocation) {
       return () => {
-        clearPending();
+        const alreadyCleared = clearPending();
+        if (alreadyCleared) {
+          return;
+        }
         const path = toHref(location);
         const { key, state } = location;
         try {
@@ -61,7 +64,10 @@ export function Browser(options: Options = {}): BrowserHistory {
     },
     replace(location: SessionLocation) {
       return () => {
-        clearPending();
+        const alreadyCleared = clearPending();
+        if (alreadyCleared) {
+          return;
+        }
         const path = toHref(location);
         const { key, state } = location;
         try {
@@ -156,16 +162,16 @@ export function Browser(options: Options = {}): BrowserHistory {
       location,
       action: "pop",
       finish: () => {
-        clearPending();
+        const alreadyCleared = clearPending();
+        if (alreadyCleared) {
+          return;
+        }
         browserHistory.location = location;
         lastAction = "pop";
       },
       cancel: (nextAction?: Action) => {
-        clearPending();
-
-        // popping while already popping is cumulative,
-        // so don't undo the original pop
-        if (nextAction === "pop") {
+        const alreadyCleared = clearPending();
+        if (alreadyCleared || nextAction === "pop") {
           return;
         }
         reverting = true;

--- a/packages/browser/tests/unit/browser.spec.ts
+++ b/packages/browser/tests/unit/browser.spec.ts
@@ -2,7 +2,7 @@ import "jest";
 import { Browser } from "../../src";
 
 import { withDOM, asyncWithDOM } from "../../../../tests/utils/dom";
-import { navigateSuite, goSuite } from "../../../../tests/cases";
+import { navigateSuite, goSuite, cancelSuite } from "../../../../tests/cases";
 
 import { TestCase, Suite } from "../../../../tests/types";
 
@@ -80,6 +80,10 @@ describe("Browser constructor", () => {
       });
     });
   });
+});
+
+describe("cancel", () => {
+  runSuite(cancelSuite);
 });
 
 describe("navigate()", () => {

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 7792,
-    "minified": 2825,
-    "gzipped": 1072,
+    "bundled": 7262,
+    "minified": 2786,
+    "gzipped": 1054,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 7962,
-    "minified": 2988,
-    "gzipped": 1121
+    "bundled": 7432,
+    "minified": 2949,
+    "gzipped": 1103
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 19165,
-    "minified": 5588,
-    "gzipped": 2242
+    "bundled": 19195,
+    "minified": 5682,
+    "gzipped": 2256
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 19165,
-    "minified": 5588,
-    "gzipped": 2242
+    "bundled": 19195,
+    "minified": 5682,
+    "gzipped": 2256
   }
 }

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 7545,
-    "minified": 2793,
-    "gzipped": 1057,
+    "bundled": 7792,
+    "minified": 2825,
+    "gzipped": 1072,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 7715,
-    "minified": 2956,
-    "gzipped": 1105
+    "bundled": 7962,
+    "minified": 2988,
+    "gzipped": 1121
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 18779,
-    "minified": 5517,
-    "gzipped": 2200
+    "bundled": 19165,
+    "minified": 5588,
+    "gzipped": 2242
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 18779,
-    "minified": 5517,
-    "gzipped": 2200
+    "bundled": 19165,
+    "minified": 5588,
+    "gzipped": 2242
   }
 }

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 7442,
-    "minified": 2684,
-    "gzipped": 1021,
+    "bundled": 7871,
+    "minified": 2801,
+    "gzipped": 1057,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 7626,
-    "minified": 2860,
-    "gzipped": 1072
+    "bundled": 8055,
+    "minified": 2977,
+    "gzipped": 1109
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 17800,
-    "minified": 5234,
-    "gzipped": 2102
+    "bundled": 18313,
+    "minified": 5380,
+    "gzipped": 2153
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 17800,
-    "minified": 5234,
-    "gzipped": 2102
+    "bundled": 18313,
+    "minified": 5380,
+    "gzipped": 2153
   }
 }

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 7871,
-    "minified": 2801,
+    "bundled": 7545,
+    "minified": 2793,
     "gzipped": 1057,
     "treeshaked": {
       "rollup": {
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 8055,
-    "minified": 2977,
-    "gzipped": 1109
+    "bundled": 7715,
+    "minified": 2956,
+    "gzipped": 1105
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 18313,
-    "minified": 5380,
-    "gzipped": 2153
+    "bundled": 18779,
+    "minified": 5517,
+    "gzipped": 2200
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 18313,
-    "minified": 5380,
-    "gzipped": 2153
+    "bundled": 18779,
+    "minified": 5517,
+    "gzipped": 2200
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+- Add `history.cancel` function for cancelling the active navigation.
+- The history object will automatically cancel the pending navigation when another navigation happens.
+
 ## 2.0.0-alpha.3
 
 - Remove generic `query` type.

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -186,7 +186,7 @@ export function Hash(options: Options = {}): HashHistory {
         hashHistory.location = location;
         lastAction = "pop";
       },
-      cancel: (nextAction: Action | undefined) => {
+      cancel: (nextAction?: Action) => {
         clearPending();
 
         // popping while already popping is cumulative,

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -52,7 +52,10 @@ export function Hash(options: Options = {}): HashHistory {
     current: () => hashHistory.location,
     push(location: SessionLocation) {
       return () => {
-        clearPending();
+        const alreadyCleared = clearPending();
+        if (alreadyCleared) {
+          return;
+        }
         const path = toHref(location);
         const { key, state } = location;
         try {
@@ -66,7 +69,10 @@ export function Hash(options: Options = {}): HashHistory {
     },
     replace(location: SessionLocation) {
       return () => {
-        clearPending();
+        const alreadyCleared = clearPending();
+        if (alreadyCleared) {
+          return;
+        }
         const path = toHref(location);
         const { key, state } = location;
         try {
@@ -168,16 +174,16 @@ export function Hash(options: Options = {}): HashHistory {
       location,
       action: "pop",
       finish: () => {
-        clearPending();
+        const alreadyCleared = clearPending();
+        if (alreadyCleared) {
+          return;
+        }
         hashHistory.location = location;
         lastAction = "pop";
       },
       cancel: (nextAction?: Action) => {
-        clearPending();
-
-        // popping while already popping is cumulative,
-        // so don't undo the original pop
-        if (nextAction === "pop") {
+        const alreadyCleared = clearPending();
+        if (alreadyCleared || nextAction === "pop") {
           return;
         }
         reverting = true;

--- a/packages/hash/tests/unit/hash.spec.ts
+++ b/packages/hash/tests/unit/hash.spec.ts
@@ -2,7 +2,7 @@ import "jest";
 import { Hash } from "../../src";
 
 import { withDOM, asyncWithDOM } from "../../../../tests/utils/dom";
-import { navigateSuite, goSuite } from "../../../../tests/cases";
+import { navigateSuite, goSuite, cancelSuite } from "../../../../tests/cases";
 
 import { TestCase, Suite } from "../../../../tests/types";
 
@@ -158,6 +158,10 @@ describe("Hash constructor", () => {
       });
     });
   });
+});
+
+describe("cancel", () => {
+  runSuite(cancelSuite);
 });
 
 describe("navigate()", () => {

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5401,
-    "minified": 1576,
-    "gzipped": 635,
+    "bundled": 5033,
+    "minified": 1559,
+    "gzipped": 631,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5462,
-    "minified": 1632,
-    "gzipped": 682
+    "bundled": 5080,
+    "minified": 1602,
+    "gzipped": 675
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15115,
-    "minified": 4391,
-    "gzipped": 1797
+    "bundled": 15535,
+    "minified": 4519,
+    "gzipped": 1843
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15115,
-    "minified": 4391,
-    "gzipped": 1797
+    "bundled": 15535,
+    "minified": 4519,
+    "gzipped": 1843
   }
 }

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5033,
-    "minified": 1559,
-    "gzipped": 631,
+    "bundled": 5552,
+    "minified": 1572,
+    "gzipped": 637,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5080,
-    "minified": 1602,
-    "gzipped": 675
+    "bundled": 5599,
+    "minified": 1615,
+    "gzipped": 680
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15535,
-    "minified": 4519,
-    "gzipped": 1843
+    "bundled": 16213,
+    "minified": 4571,
+    "gzipped": 1870
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15535,
-    "minified": 4519,
-    "gzipped": 1843
+    "bundled": 16213,
+    "minified": 4571,
+    "gzipped": 1870
   }
 }

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5552,
-    "minified": 1572,
-    "gzipped": 637,
+    "bundled": 4785,
+    "minified": 1557,
+    "gzipped": 630,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5599,
-    "minified": 1615,
-    "gzipped": 680
+    "bundled": 4832,
+    "minified": 1600,
+    "gzipped": 675
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 16213,
-    "minified": 4571,
-    "gzipped": 1870
+    "bundled": 15990,
+    "minified": 4680,
+    "gzipped": 1893
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 16213,
-    "minified": 4571,
-    "gzipped": 1870
+    "bundled": 15990,
+    "minified": 4680,
+    "gzipped": 1893
   }
 }

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 4769,
-    "minified": 1443,
-    "gzipped": 591,
+    "bundled": 5401,
+    "minified": 1576,
+    "gzipped": 635,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 4830,
-    "minified": 1499,
-    "gzipped": 638
+    "bundled": 5462,
+    "minified": 1632,
+    "gzipped": 682
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 14399,
-    "minified": 4237,
-    "gzipped": 1752
+    "bundled": 15115,
+    "minified": 4391,
+    "gzipped": 1797
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 14399,
-    "minified": 4237,
-    "gzipped": 1752
+    "bundled": 15115,
+    "minified": 4391,
+    "gzipped": 1797
   }
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Next
 
+- Add `history.cancel` function for cancelling the active navigation.
+- The history object will automatically cancel the pending navigation when another navigation happens.
 - Remove `history.locations` and `history.index` values.
-- `go` emulates browser behavior by setting `history.index` immediately instead of when the navigation is finished. This means that a subsequent `go` call will be based on the pending `index`, not the index of the current `history.location`.
+- `go` emulates browser behavior by setting `index` immediately instead of when the navigation is finished. This means that a subsequent `go` call will be based on the pending `index`, not the index of the current `history.location`.
 
 ## 2.0.0-alpha.3
 

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -56,7 +56,10 @@ export function InMemory(options: Options = {}): InMemoryHistory {
     current: () => memoryHistory.location,
     push(location: SessionLocation) {
       return () => {
-        clearPending();
+        const alreadyCleared = clearPending();
+        if (alreadyCleared) {
+          return;
+        }
         memoryHistory.location = location;
         index++;
         locations = [...locations.slice(0, index), location];
@@ -65,7 +68,10 @@ export function InMemory(options: Options = {}): InMemoryHistory {
     },
     replace(location: SessionLocation) {
       return () => {
-        clearPending();
+        const alreadyCleared = clearPending();
+        if (alreadyCleared) {
+          return;
+        }
         memoryHistory.location = location;
         locations[index] = memoryHistory.location;
         lastAction = "replace";
@@ -119,7 +125,10 @@ export function InMemory(options: Options = {}): InMemoryHistory {
           location: memoryHistory.location,
           action: "pop",
           finish: () => {
-            clearPending();
+            const alreadyCleared = clearPending();
+            if (alreadyCleared) {
+              return;
+            }
             lastAction = "pop";
           },
           cancel: clearPending
@@ -139,13 +148,16 @@ export function InMemory(options: Options = {}): InMemoryHistory {
           location,
           action: "pop",
           finish: () => {
-            clearPending();
+            const alreadyCleared = clearPending();
+            if (alreadyCleared) {
+              return;
+            }
             memoryHistory.location = location;
             lastAction = "pop";
           },
           cancel: (nextAction?: Action) => {
-            clearPending();
-            if (nextAction === "pop") {
+            const alreadyCleared = clearPending();
+            if (alreadyCleared || nextAction === "pop") {
               return;
             }
             index = originalIndex;

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -159,7 +159,7 @@ export function InMemory(options: Options = {}): InMemoryHistory {
             memoryHistory.location = location;
             lastAction = "pop";
           },
-          cancel: (nextAction: Action | undefined) => {
+          cancel: (nextAction?: Action) => {
             clearPending();
             if (nextAction === "pop") {
               return;

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -24,6 +24,8 @@ import {
 
 export * from "./types";
 
+function noop() {}
+
 export function InMemory(options: Options = {}): InMemoryHistory {
   const locationUtilities = locationUtils(options);
   const keygen = keyGenerator();
@@ -44,22 +46,13 @@ export function InMemory(options: Options = {}): InMemoryHistory {
       )
     );
   }
-  const {
-    emitNavigation,
-    clearPending,
-    cancelPending,
-    setHandler
-  } = navigationHandler();
+  const { emitNavigation, cancelPending, setHandler } = navigationHandler();
   const prep = prepareNavigate({
     locationUtils: locationUtilities,
     keygen,
     current: () => memoryHistory.location,
     push(location: SessionLocation) {
       return () => {
-        const alreadyCleared = clearPending();
-        if (alreadyCleared) {
-          return;
-        }
         memoryHistory.location = location;
         index++;
         locations = [...locations.slice(0, index), location];
@@ -68,10 +61,6 @@ export function InMemory(options: Options = {}): InMemoryHistory {
     },
     replace(location: SessionLocation) {
       return () => {
-        const alreadyCleared = clearPending();
-        if (alreadyCleared) {
-          return;
-        }
         memoryHistory.location = location;
         locations[index] = memoryHistory.location;
         lastAction = "replace";
@@ -98,8 +87,8 @@ export function InMemory(options: Options = {}): InMemoryHistory {
       emitNavigation({
         location: memoryHistory.location,
         action: lastAction,
-        finish: clearPending,
-        cancel: clearPending
+        finish: noop,
+        cancel: noop
       });
     },
     toHref,
@@ -116,7 +105,7 @@ export function InMemory(options: Options = {}): InMemoryHistory {
         location: next.location,
         action: next.action,
         finish: next.finish,
-        cancel: clearPending
+        cancel: noop
       });
     },
     go(num?: number): void {
@@ -125,13 +114,9 @@ export function InMemory(options: Options = {}): InMemoryHistory {
           location: memoryHistory.location,
           action: "pop",
           finish: () => {
-            const alreadyCleared = clearPending();
-            if (alreadyCleared) {
-              return;
-            }
             lastAction = "pop";
           },
-          cancel: clearPending
+          cancel: noop
         });
       } else {
         const originalIndex = index;
@@ -148,16 +133,11 @@ export function InMemory(options: Options = {}): InMemoryHistory {
           location,
           action: "pop",
           finish: () => {
-            const alreadyCleared = clearPending();
-            if (alreadyCleared) {
-              return;
-            }
             memoryHistory.location = location;
             lastAction = "pop";
           },
           cancel: (nextAction?: Action) => {
-            const alreadyCleared = clearPending();
-            if (alreadyCleared || nextAction === "pop") {
+            if (nextAction === "pop") {
               return;
             }
             index = originalIndex;
@@ -175,8 +155,8 @@ export function InMemory(options: Options = {}): InMemoryHistory {
       emitNavigation({
         location: memoryHistory.location,
         action: lastAction,
-        finish: clearPending,
-        cancel: clearPending
+        finish: noop,
+        cancel: noop
       });
     }
   };

--- a/packages/in-memory/tests/in-memory.spec.ts
+++ b/packages/in-memory/tests/in-memory.spec.ts
@@ -1,7 +1,7 @@
 import "jest";
 import { InMemory } from "../src";
 
-import { navigateSuite, goSuite } from "../../../tests/cases";
+import { navigateSuite, goSuite, cancelSuite } from "../../../tests/cases";
 import { ignoreFirstCall } from "../../../tests/utils/ignoreFirst";
 
 import { TestCase, Suite } from "../../../tests/types";
@@ -103,6 +103,10 @@ describe("Memory constructor", () => {
       expect(pending.action).toBe("push");
     });
   });
+});
+
+describe("cancel", () => {
+  runSuite(cancelSuite);
 });
 
 describe("navigate()", () => {

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 8273,
-    "minified": 3328,
-    "gzipped": 1405,
+    "bundled": 9076,
+    "minified": 3573,
+    "gzipped": 1486,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 8393,
-    "minified": 3434,
-    "gzipped": 1440
+    "bundled": 9203,
+    "minified": 3684,
+    "gzipped": 1522
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 10141,
-    "minified": 3278,
-    "gzipped": 1466
+    "bundled": 11083,
+    "minified": 3503,
+    "gzipped": 1542
   },
   "dist/hickory-root.min.js": {
-    "bundled": 10141,
-    "minified": 3278,
-    "gzipped": 1466
+    "bundled": 11083,
+    "minified": 3503,
+    "gzipped": 1542
   }
 }

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 9076,
-    "minified": 3573,
-    "gzipped": 1486,
+    "bundled": 9175,
+    "minified": 3612,
+    "gzipped": 1504,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 9203,
-    "minified": 3684,
-    "gzipped": 1522
+    "bundled": 9302,
+    "minified": 3723,
+    "gzipped": 1540
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 11083,
-    "minified": 3503,
-    "gzipped": 1542
+    "bundled": 11194,
+    "minified": 3542,
+    "gzipped": 1561
   },
   "dist/hickory-root.min.js": {
-    "bundled": 11083,
-    "minified": 3503,
-    "gzipped": 1542
+    "bundled": 11194,
+    "minified": 3542,
+    "gzipped": 1561
   }
 }

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 9175,
-    "minified": 3612,
-    "gzipped": 1504,
+    "bundled": 9718,
+    "minified": 3752,
+    "gzipped": 1544,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 9302,
-    "minified": 3723,
-    "gzipped": 1540
+    "bundled": 9866,
+    "minified": 3884,
+    "gzipped": 1585
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 11194,
-    "minified": 3542,
-    "gzipped": 1561
+    "bundled": 11802,
+    "minified": 3687,
+    "gzipped": 1608
   },
   "dist/hickory-root.min.js": {
-    "bundled": 11194,
-    "minified": 3542,
-    "gzipped": 1561
+    "bundled": 11802,
+    "minified": 3687,
+    "gzipped": 1608
   }
 }

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Add `cancel` method to `History` interface
+
 ## 2.0.0-alpha.3
 
 - Remove generic `query` type.

--- a/packages/root/src/index.ts
+++ b/packages/root/src/index.ts
@@ -4,5 +4,12 @@ import locationUtils from "./locationUtils";
 import keyGenerator from "./keyGenerator";
 import prepareNavigate from "./prepareNavigate";
 import navigationConfirmation from "./navigationConfirmation";
+import navigationHandler from "./navigationHandler";
 
-export { locationUtils, keyGenerator, navigationConfirmation, prepareNavigate };
+export {
+  locationUtils,
+  keyGenerator,
+  navigationConfirmation,
+  prepareNavigate,
+  navigationHandler
+};

--- a/packages/root/src/navigationHandler.ts
+++ b/packages/root/src/navigationHandler.ts
@@ -12,10 +12,13 @@ export default function responder() {
     responseHandler(nav);
   }
 
-  function clearPending() {
+  function clearPending(): boolean {
     if (pending) {
+      let retVal = !!pending.cancelled;
       pending = undefined;
+      return retVal;
     }
+    return true;
   }
 
   function cancelPending(action?: Action) {

--- a/packages/root/src/navigationHandler.ts
+++ b/packages/root/src/navigationHandler.ts
@@ -1,0 +1,39 @@
+import { ResponseHandler, PendingNavigation, Action } from "./types/navigation";
+
+export default function responder() {
+  let responseHandler: ResponseHandler | undefined;
+  let pending: PendingNavigation | undefined;
+
+  function emitNavigation(nav: PendingNavigation) {
+    if (!responseHandler) {
+      return;
+    }
+    pending = nav;
+    responseHandler(nav);
+  }
+
+  function clearPending() {
+    if (pending) {
+      pending = undefined;
+    }
+  }
+
+  function cancelPending(action?: Action) {
+    if (pending) {
+      pending.cancelled = true;
+      pending.cancel(action);
+      pending = undefined;
+    }
+  }
+
+  function setHandler(fn: ResponseHandler) {
+    responseHandler = fn;
+  }
+
+  return {
+    emitNavigation,
+    clearPending,
+    cancelPending,
+    setHandler
+  };
+}

--- a/packages/root/src/types/hickory.ts
+++ b/packages/root/src/types/hickory.ts
@@ -5,6 +5,7 @@ export interface History {
   location: SessionLocation;
   toHref(to: AnyLocation): string;
   respondWith(fn: ResponseHandler): void;
+  cancel(): void;
   destroy(): void;
   navigate(to: ToArgument, navType?: NavType): void;
   go(num?: number): void;

--- a/packages/root/src/types/index.ts
+++ b/packages/root/src/types/index.ts
@@ -13,7 +13,8 @@ export {
   Action,
   NavType,
   PendingNavigation,
-  ResponseHandler
+  ResponseHandler,
+  CancelNavigation
 } from "./navigation";
 
 export { KeyFns } from "./keyGenerator";

--- a/packages/root/src/types/locationUtils.ts
+++ b/packages/root/src/types/locationUtils.ts
@@ -1,8 +1,8 @@
 import { Location, SessionLocation, PartialLocation } from "./location";
 
 export interface QueryFunctions {
-  parse: (query?: string) => Q;
-  stringify: (query?: Q) => string;
+  parse: (query?: string) => any;
+  stringify: (query?: any) => string;
 }
 
 export type RawPathname = (pathname: string) => string;

--- a/packages/root/src/types/navigation.ts
+++ b/packages/root/src/types/navigation.ts
@@ -4,12 +4,12 @@ export type ToArgument = string | PartialLocation;
 
 export type Action = "push" | "replace" | "pop";
 export type NavType = "anchor" | "push" | "replace";
-
+export type CancelNavigation = (nextAction: Action | undefined) => void;
 export interface PendingNavigation {
   location: SessionLocation;
   action: Action;
   finish(): void;
-  cancel(nextAction?: Action): void;
+  cancel: CancelNavigation;
   cancelled?: boolean;
 }
 

--- a/packages/root/src/types/navigation.ts
+++ b/packages/root/src/types/navigation.ts
@@ -4,7 +4,7 @@ export type ToArgument = string | PartialLocation;
 
 export type Action = "push" | "replace" | "pop";
 export type NavType = "anchor" | "push" | "replace";
-export type CancelNavigation = (nextAction: Action | undefined) => void;
+export type CancelNavigation = (nextAction?: Action) => void;
 export interface PendingNavigation {
   location: SessionLocation;
   action: Action;

--- a/packages/root/tests/navigationHandler.spec.ts
+++ b/packages/root/tests/navigationHandler.spec.ts
@@ -1,0 +1,211 @@
+import "jest";
+import { navigationHandler } from "../src";
+
+import { PendingNavigation, SessionLocation } from "@hickory/root";
+
+const locationOne: SessionLocation = {
+  pathname: "/one",
+  hash: "",
+  query: "",
+  key: "1.0",
+  rawPathname: "/one"
+};
+
+const locationTwo: SessionLocation = {
+  pathname: "/two",
+  hash: "",
+  query: "",
+  key: "2.0",
+  rawPathname: "/two"
+};
+
+describe("navigationHandler", () => {
+  describe("emitNavigation", () => {
+    // TODO: test what happens if there is no response handler?
+    // aka how to test that nothing happens...
+
+    it("calls response handler set using setHandler", () => {
+      const handler = jest.fn();
+      const { emitNavigation, setHandler } = navigationHandler();
+      setHandler(handler);
+      emitNavigation({} as PendingNavigation);
+      expect(handler.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe("cancelPending", () => {
+    it("calls the pending navigation's cancel method with action", () => {
+      const finish = jest.fn();
+      const cancel = jest.fn();
+      const { emitNavigation, setHandler, cancelPending } = navigationHandler();
+      setHandler(pending => {
+        cancelPending("pop");
+        expect(cancel.mock.calls.length).toBe(1);
+      });
+      emitNavigation({
+        location: locationOne,
+        action: "push",
+        finish,
+        cancel
+      });
+    });
+  });
+
+  describe("finish", () => {
+    it("does nothing if not the current pending", () => {
+      const finishOne = jest.fn();
+      const finishTwo = jest.fn();
+      const cancelOne = jest.fn();
+      const cancelTwo = jest.fn();
+      const { emitNavigation, setHandler } = navigationHandler();
+      let calls = 0;
+
+      let originalPending;
+      setHandler(pending => {
+        switch (calls++) {
+          case 0:
+            originalPending = pending;
+            break;
+          case 1:
+            pending.finish();
+            expect(finishTwo.mock.calls.length).toBe(1);
+            originalPending.finish();
+            expect(finishOne.mock.calls.length).toBe(0);
+        }
+      });
+
+      emitNavigation({
+        location: locationOne,
+        action: "push",
+        finish: finishOne,
+        cancel: cancelOne
+      });
+
+      emitNavigation({
+        location: locationTwo,
+        action: "push",
+        finish: finishTwo,
+        cancel: cancelTwo
+      });
+    });
+
+    it("does nothing if already called", () => {
+      const finishOne = jest.fn();
+      const cancelOne = jest.fn();
+      const { emitNavigation, setHandler } = navigationHandler();
+
+      setHandler(pending => {
+        pending.finish();
+        expect(finishOne.mock.calls.length).toBe(1);
+        pending.finish();
+        expect(finishOne.mock.calls.length).toBe(1);
+      });
+
+      emitNavigation({
+        location: locationOne,
+        action: "push",
+        finish: finishOne,
+        cancel: cancelOne
+      });
+    });
+
+    it("does nothing if already cancelled", () => {
+      const finishOne = jest.fn();
+      const cancelOne = jest.fn();
+      const { emitNavigation, setHandler } = navigationHandler();
+
+      setHandler(pending => {
+        pending.cancel();
+        expect(finishOne.mock.calls.length).toBe(0);
+        pending.finish();
+        expect(finishOne.mock.calls.length).toBe(0);
+      });
+
+      emitNavigation({
+        location: locationOne,
+        action: "push",
+        finish: finishOne,
+        cancel: cancelOne
+      });
+    });
+  });
+
+  describe("cancel", () => {
+    it("does nothing if not the current pending", () => {
+      const finishOne = jest.fn();
+      const finishTwo = jest.fn();
+      const cancelOne = jest.fn();
+      const cancelTwo = jest.fn();
+      const { emitNavigation, setHandler } = navigationHandler();
+      let calls = 0;
+
+      let originalPending;
+      setHandler(pending => {
+        switch (calls++) {
+          case 0:
+            originalPending = pending;
+            break;
+          case 1:
+            pending.finish();
+            expect(finishTwo.mock.calls.length).toBe(1);
+            originalPending.cancel();
+            expect(cancelOne.mock.calls.length).toBe(0);
+        }
+      });
+
+      emitNavigation({
+        location: locationOne,
+        action: "push",
+        finish: finishOne,
+        cancel: cancelOne
+      });
+
+      emitNavigation({
+        location: locationTwo,
+        action: "push",
+        finish: finishTwo,
+        cancel: cancelTwo
+      });
+    });
+
+    it("does nothing if already called", () => {
+      const finishOne = jest.fn();
+      const cancelOne = jest.fn();
+      const { emitNavigation, setHandler } = navigationHandler();
+
+      setHandler(pending => {
+        pending.cancel();
+        expect(cancelOne.mock.calls.length).toBe(1);
+        pending.cancel();
+        expect(cancelOne.mock.calls.length).toBe(1);
+      });
+
+      emitNavigation({
+        location: locationOne,
+        action: "push",
+        finish: finishOne,
+        cancel: cancelOne
+      });
+    });
+
+    it("does nothing if already cancelled", () => {
+      const finishOne = jest.fn();
+      const cancelOne = jest.fn();
+      const { emitNavigation, setHandler } = navigationHandler();
+
+      setHandler(pending => {
+        pending.cancel();
+        expect(cancelOne.mock.calls.length).toBe(1);
+        pending.cancel();
+        expect(cancelOne.mock.calls.length).toBe(1);
+      });
+
+      emitNavigation({
+        location: locationOne,
+        action: "push",
+        finish: finishOne,
+        cancel: cancelOne
+      });
+    });
+  });
+});

--- a/packages/root/types/index.d.ts
+++ b/packages/root/types/index.d.ts
@@ -3,4 +3,5 @@ import locationUtils from "./locationUtils";
 import keyGenerator from "./keyGenerator";
 import prepareNavigate from "./prepareNavigate";
 import navigationConfirmation from "./navigationConfirmation";
-export { locationUtils, keyGenerator, navigationConfirmation, prepareNavigate };
+import navigationHandler from "./navigationHandler";
+export { locationUtils, keyGenerator, navigationConfirmation, prepareNavigate, navigationHandler };

--- a/packages/root/types/navigationHandler.d.ts
+++ b/packages/root/types/navigationHandler.d.ts
@@ -1,0 +1,7 @@
+import { ResponseHandler, PendingNavigation } from "./types/navigation";
+export default function responder(): {
+    emitNavigation: (nav: PendingNavigation) => void;
+    clearPending: () => void;
+    cancelPending: (action?: "push" | "replace" | "pop" | undefined) => void;
+    setHandler: (fn: ResponseHandler) => void;
+};

--- a/packages/root/types/navigationHandler.d.ts
+++ b/packages/root/types/navigationHandler.d.ts
@@ -1,7 +1,6 @@
 import { ResponseHandler, PendingNavigation } from "./types/navigation";
-export default function responder(): {
+export default function navigationHandler(): {
     emitNavigation: (nav: PendingNavigation) => void;
-    clearPending: () => boolean;
     cancelPending: (action?: "push" | "replace" | "pop" | undefined) => void;
     setHandler: (fn: ResponseHandler) => void;
 };

--- a/packages/root/types/navigationHandler.d.ts
+++ b/packages/root/types/navigationHandler.d.ts
@@ -1,7 +1,7 @@
 import { ResponseHandler, PendingNavigation } from "./types/navigation";
 export default function responder(): {
     emitNavigation: (nav: PendingNavigation) => void;
-    clearPending: () => void;
+    clearPending: () => boolean;
     cancelPending: (action?: "push" | "replace" | "pop" | undefined) => void;
     setHandler: (fn: ResponseHandler) => void;
 };

--- a/packages/root/types/types/hickory.d.ts
+++ b/packages/root/types/types/hickory.d.ts
@@ -4,6 +4,7 @@ export interface History {
     location: SessionLocation;
     toHref(to: AnyLocation): string;
     respondWith(fn: ResponseHandler): void;
+    cancel(): void;
     destroy(): void;
     navigate(to: ToArgument, navType?: NavType): void;
     go(num?: number): void;

--- a/packages/root/types/types/index.d.ts
+++ b/packages/root/types/types/index.d.ts
@@ -1,6 +1,6 @@
 export { History } from "./hickory";
 export { LocationComponents, PartialLocation, SessionLocation, AnyLocation, Location } from "./location";
-export { ToArgument, Action, NavType, PendingNavigation, ResponseHandler } from "./navigation";
+export { ToArgument, Action, NavType, PendingNavigation, ResponseHandler, CancelNavigation } from "./navigation";
 export { KeyFns } from "./keyGenerator";
 export { LocationUtilOptions, QueryFunctions, RawPathname, LocationUtils } from "./locationUtils";
 export { NavigationInfo, ConfirmationFunction, ConfirmationMethods, BlockingHistory } from "./navigationConfirmation";

--- a/packages/root/types/types/locationUtils.d.ts
+++ b/packages/root/types/types/locationUtils.d.ts
@@ -1,7 +1,7 @@
 import { Location, SessionLocation, PartialLocation } from "./location";
 export interface QueryFunctions {
-    parse: (query?: string) => Q;
-    stringify: (query?: Q) => string;
+    parse: (query?: string) => any;
+    stringify: (query?: any) => string;
 }
 export declare type RawPathname = (pathname: string) => string;
 export interface LocationUtilOptions {

--- a/packages/root/types/types/navigation.d.ts
+++ b/packages/root/types/types/navigation.d.ts
@@ -2,11 +2,12 @@ import { PartialLocation, SessionLocation } from "./location";
 export declare type ToArgument = string | PartialLocation;
 export declare type Action = "push" | "replace" | "pop";
 export declare type NavType = "anchor" | "push" | "replace";
+export declare type CancelNavigation = (nextAction: Action | undefined) => void;
 export interface PendingNavigation {
     location: SessionLocation;
     action: Action;
     finish(): void;
-    cancel(nextAction?: Action): void;
+    cancel: CancelNavigation;
     cancelled?: boolean;
 }
 export declare type ResponseHandler = (resp: PendingNavigation) => void;

--- a/packages/root/types/types/navigation.d.ts
+++ b/packages/root/types/types/navigation.d.ts
@@ -2,7 +2,7 @@ import { PartialLocation, SessionLocation } from "./location";
 export declare type ToArgument = string | PartialLocation;
 export declare type Action = "push" | "replace" | "pop";
 export declare type NavType = "anchor" | "push" | "replace";
-export declare type CancelNavigation = (nextAction: Action | undefined) => void;
+export declare type CancelNavigation = (nextAction?: Action) => void;
 export interface PendingNavigation {
     location: SessionLocation;
     action: Action;

--- a/tests/cases/cancel/cancel-call.ts
+++ b/tests/cases/cancel/cancel-call.ts
@@ -3,7 +3,7 @@ import "jest";
 import { AsyncTestCaseArgs } from "../../types";
 
 export default {
-  msg: "pop is cancelled if there is a pop before pending response finishes",
+  msg: "cancels the pending navigation",
   async: true,
   assertions: 1,
   fn: function({ history, resolve }: AsyncTestCaseArgs) {
@@ -35,15 +35,15 @@ export default {
           history.go(-2);
           break;
         case 6:
-          history.go(-1);
-          break;
-        case 7:
+          history.cancel();
           pending.finish();
-          expect(history.location).toMatchObject({
-            pathname: "/three",
-            key: "2.0"
-          });
-          resolve();
+          setTimeout(() => {
+            expect(history.location).toMatchObject({
+              pathname: "/six",
+              key: "5.0"
+            });
+            resolve();
+          }, 25);
       }
     });
   }

--- a/tests/cases/cancel/index.ts
+++ b/tests/cases/cancel/index.ts
@@ -1,0 +1,5 @@
+import CancelCall from "./cancel-call";
+
+import { Suite } from "../../types";
+
+export const cancelSuite: Suite = [CancelCall];

--- a/tests/cases/go/cancel-with-push.ts
+++ b/tests/cases/go/cancel-with-push.ts
@@ -8,32 +8,44 @@ export default {
   async: true,
   assertions: 1,
   fn: function({ history, resolve }: AsyncTestCaseArgs) {
-    function initialRouter(pending) {
-      pending.finish();
-    }
-    let cancelGo;
-    const goRouter = ignoreFirstCall(function(pending) {
-      cancelGo = pending.cancel;
-      // trigger a push call and don't resolve the go
-      history.respondWith(pushRouter);
-      history.navigate("/seven", "push");
+    let calls = 0;
+    history.respondWith(pending => {
+      switch (calls++) {
+        case 0:
+          pending.finish();
+          history.navigate("/two", "push");
+          break;
+        case 1:
+          pending.finish();
+          history.navigate("/three", "push");
+          break;
+        case 2:
+          pending.finish();
+          history.navigate("/four", "push");
+          break;
+        case 3:
+          pending.finish();
+          history.navigate("/five", "push");
+          break;
+        case 4:
+          pending.finish();
+          history.navigate("/six", "push");
+          break;
+        case 5:
+          pending.finish();
+          history.go(-2);
+          break;
+        case 6:
+          history.navigate("/seven", "push");
+          break;
+        case 7:
+          pending.finish();
+          expect(history.location).toMatchObject({
+            pathname: "/seven",
+            key: "6.0"
+          });
+          resolve();
+      }
     });
-    const pushRouter = ignoreFirstCall(function(pending) {
-      cancelGo("push");
-      setTimeout(() => {
-        expect(history.location.pathname).toBe("/six");
-        resolve();
-      }, 50);
-    });
-
-    history.respondWith(initialRouter);
-    history.navigate("/two", "push"); // 1.0
-    history.navigate("/three", "push"); // 2.0
-    history.navigate("/four", "push"); // 3.0
-    history.navigate("/five", "push"); // 4.0
-    history.navigate("/six", "push"); // 5.0
-
-    history.respondWith(goRouter);
-    history.go(-2);
   }
 };

--- a/tests/cases/index.ts
+++ b/tests/cases/index.ts
@@ -1,4 +1,5 @@
 import { navigateSuite } from "./navigate";
 import { goSuite } from "./go";
+import { cancelSuite } from "./cancel";
 
-export { navigateSuite, goSuite };
+export { navigateSuite, goSuite, cancelSuite };

--- a/tests/cases/navigate/cancel-call-location.ts
+++ b/tests/cases/navigate/cancel-call-location.ts
@@ -3,7 +3,7 @@ import { ignoreFirstCall } from "../../utils/ignoreFirst";
 import { TestCaseArgs } from "../../types";
 
 export default {
-  msg: "calling cancel does not update history's location or action",
+  msg: "calling cancel maintains current location",
   fn: function({ history }: TestCaseArgs) {
     let router = ignoreFirstCall(function(pending) {
       expect(history.location.pathname).toBe("/one");

--- a/tests/cases/navigate/finish-not-called.ts
+++ b/tests/cases/navigate/finish-not-called.ts
@@ -4,7 +4,7 @@ export default {
   msg: "does nothing if pending.finish() is not called",
   fn: function({ history }: TestCaseArgs) {
     function router() {}
-    history.respondWith(router); // calls router
+    history.respondWith(router);
     history.navigate("/two");
     expect(history.location.pathname).toBe("/one");
   }

--- a/tests/cases/navigate/finish-sets-location.ts
+++ b/tests/cases/navigate/finish-sets-location.ts
@@ -6,7 +6,7 @@ export default {
     function router(pending) {
       pending.finish();
     }
-    history.respondWith(router); // calls router
+    history.respondWith(router);
     history.navigate("/next");
     expect(history.location).toMatchObject({
       pathname: "/next"

--- a/tests/cases/navigate/push-increments-key-major.ts
+++ b/tests/cases/navigate/push-increments-key-major.ts
@@ -6,7 +6,7 @@ export default {
     function router(pending) {
       pending.finish();
     }
-    history.respondWith(router); // calls router
+    history.respondWith(router);
 
     const [initMajor] = history.location.key.split(".");
     const initMajorNum = parseInt(initMajor, 10);

--- a/tests/cases/navigate/replace-increments-key-minor.ts
+++ b/tests/cases/navigate/replace-increments-key-minor.ts
@@ -6,7 +6,7 @@ export default {
     function router(pending) {
       pending.finish();
     }
-    history.respondWith(router); // calls router
+    history.respondWith(router);
 
     const [initMajor, initMinor] = history.location.key.split(".");
     const initMajorNum = parseInt(initMajor, 10);


### PR DESCRIPTION
A `history` instance stores a currently pending navigation. When a navigation happens, it will check to see if it has a pending navigation and cancel it.

A `history` instance now has a `cancel` method for cancelling the currently pending navigation.

```js
history.navigate("/somewhere-that-will-take-a-while-to-finish");
history.cancel();
```