### PR TITLE
Rename Location type to RawLocation

### DIFF
--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- Rename `Location` type to `RawLocation`.
 - `location.key` is now a two number tuple (`[1, 0]` instead of `1.0`).
 - Add `history.current` function that emits a navigation for the current location (with a no-op functions for finishing and cancelling the navigation).
 - `Browser` returns a pending history function. The "real" history object is created by passing a response handler to the pending history.

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -4,7 +4,7 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  Location,
+  RawLocation,
   AnyLocation,
   LocationUtilOptions
 } from "@hickory/root";
@@ -15,7 +15,7 @@ export {
   SessionLocation,
   PartialLocation,
   AnyLocation,
-  Location,
+  RawLocation,
   LocationComponents
 };
 

--- a/packages/browser/types/types.d.ts
+++ b/packages/browser/types/types.d.ts
@@ -1,5 +1,5 @@
-import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, Location, AnyLocation, LocationUtilOptions } from "@hickory/root";
-export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, Location, LocationComponents };
+import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation, LocationUtilOptions } from "@hickory/root";
+export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
 export declare type Options = LocationUtilOptions;
 export declare type BrowserHistory = History;
 export declare type PendingBrowserHistory = PendingHistory<BrowserHistory>;

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- Rename `Location` type to `RawLocation`.
 - `location.key` is now a two number tuple (`[1, 0]` instead of `1.0`).
 - Add `history.current` function that emits a navigation for the current location (with a no-op functions for finishing and cancelling the navigation).
 - `Hash` returns a pending history function. The "real" history object is created by passing a response handler to the pending history.

--- a/packages/hash/src/types.ts
+++ b/packages/hash/src/types.ts
@@ -4,7 +4,7 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  Location,
+  RawLocation,
   AnyLocation,
   LocationUtilOptions
 } from "@hickory/root";
@@ -15,7 +15,7 @@ export {
   SessionLocation,
   PartialLocation,
   AnyLocation,
-  Location,
+  RawLocation,
   LocationComponents
 };
 

--- a/packages/hash/types/types.d.ts
+++ b/packages/hash/types/types.d.ts
@@ -1,5 +1,5 @@
-import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, Location, AnyLocation, LocationUtilOptions } from "@hickory/root";
-export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, Location, LocationComponents };
+import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation, LocationUtilOptions } from "@hickory/root";
+export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
 export interface HashOptions {
     hashType?: string;
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- Rename `Location` type to `RawLocation`.
 - `location.key` is now a two number tuple (`[1, 0]` instead of `1.0`).
 - Add `history.current` function that emits a navigation for the current location (with a no-op functions for finishing and cancelling the navigation).
 - `InMemory` returns a pending history function. The "real" history object is created by passing a response handler to the pending history.

--- a/packages/in-memory/src/types.ts
+++ b/packages/in-memory/src/types.ts
@@ -4,7 +4,7 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  Location,
+  RawLocation,
   AnyLocation,
   LocationUtilOptions
 } from "@hickory/root";
@@ -15,7 +15,7 @@ export {
   SessionLocation,
   PartialLocation,
   AnyLocation,
-  Location,
+  RawLocation,
   LocationComponents
 };
 

