### PR TITLE
 Convert key to two number tuple

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 5249,
-    "minified": 1883,
-    "gzipped": 826,
+    "bundled": 5196,
+    "minified": 1874,
+    "gzipped": 823,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 5287,
-    "minified": 1918,
-    "gzipped": 867
+    "bundled": 5234,
+    "minified": 1909,
+    "gzipped": 862
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 17148,
-    "minified": 5053,
-    "gzipped": 2112
+    "bundled": 16781,
+    "minified": 4901,
+    "gzipped": 2042
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 17148,
-    "minified": 5053,
-    "gzipped": 2112
+    "bundled": 16781,
+    "minified": 4901,
+    "gzipped": 2042
   }
 }

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- `location.key` is now a two number tuple (`[1, 0]` instead of `1.0`).
 - Add `history.current` function that emits a navigation for the current location (with a no-op functions for finishing and cancelling the navigation).
 - `Browser` returns a pending history function. The "real" history object is created by passing a response handler to the pending history.
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -111,9 +111,7 @@ export function Browser(options: Options = {}): PendingBrowserHistory {
       cancelPending("pop");
 
       const location = locationFromBrowser(event.state);
-      const currentKey = browserHistory.location.key;
-      const diff = keygen.diff(currentKey, location.key);
-
+      const diff = browserHistory.location.key[0] - location.key[0];
       const navigation = createNavigation(
         location,
         "pop",
@@ -126,7 +124,7 @@ export function Browser(options: Options = {}): PendingBrowserHistory {
             return;
           }
           reverting = true;
-          window.history.go(-1 * diff);
+          window.history.go(diff);
         }
       );
 

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -57,7 +57,7 @@ describe("browser integration tests", () => {
         );
         const { state, key } = testHistory.location;
         expect(window.history.state.state).toEqual(state);
-        expect(window.history.state.key).toBe(key);
+        expect(window.history.state.key).toEqual(key);
       });
     });
 
@@ -82,7 +82,7 @@ describe("browser integration tests", () => {
         );
         const { state, key } = testHistory.location;
         expect(window.history.state.state).toEqual(state);
-        expect(window.history.state.key).toBe(key);
+        expect(window.history.state.key).toEqual(key);
       });
     });
   });

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 7407,
-    "minified": 2711,
-    "gzipped": 1046,
+    "bundled": 7354,
+    "minified": 2702,
+    "gzipped": 1042,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 7594,
-    "minified": 2890,
-    "gzipped": 1099
+    "bundled": 7541,
+    "minified": 2881,
+    "gzipped": 1094
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 19224,
-    "minified": 5575,
-    "gzipped": 2253
+    "bundled": 18857,
+    "minified": 5423,
+    "gzipped": 2183
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 19224,
-    "minified": 5575,
-    "gzipped": 2253
+    "bundled": 18857,
+    "minified": 5423,
+    "gzipped": 2183
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- `location.key` is now a two number tuple (`[1, 0]` instead of `1.0`).
 - Add `history.current` function that emits a navigation for the current location (with a no-op functions for finishing and cancelling the navigation).
 - `Hash` returns a pending history function. The "real" history object is created by passing a response handler to the pending history.
 

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -121,8 +121,7 @@ export function Hash(options: Options = {}): PendingHashHistory {
       cancelPending("pop");
 
       const location: SessionLocation = locationFromBrowser(event.state);
-      const currentKey: string = hashHistory.location.key;
-      const diff: number = keygen.diff(currentKey, location.key);
+      const diff = hashHistory.location.key[0] - location.key[0];
 
       const navigation = createNavigation(
         location,
@@ -136,7 +135,7 @@ export function Hash(options: Options = {}): PendingHashHistory {
             return;
           }
           reverting = true;
-          window.history.go(-1 * diff);
+          window.history.go(diff);
         }
       );
       emitNavigation(navigation);

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -60,7 +60,7 @@ describe("hash integration tests", () => {
         );
         const { state, key } = testHistory.location;
         expect(window.history.state.state).toEqual(state);
-        expect(window.history.state.key).toBe(key);
+        expect(window.history.state.key).toEqual(key);
       });
     });
 
@@ -85,7 +85,7 @@ describe("hash integration tests", () => {
         );
         const { state, key } = testHistory.location;
         expect(window.history.state.state).toEqual(state);
-        expect(window.history.state.key).toBe(key);
+        expect(window.history.state.key).toEqual(key);
       });
     });
   });

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 678
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15922,
-    "minified": 4538,
-    "gzipped": 1908
+    "bundled": 15612,
+    "minified": 4395,
+    "gzipped": 1850
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15922,
-    "minified": 4538,
-    "gzipped": 1908
+    "bundled": 15612,
+    "minified": 4395,
+    "gzipped": 1850
   }
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- `location.key` is now a two number tuple (`[1, 0]` instead of `1.0`).
 - Add `history.current` function that emits a navigation for the current location (with a no-op functions for finishing and cancelling the navigation).
 - `InMemory` returns a pending history function. The "real" history object is created by passing a response handler to the pending history.
 

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 9662,
-    "minified": 3642,
-    "gzipped": 1539,
+    "bundled": 9388,
+    "minified": 3465,
+    "gzipped": 1477,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 9763,
-    "minified": 3729,
-    "gzipped": 1571
+    "bundled": 9489,
+    "minified": 3552,
+    "gzipped": 1511
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 11659,
-    "minified": 3569,
-    "gzipped": 1597
+    "bundled": 11349,
+    "minified": 3426,
+    "gzipped": 1546
   },
   "dist/hickory-root.min.js": {
-    "bundled": 11659,
-    "minified": 3569,
-    "gzipped": 1597
+    "bundled": 11349,
+    "minified": 3426,
+    "gzipped": 1546
   }
 }

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- Convert key to a two number tuple (`[1, 0]` instead of `1.0`). (**Note:** `pathname` is almost always better than `key` for a "unique" identifier)
 - `history.current` function will emit a navigation for the current location (with a no-op functions for finishing and cancelling the navigation).
 - Unify `prepare` with pending navigation handlers. Users now create a "pending" history; the "real" history is created by passing a response handler to the "pending" history function.
 

--- a/packages/root/src/keyGenerator.ts
+++ b/packages/root/src/keyGenerator.ts
@@ -1,29 +1,18 @@
+import { Key } from "./types/location";
 import { KeyFns } from "./types/keyGenerator";
-
-function parse(key: string): Array<number> {
-  return key.split(".").map((value: string): number => parseInt(value, 10));
-}
-
-function diff(first: string, second: string): number {
-  return parse(second)[0] - parse(first)[0];
-}
-
-function minor(current: string): string {
-  const [major, minor] = parse(current);
-  return `${major}.${minor + 1}`;
-}
 
 export default function createKeyGenerator(): KeyFns {
   let currentMajor: number = 0;
 
   return {
-    major: function(previous?: string): string {
+    major: function(previous?: Key): Key {
       if (previous) {
-        currentMajor = parse(previous)[0] + 1;
+        currentMajor = previous[0] + 1;
       }
-      return `${currentMajor++}.0`;
+      return [currentMajor++, 0];
     },
-    minor,
-    diff
+    minor: function(current: Key): Key {
+      return [current[0], current[1] + 1];
+    }
   };
 }

--- a/packages/root/src/locationUtils.ts
+++ b/packages/root/src/locationUtils.ts
@@ -10,7 +10,8 @@ import {
   PartialLocation,
   AnyLocation,
   LocationComponents,
-  Location
+  Location,
+  Key
 } from "./types/location";
 import { ToArgument } from "./types/navigate";
 import { LocationUtilOptions, LocationUtils } from "./types/locationUtils";
@@ -143,7 +144,7 @@ export default function locationFactory(
     };
   }
 