--- a/packages/in-memory/types/types.d.ts
+++ b/packages/in-memory/types/types.d.ts
@@ -1,5 +1,5 @@
-import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, Location, AnyLocation, LocationUtilOptions } from "@hickory/root";
-export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, Location, LocationComponents };
+import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation, LocationUtilOptions } from "@hickory/root";
+export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
 export declare type InputLocation = string | PartialLocation;
 export declare type InputLocations = Array<InputLocation>;
 export interface SessionOptions {

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- Rename `Location` type to `RawLocation`.
 - Convert key to a two number tuple (`[1, 0]` instead of `1.0`). (**Note:** `pathname` is almost always better than `key` for a "unique" identifier)
 - `history.current` function will emit a navigation for the current location (with a no-op functions for finishing and cancelling the navigation).
 - Unify `prepare` with pending navigation handlers. Users now create a "pending" history; the "real" history is created by passing a response handler to the "pending" history function.

--- a/packages/root/src/locationUtils.ts
+++ b/packages/root/src/locationUtils.ts
@@ -10,7 +10,7 @@ import {
   PartialLocation,
   AnyLocation,
   LocationComponents,
-  Location,
+  RawLocation,
   Key
 } from "./types/location";
 import { ToArgument } from "./types/navigate";
@@ -113,7 +113,7 @@ export default function locationFactory(
     return details;
   }
 
-  function genericLocation(value: ToArgument, state?: any): Location {
+  function genericLocation(value: ToArgument, state?: any): RawLocation {
     if (state === undefined) {
       state = null;
     }
@@ -144,7 +144,7 @@ export default function locationFactory(
     };
   }
 
-  function keyed(location: Location, key: Key): SessionLocation {
+  function keyed(location: RawLocation, key: Key): SessionLocation {
     return {
       ...location,
       key

--- a/packages/root/src/navigate.ts
+++ b/packages/root/src/navigate.ts
@@ -1,4 +1,4 @@
-import { SessionLocation, Location } from "./types/location";
+import { SessionLocation, RawLocation } from "./types/location";
 import {
   PendingNavigation,
   FinishNavigation,
@@ -87,7 +87,7 @@ export default function navigationHandler(args: NavigateArgs): NavigateHelpers {
     }
   }
 
-  function replaceNav(location: Location): PendingNavigation {
+  function replaceNav(location: RawLocation): PendingNavigation {
     const keyedLocation = locationUtils.keyed(
       location,
       keygen.minor(current().key)
@@ -100,7 +100,7 @@ export default function navigationHandler(args: NavigateArgs): NavigateHelpers {
     );
   }
 
-  function pushNav(location: Location): PendingNavigation {
+  function pushNav(location: RawLocation): PendingNavigation {
     const keyedLocation = locationUtils.keyed(
       location,
       keygen.major(current().key)

--- a/packages/root/src/types/index.ts
+++ b/packages/root/src/types/index.ts
@@ -5,7 +5,7 @@ export {
   PartialLocation,
   SessionLocation,
   AnyLocation,
-  Location
+  RawLocation
 } from "./location";
 
 export { KeyFns } from "./keyGenerator";

--- a/packages/root/src/types/location.ts
+++ b/packages/root/src/types/location.ts
@@ -7,13 +7,13 @@ export interface LocationComponents {
 
 export type PartialLocation = Partial<LocationComponents>;
 
-export interface Location extends LocationComponents {
+export interface RawLocation extends LocationComponents {
   rawPathname: string;
 }
 
 export type Key = [number, number];
 
-export interface SessionLocation extends Location {
+export interface SessionLocation extends RawLocation {
   key: Key;
 }
 

--- a/packages/root/types/types/index.d.ts
+++ b/packages/root/types/types/index.d.ts
@@ -1,5 +1,5 @@
 export { PendingHistory, History } from "./hickory";
-export { LocationComponents, PartialLocation, SessionLocation, AnyLocation, Location } from "./location";
+export { LocationComponents, PartialLocation, SessionLocation, AnyLocation, RawLocation } from "./location";
 export { KeyFns } from "./keyGenerator";
 export { LocationUtilOptions, QueryFunctions, RawPathname, LocationUtils } from "./locationUtils";
 export { NavigationInfo, ConfirmationFunction, ConfirmationMethods, BlockingHistory } from "./navigationConfirmation";

--- a/packages/root/types/types/location.d.ts
+++ b/packages/root/types/types/location.d.ts
@@ -5,11 +5,11 @@ export interface LocationComponents {
     state?: any;
 }
 export declare type PartialLocation = Partial<LocationComponents>;
-export interface Location extends LocationComponents {
+export interface RawLocation extends LocationComponents {
     rawPathname: string;
 }
 export declare type Key = [number, number];
-export interface SessionLocation extends Location {
+export interface SessionLocation extends RawLocation {
     key: Key;
 }
 export declare type AnyLocation = SessionLocation | PartialLocation;


### PR DESCRIPTION
Playing it safe to avoid conflicts with the built-in DOM `Location` type.