-  function keyed(location: Location, key: string): SessionLocation {
+  function keyed(location: Location, key: Key): SessionLocation {
     return {
       ...location,
       key

--- a/packages/root/src/types/keyGenerator.ts
+++ b/packages/root/src/types/keyGenerator.ts
@@ -1,5 +1,6 @@
+import { Key } from "./location";
+
 export interface KeyFns {
-  major(previous?: string): string;
-  minor(current: string): string;
-  diff(first: string, second: string): number;
+  major(previous?: Key): Key;
+  minor(current: Key): Key;
 }

--- a/packages/root/src/types/location.ts
+++ b/packages/root/src/types/location.ts
@@ -11,10 +11,10 @@ export interface Location extends LocationComponents {
   rawPathname: string;
 }
 
-// use SessionLocation instead of Location to prevent
-// errors from colliding with window.Location interface
+export type Key = [number, number];
+
 export interface SessionLocation extends Location {
-  key: string;
+  key: Key;
 }
 
 export type AnyLocation = SessionLocation | PartialLocation;

--- a/packages/root/src/types/locationUtils.ts
+++ b/packages/root/src/types/locationUtils.ts
@@ -1,4 +1,4 @@
-import { Location, SessionLocation, PartialLocation } from "./location";
+import { Location, SessionLocation, PartialLocation, Key } from "./location";
 
 export interface QueryFunctions {
   parse: (query?: string) => any;
@@ -15,7 +15,7 @@ export interface LocationUtilOptions {
 }
 
 export interface LocationUtils {
-  keyed(location: Location, key: string): SessionLocation;
+  keyed(location: Location, key: Key): SessionLocation;
   genericLocation(value: string | object, state?: any): Location;
   stringifyLocation(location: SessionLocation): string;
   stringifyLocation(location: PartialLocation): string;

--- a/packages/root/tests/keygen.spec.ts
+++ b/packages/root/tests/keygen.spec.ts
@@ -6,27 +6,27 @@ describe("key generator", () => {
     it("returns key whose major value is the stored value", () => {
       const keygen = keyGenerator();
       const key = keygen.major();
-      expect(key).toBe("0.0");
+      expect(key).toEqual([0, 0]);
     });
 
     it("increments major value for successive calls", () => {
       const keygen = keyGenerator();
       const key = keygen.major();
-      expect(key).toBe("0.0");
-      expect(keygen.major()).toBe("1.0");
+      expect(key).toEqual([0, 0]);
+      expect(keygen.major()).toEqual([1, 0]);
     });
 
     describe("previous argument", () => {
       it("increments the provided key's major version by 1", () => {
         const keygen = keyGenerator();
-        const key = keygen.major("3.0");
-        expect(key).toBe("4.0");
+        const key = keygen.major([3, 0]);
+        expect(key).toEqual([4, 0]);
       });
 
       it("sets the key's minor version to 0", () => {
         const keygen = keyGenerator();
-        const key = keygen.major("3.14");
-        expect(key).toBe("4.0");
+        const key = keygen.major([3, 14]);
+        expect(key).toEqual([4, 0]);
       });
     });
   });
@@ -34,24 +34,14 @@ describe("key generator", () => {
   describe("minor", () => {
     it("increments the minor value from the provided key", () => {
       const keygen = keyGenerator();
-      const key = keygen.minor("0.0");
-      expect(key).toBe("0.1");
+      const key = keygen.minor([0, 0]);
+      expect(key).toEqual([0, 1]);
     });
 
     it("uses the major value from the provided key", () => {
       const keygen = keyGenerator();
-      const key = keygen.minor("18.0");
-      expect(key).toBe("18.1");
-    });
-  });
-
-  describe("diff", () => {
-    it("returns the different between the major value of two keys", () => {
-      const keygen = keyGenerator();
-      const first = "5.3";
-      const second = "10.4";
-      expect(keygen.diff(first, second)).toBe(5);
-      expect(keygen.diff(second, first)).toBe(-5);
+      const key = keygen.minor([18, 0]);
+      expect(key).toEqual([18, 1]);
     });
   });
 });

--- a/packages/root/tests/locationUtils.spec.ts
+++ b/packages/root/tests/locationUtils.spec.ts
@@ -2,7 +2,7 @@ import "jest";
 import { locationUtils } from "../src";
 import * as qs from "qs";
 
-import { SessionLocation } from "../src/types";
+import { SessionLocation, Key } from "../src/types";
 
 describe("locationFactory", () => {
   describe("constructor", () => {
@@ -296,7 +296,7 @@ describe("locationFactory", () => {
     const { keyed, genericLocation } = locationUtils();
 
     it("attaches a key to a keyless location", () => {
-      const key = "3.1.4";
+      const key: Key = [3, 14];
       const keylessLocation = genericLocation("/test");
       const location = keyed(keylessLocation, key);
       expect(location.key).toBe(key);

--- a/packages/root/tests/navigationHandler.spec.ts
+++ b/packages/root/tests/navigationHandler.spec.ts
@@ -11,7 +11,7 @@ const initialLocation: SessionLocation = {
   pathname: "/",
   hash: "",
   query: "",
-  key: "0.0",
+  key: [0, 0],
   rawPathname: "/"
 };
 
@@ -19,7 +19,7 @@ const locationOne: SessionLocation = {
   pathname: "/one",
   hash: "",
   query: "",
-  key: "1.0",
+  key: [1, 0],
   rawPathname: "/one"
 };
 
@@ -27,7 +27,7 @@ const locationTwo: SessionLocation = {
   pathname: "/two",
   hash: "",
   query: "",
-  key: "2.0",
+  key: [2, 0],
   rawPathname: "/two"
 };
 
@@ -86,7 +86,7 @@ describe("navigateWith", () => {
         it("returns a push navigation object", () => {
           expect(nav.location).toMatchObject({
             pathname: "/next",
-            key: "1.0"
+            key: [1, 0]
           });
           expect(nav.action).toBe("push");
 
@@ -120,7 +120,7 @@ describe("navigateWith", () => {
         it("returns a replace navigation object", () => {
           expect(nav.location).toMatchObject({
             pathname: "/",
-            key: "0.1"
+            key: [0, 1]
           });
           expect(nav.action).toBe("replace");
           expect(rest.push.finish.mock.calls.length).toBe(0);
@@ -154,7 +154,7 @@ describe("navigateWith", () => {
         it("returns a push navigation object", () => {
           expect(nav.location).toMatchObject({
             pathname: "/next",
-            key: "1.0"
+            key: [1, 0]
           });
           expect(nav.action).toBe("push");
 
@@ -190,7 +190,7 @@ describe("navigateWith", () => {
         it("returns a replace navigation object", () => {
           expect(nav.location).toMatchObject({
             pathname: "/next",
-            key: "0.1"
+            key: [0, 1]
           });
           expect(nav.action).toBe("replace");
           expect(rest.push.finish.mock.calls.length).toBe(0);

--- a/packages/root/types/types/keyGenerator.d.ts
+++ b/packages/root/types/types/keyGenerator.d.ts
@@ -1,5 +1,5 @@
+import { Key } from "./location";
 export interface KeyFns {
-    major(previous?: string): string;
-    minor(current: string): string;
-    diff(first: string, second: string): number;
+    major(previous?: Key): Key;
+    minor(current: Key): Key;
 }

--- a/packages/root/types/types/location.d.ts
+++ b/packages/root/types/types/location.d.ts
@@ -8,7 +8,8 @@ export declare type PartialLocation = Partial<LocationComponents>;
 export interface Location extends LocationComponents {
     rawPathname: string;
 }
+export declare type Key = [number, number];
 export interface SessionLocation extends Location {
-    key: string;
+    key: Key;
 }
 export declare type AnyLocation = SessionLocation | PartialLocation;

--- a/packages/root/types/types/locationUtils.d.ts
+++ b/packages/root/types/types/locationUtils.d.ts
@@ -1,4 +1,4 @@
-import { Location, SessionLocation, PartialLocation } from "./location";
+import { Location, SessionLocation, PartialLocation, Key } from "./location";
 export interface QueryFunctions {
     parse: (query?: string) => any;
     stringify: (query?: any) => string;
@@ -11,7 +11,7 @@ export interface LocationUtilOptions {
     raw?: RawPathname;
 }
 export interface LocationUtils {
-    keyed(location: Location, key: string): SessionLocation;
+    keyed(location: Location, key: Key): SessionLocation;
     genericLocation(value: string | object, state?: any): Location;
     stringifyLocation(location: SessionLocation): string;
     stringifyLocation(location: PartialLocation): string;

--- a/tests/cases/cancel/cancel-call.ts
+++ b/tests/cases/cancel/cancel-call.ts
@@ -41,7 +41,7 @@ export default {
           setTimeout(() => {
             expect(localHistory.location).toMatchObject({
               pathname: "/six",
-              key: "5.0"
+              key: [5, 0]
             });
             resolve();
           }, 25);

--- a/tests/cases/go/cancel-with-pop.ts
+++ b/tests/cases/go/cancel-with-pop.ts
@@ -42,7 +42,7 @@ export default {
           pending.finish();
           expect(localHistory.location).toMatchObject({
             pathname: "/three",
-            key: "2.0"
+            key: [2, 0]
           });
           resolve();
       }

--- a/tests/cases/go/cancel-with-push.ts
+++ b/tests/cases/go/cancel-with-push.ts
@@ -41,7 +41,7 @@ export default {
           pending.finish();
           expect(history.location).toMatchObject({
             pathname: "/seven",
-            key: "6.0"
+            key: [6, 0]
           });
           resolve();
       }

--- a/tests/cases/go/cancel-with-replace.ts
+++ b/tests/cases/go/cancel-with-replace.ts
@@ -43,7 +43,7 @@ export default {
           pending.finish();
           expect(localHistory.location).toMatchObject({
             pathname: "/seven",
-            key: "5.1"
+            key: [5, 1]
           });
           resolve();
       }

--- a/tests/cases/go/response-handler.ts
+++ b/tests/cases/go/response-handler.ts
@@ -38,7 +38,7 @@ export default {
         case 6:
           expect(pending.location).toMatchObject({
             pathname: "/four",
-            key: "3.0"
+            key: [3, 0]
           });
           expect(pending.action).toBe("pop");
           resolve();

--- a/tests/cases/navigate/push-increments-key-major.ts
+++ b/tests/cases/navigate/push-increments-key-major.ts
@@ -9,15 +9,14 @@ export default {
       pending.finish();
       switch (calls++) {
         case 0:
-          const [initMajor] = history.location.key.split(".");
-          initMajorNum = parseInt(initMajor, 10);
+          const [initMajor] = history.location.key;
+          initMajorNum = initMajor;
           break;
         case 1:
           const current = history.location;
-          const [currentMajor, currentMinor] = current.key.split(".");
-          const currentMajorNum = parseInt(currentMajor, 10);
-          expect(currentMajorNum).toEqual(initMajorNum + 1);
-          expect(currentMinor).toBe("0");
+          const [currentMajor, currentMinor] = current.key;
+          expect(currentMajor).toEqual(initMajorNum + 1);
+          expect(currentMinor).toBe(0);
       }
     });
     history.navigate("/next");

--- a/tests/cases/navigate/replace-increments-key-minor.ts
+++ b/tests/cases/navigate/replace-increments-key-minor.ts
@@ -9,18 +9,16 @@ export default {
       pending.finish();
       switch (calls++) {
         case 0:
-          const [initMajor, initMinor] = history.location.key.split(".");
-          initMajorNum = parseInt(initMajor, 10);
-          initMinorNum = parseInt(initMinor, 10);
+          const [initMajor, initMinor] = history.location.key;
+          initMajorNum = initMajor;
+          initMinorNum = initMinor;
           break;
         case 1:
           const current = history.location;
-          const [currentMajor, currentMinor] = current.key.split(".");
-          const currentMajorNum = parseInt(currentMajor, 10);
-          const currentMinorNum = parseInt(currentMinor, 10);
+          const [currentMajor, currentMinor] = current.key;
 
-          expect(currentMajorNum).toEqual(initMajorNum);
-          expect(currentMinorNum).toBe(initMinorNum + 1);
+          expect(currentMajor).toEqual(initMajorNum);
+          expect(currentMinor).toBe(initMinorNum + 1);
       }
     });
 


### PR DESCRIPTION
The primary purpose of `location.key` is to determine how to revert a `pop` in browsers. With a string, this was done by splitting and parsing the string. This gets rid of those steps, storing the "major" and "minor" parts of the key as numbers in a tuple.

A secondary purpose of the key may be as an identifier. If necessary, the tuple can be stringified (`location.key.join(".")`), but unless the identifier has to be unique across a session, the location's `pathname` is generally a better identifier. For example, with animation the `pathname` is non-unique across hash changes, which means that navigating to a hash within a page would not trigger an unnecessary animation.