### PR TITLE
Pass response handler to history constructors

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 5196,
-    "minified": 1874,
-    "gzipped": 823,
+    "bundled": 4771,
+    "minified": 1856,
+    "gzipped": 820,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 5234,
-    "minified": 1909,
-    "gzipped": 862
+    "bundled": 4809,
+    "minified": 1891,
+    "gzipped": 864
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 16781,
-    "minified": 4901,
-    "gzipped": 2042
+    "bundled": 16348,
+    "minified": 4883,
+    "gzipped": 2053
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 16781,
-    "minified": 4901,
-    "gzipped": 2042
+    "bundled": 16348,
+    "minified": 4883,
+    "gzipped": 2053
   }
 }

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -1,16 +1,17 @@
 import {
-  PendingHistory,
+  HistoryConstructor,
+  HistoryOptions,
   History,
   LocationComponents,
   SessionLocation,
   PartialLocation,
   RawLocation,
-  AnyLocation,
-  LocationUtilOptions
+  AnyLocation
 } from "@hickory/root";
 
 export {
-  PendingHistory,
+  HistoryConstructor,
+  HistoryOptions,
   History,
   SessionLocation,
   PartialLocation,
@@ -19,6 +20,5 @@ export {
   LocationComponents
 };
 
-export type Options = LocationUtilOptions;
+export type BrowserHistoryOptions = HistoryOptions;
 export type BrowserHistory = History;
-export type PendingBrowserHistory = PendingHistory<BrowserHistory>;

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -6,7 +6,6 @@ describe("browser integration tests", () => {
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
     window.history.pushState(null, "", "/");
-    console.log('FAKE "RESET"');
   });
 
   afterEach(() => {
@@ -17,7 +16,6 @@ describe("browser integration tests", () => {
     beforeEach(() => {
       spyOn(window.history, "pushState").and.callThrough();
       spyOn(window.history, "replaceState").and.callThrough();
-      console.log("CREATED SPYS");
     });
 
     afterEach(() => {
@@ -48,6 +46,13 @@ describe("browser integration tests", () => {
           pending.finish();
         });
         testHistory.navigate("/the-new-location", "push");
+
+        console.log(
+          "AFTER PUSHING",
+          (<jasmine.Spy>window.history.pushState).calls.count(),
+          (<jasmine.Spy>window.history.replaceState).calls.count()
+        );
+
         expect(window.location.pathname).toEqual("/the-new-location");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(1);
         expect((<jasmine.Spy>window.history.replaceState).calls.count()).toBe(

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -23,7 +23,7 @@ describe("browser integration tests", () => {
       (<jasmine.Spy>window.history.replaceState).calls.reset();
     });
 
-    it("new URL uses rawPathname, not pathname", () => {
+    /*     it("new URL uses rawPathname, not pathname", () => {
       testHistory = Browser(pending => {
         pending.finish();
       });
@@ -32,7 +32,7 @@ describe("browser integration tests", () => {
       });
       expect(window.location.pathname).toEqual("/encoded-percent%25");
       expect(testHistory.location.pathname).toEqual("/encoded-percent%");
-    });
+    }); */
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
@@ -60,7 +60,7 @@ describe("browser integration tests", () => {
         );
       });
 
-      it("sets the state", () => {
+      /*       it("sets the state", () => {
         testHistory = Browser(pending => {
           pending.finish();
         });
@@ -75,10 +75,10 @@ describe("browser integration tests", () => {
         const { state, key } = testHistory.location;
         expect(window.history.state.state).toEqual(state);
         expect(window.history.state.key).toEqual(key);
-      });
+      }); */
     });
 
-    describe("replace navigation", () => {
+    /*     describe("replace navigation", () => {
       it("uses history.replaceState", () => {
         testHistory = Browser(pending => {
           pending.finish();
@@ -107,10 +107,10 @@ describe("browser integration tests", () => {
         expect(window.history.state.state).toEqual(state);
         expect(window.history.state.key).toEqual(key);
       });
-    });
+    }); */
   });
 
-  describe("go", () => {
+  /*   describe("go", () => {
     it("is detectable through a popstate listener", done => {
       let calls = 0;
       testHistory = Browser(pending => {
@@ -176,5 +176,5 @@ describe("browser integration tests", () => {
       });
       testHistory.current();
     });
-  });
+  }); */
 });

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -6,6 +6,7 @@ describe("browser integration tests", () => {
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
     window.history.pushState(null, "", "/");
+    console.log('FAKE "RESET"');
   });
 
   afterEach(() => {
@@ -16,6 +17,7 @@ describe("browser integration tests", () => {
     beforeEach(() => {
       spyOn(window.history, "pushState").and.callThrough();
       spyOn(window.history, "replaceState").and.callThrough();
+      console.log("CREATED SPYS");
     });
 
     afterEach(() => {
@@ -36,6 +38,12 @@ describe("browser integration tests", () => {
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
+        console.log(
+          "BEFORE PUSHING",
+          (<jasmine.Spy>window.history.pushState).calls.count(),
+          (<jasmine.Spy>window.history.replaceState).calls.count()
+        );
+
         testHistory = Browser(pending => {
           pending.finish();
         });

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -3,14 +3,9 @@ import { Browser } from "../../src";
 
 describe("browser integration tests", () => {
   let testHistory;
-
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
     window.history.pushState(null, "", "/");
-    const pendingHistory = Browser();
-    testHistory = pendingHistory(pending => {
-      pending.finish();
-    });
   });
 
   afterEach(() => {
@@ -29,6 +24,9 @@ describe("browser integration tests", () => {
     });
 
     it("new URL uses rawPathname, not pathname", () => {
+      testHistory = Browser(pending => {
+        pending.finish();
+      });
       testHistory.navigate({
         pathname: "/encoded-percent%25"
       });
@@ -38,6 +36,9 @@ describe("browser integration tests", () => {
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
+        testHistory = Browser(pending => {
+          pending.finish();
+        });
         testHistory.navigate("/the-new-location", "push");
         expect(window.location.pathname).toEqual("/the-new-location");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(1);
@@ -47,6 +48,9 @@ describe("browser integration tests", () => {
       });
 
       it("sets the state", () => {
+        testHistory = Browser(pending => {
+          pending.finish();
+        });
         const providedState = { isSet: true };
         testHistory.navigate(
           {
@@ -63,6 +67,9 @@ describe("browser integration tests", () => {
 
     describe("replace navigation", () => {
       it("uses history.replaceState", () => {
+        testHistory = Browser(pending => {
+          pending.finish();
+        });
         testHistory.navigate("/the-same-location", "replace");
         expect(window.location.pathname).toEqual("/the-same-location");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(0);
@@ -72,6 +79,9 @@ describe("browser integration tests", () => {
       });
 
       it("sets the state", () => {
+        testHistory = Browser(pending => {
+          pending.finish();
+        });
         const providedState = { isSet: true };
         testHistory.navigate(
           {
@@ -89,10 +99,9 @@ describe("browser integration tests", () => {
 
   describe("go", () => {
     it("is detectable through a popstate listener", done => {
-      const pendingHistory = Browser();
       let calls = 0;
-      const history = pendingHistory(pending => {
-        let localHistory = history;
+      testHistory = Browser(pending => {
+        let localHistory = testHistory;
         switch (calls++) {
           case 0:
             pending.finish();
@@ -118,16 +127,15 @@ describe("browser integration tests", () => {
             done();
         }
       });
-      history.current();
+      testHistory.current();
     });
   });
 
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
-      const pendingHistory = Browser();
       let calls = 0;
-      const history = pendingHistory(pending => {
-        let localHistory = history;
+      testHistory = Browser(pending => {
+        let localHistory = testHistory;
         switch (calls++) {
           case 0:
             pending.finish();
@@ -153,7 +161,7 @@ describe("browser integration tests", () => {
             done();
         }
       });
-      history.current();
+      testHistory.current();
     });
   });
 });

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -5,7 +5,7 @@ describe("browser integration tests", () => {
   let testHistory;
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
-    window.history.pushState(null, "", "/");
+    window.history.pushState({ key: [0, 0] }, "", "/");
   });
 
   afterEach(() => {
@@ -23,7 +23,7 @@ describe("browser integration tests", () => {
       (<jasmine.Spy>window.history.replaceState).calls.reset();
     });
 
-    /*     it("new URL uses rawPathname, not pathname", () => {
+    it("new URL uses rawPathname, not pathname", () => {
       testHistory = Browser(pending => {
         pending.finish();
       });
@@ -32,7 +32,7 @@ describe("browser integration tests", () => {
       });
       expect(window.location.pathname).toEqual("/encoded-percent%25");
       expect(testHistory.location.pathname).toEqual("/encoded-percent%");
-    }); */
+    });
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
@@ -60,7 +60,7 @@ describe("browser integration tests", () => {
         );
       });
 
-      /*       it("sets the state", () => {
+      it("sets the state", () => {
         testHistory = Browser(pending => {
           pending.finish();
         });
@@ -75,10 +75,10 @@ describe("browser integration tests", () => {
         const { state, key } = testHistory.location;
         expect(window.history.state.state).toEqual(state);
         expect(window.history.state.key).toEqual(key);
-      }); */
+      });
     });
 
-    /*     describe("replace navigation", () => {
+    describe("replace navigation", () => {
       it("uses history.replaceState", () => {
         testHistory = Browser(pending => {
           pending.finish();
@@ -107,10 +107,10 @@ describe("browser integration tests", () => {
         expect(window.history.state.state).toEqual(state);
         expect(window.history.state.key).toEqual(key);
       });
-    }); */
+    });
   });
 
-  /*   describe("go", () => {
+  describe("go", () => {
     it("is detectable through a popstate listener", done => {
       let calls = 0;
       testHistory = Browser(pending => {
@@ -176,5 +176,5 @@ describe("browser integration tests", () => {
       });
       testHistory.current();
     });
-  }); */
+  });
 });

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -36,22 +36,10 @@ describe("browser integration tests", () => {
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
-        console.log(
-          "BEFORE PUSHING",
-          (<jasmine.Spy>window.history.pushState).calls.count(),
-          (<jasmine.Spy>window.history.replaceState).calls.count()
-        );
-
         testHistory = Browser(pending => {
           pending.finish();
         });
         testHistory.navigate("/the-new-location", "push");
-
-        console.log(
-          "AFTER PUSHING",
-          (<jasmine.Spy>window.history.pushState).calls.count(),
-          (<jasmine.Spy>window.history.replaceState).calls.count()
-        );
 
         expect(window.location.pathname).toEqual("/the-new-location");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(1);

--- a/packages/browser/types/index.d.ts
+++ b/packages/browser/types/index.d.ts
@@ -1,3 +1,4 @@
-import { PendingBrowserHistory, Options } from "./types";
+import { ResponseHandler } from "@hickory/root";
+import { BrowserHistoryOptions, BrowserHistory } from "./types";
 export * from "./types";
-export declare function Browser(options?: Options): PendingBrowserHistory;
+export declare function Browser(fn: ResponseHandler, options?: BrowserHistoryOptions): BrowserHistory;

--- a/packages/browser/types/types.d.ts
+++ b/packages/browser/types/types.d.ts
@@ -1,5 +1,4 @@
-import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation, LocationUtilOptions } from "@hickory/root";
-export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
-export declare type Options = LocationUtilOptions;
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
+export declare type BrowserHistoryOptions = HistoryOptions;
 export declare type BrowserHistory = History;
-export declare type PendingBrowserHistory = PendingHistory<BrowserHistory>;

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 7354,
-    "minified": 2702,
+    "bundled": 6956,
+    "minified": 2684,
     "gzipped": 1042,
     "treeshaked": {
       "rollup": {
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 7541,
-    "minified": 2881,
+    "bundled": 7143,
+    "minified": 2863,
     "gzipped": 1094
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 18857,
-    "minified": 5423,
-    "gzipped": 2183
+    "bundled": 18451,
+    "minified": 5405,
+    "gzipped": 2202
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 18857,
-    "minified": 5423,
-    "gzipped": 2183
+    "bundled": 18451,
+    "minified": 5405,
+    "gzipped": 2202
   }
 }

--- a/packages/hash/src/types.ts
+++ b/packages/hash/src/types.ts
@@ -1,16 +1,17 @@
 import {
-  PendingHistory,
+  HistoryConstructor,
+  HistoryOptions,
   History,
   LocationComponents,
   SessionLocation,
   PartialLocation,
   RawLocation,
-  AnyLocation,
-  LocationUtilOptions
+  AnyLocation
 } from "@hickory/root";
 
 export {
-  PendingHistory,
+  HistoryConstructor,
+  HistoryOptions,
   History,
   SessionLocation,
   PartialLocation,
@@ -19,9 +20,8 @@ export {
   LocationComponents
 };
 
-export interface HashOptions {
+export interface HashTypeOptions {
   hashType?: string;
 }
-export type Options = LocationUtilOptions & HashOptions;
+export type HashOptions = HistoryOptions & HashTypeOptions;
 export type HashHistory = History;
-export type PendingHashHistory = PendingHistory<HashHistory>;

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -7,10 +7,6 @@ describe("hash integration tests", () => {
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
     window.history.pushState(null, "", "/#/");
-    const pendingHistory = Hash();
-    testHistory = pendingHistory(pending => {
-      pending.finish();
-    });
   });
 
   afterEach(() => {
@@ -29,6 +25,9 @@ describe("hash integration tests", () => {
     });
 
     it("new URL uses rawPathname, not pathname", () => {
+      testHistory = Hash(pending => {
+        pending.finish();
+      });
       testHistory.navigate(
         {
           pathname: "/encoded-percent%25"
@@ -41,6 +40,9 @@ describe("hash integration tests", () => {
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
+        testHistory = Hash(pending => {
+          pending.finish();
+        });
         testHistory.navigate("/a-new-position", "push");
         expect(window.location.hash).toEqual("#/a-new-position");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(1);
@@ -50,6 +52,9 @@ describe("hash integration tests", () => {
       });
 
       it("sets the state", () => {
+        testHistory = Hash(pending => {
+          pending.finish();
+        });
         const providedState = { isSet: true };
         testHistory.navigate(
           {
@@ -66,6 +71,9 @@ describe("hash integration tests", () => {
 
     describe("replace navigation", () => {
       it("uses history.replaceState", () => {
+        testHistory = Hash(pending => {
+          pending.finish();
+        });
         testHistory.navigate("/the-same-position", "replace");
         expect(window.location.hash).toEqual("#/the-same-position");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(0);
@@ -75,6 +83,9 @@ describe("hash integration tests", () => {
       });
 
       it("sets the state", () => {
+        testHistory = Hash(pending => {
+          pending.finish();
+        });
         const providedState = { isSet: true };
         testHistory.navigate(
           {
@@ -92,10 +103,9 @@ describe("hash integration tests", () => {
 
   describe("go", () => {
     it("is detectable through a popstate listener", done => {
-      const pendingHistory = Hash();
       let calls = 0;
-      const history = pendingHistory(pending => {
-        let localHistory = history;
+      testHistory = Hash(pending => {
+        let localHistory = testHistory;
         switch (calls++) {
           case 0:
             pending.finish();
@@ -121,16 +131,15 @@ describe("hash integration tests", () => {
             done();
         }
       });
-      history.current();
+      testHistory.current();
     });
   });
 
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
-      const pendingHistory = Hash();
       let calls = 0;
-      const history = pendingHistory(pending => {
-        let localHistory = history;
+      testHistory = Hash(pending => {
+        let localHistory = testHistory;
         switch (calls++) {
           case 0:
             pending.finish();
@@ -156,7 +165,7 @@ describe("hash integration tests", () => {
             done();
         }
       });
-      history.current();
+      testHistory.current();
     });
   });
 });

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -6,18 +6,14 @@ describe("hash integration tests", () => {
 
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
-    window.history.pushState(null, "", "/#/");
+    window.history.pushState({ key: [0, 0] }, "", "/#/");
   });
 
   afterEach(() => {
     testHistory.destroy();
   });
 
-  it("passes", () => {
-    expect(1).toEqual(1);
-  });
-
-  /* describe("navigate()", () => {
+  describe("navigate()", () => {
     beforeEach(() => {
       spyOn(window.history, "pushState").and.callThrough();
       spyOn(window.history, "replaceState").and.callThrough();
@@ -171,5 +167,5 @@ describe("hash integration tests", () => {
       });
       testHistory.current();
     });
-  }); */
+  });
 });

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -13,7 +13,11 @@ describe("hash integration tests", () => {
     testHistory.destroy();
   });
 
-  describe("navigate()", () => {
+  it("passes", () => {
+    expect(1).toEqual(1);
+  });
+
+  /* describe("navigate()", () => {
     beforeEach(() => {
       spyOn(window.history, "pushState").and.callThrough();
       spyOn(window.history, "replaceState").and.callThrough();
@@ -167,5 +171,5 @@ describe("hash integration tests", () => {
       });
       testHistory.current();
     });
-  });
+  }); */
 });

--- a/packages/hash/types/index.d.ts
+++ b/packages/hash/types/index.d.ts
@@ -1,3 +1,4 @@
-import { Options, PendingHashHistory } from "./types";
+import { ResponseHandler } from "@hickory/root";
+import { HashOptions, HashHistory } from "./types";
 export * from "./types";
-export declare function Hash(options?: Options): PendingHashHistory;
+export declare function Hash(fn: ResponseHandler, options?: HashOptions): HashHistory;

--- a/packages/hash/types/types.d.ts
+++ b/packages/hash/types/types.d.ts
@@ -1,8 +1,7 @@
-import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation, LocationUtilOptions } from "@hickory/root";
-export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
-export interface HashOptions {
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
+export interface HashTypeOptions {
     hashType?: string;
 }
-export declare type Options = LocationUtilOptions & HashOptions;
+export declare type HashOptions = HistoryOptions & HashTypeOptions;
 export declare type HashHistory = History;
-export declare type PendingHashHistory = PendingHistory<HashHistory>;

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 4841,
-    "minified": 1443,
-    "gzipped": 630,
+    "bundled": 4439,
+    "minified": 1422,
+    "gzipped": 631,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 4905,
-    "minified": 1502,
-    "gzipped": 678
+    "bundled": 4503,
+    "minified": 1481,
+    "gzipped": 681
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15612,
-    "minified": 4395,
-    "gzipped": 1850
+    "bundled": 15202,
+    "minified": 4374,
+    "gzipped": 1856
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15612,
-    "minified": 4395,
-    "gzipped": 1850
+    "bundled": 15202,
+    "minified": 4374,
+    "gzipped": 1856
   }
 }

--- a/packages/in-memory/src/types.ts
+++ b/packages/in-memory/src/types.ts
@@ -1,16 +1,17 @@
 import {
-  PendingHistory,
+  HistoryConstructor,
+  HistoryOptions,
   History,
   LocationComponents,
   SessionLocation,
   PartialLocation,
   RawLocation,
-  AnyLocation,
-  LocationUtilOptions
+  AnyLocation
 } from "@hickory/root";
 
 export {
-  PendingHistory,
+  HistoryConstructor,
+  HistoryOptions,
   History,
   SessionLocation,
   PartialLocation,
@@ -27,11 +28,7 @@ export interface SessionOptions {
   index?: number;
 }
 
-export type Options = LocationUtilOptions & SessionOptions;
-
-export interface SessionHistory {
+export type InMemoryOptions = HistoryOptions & SessionOptions;
+export interface InMemoryHistory extends History {
   reset(options?: SessionOptions): void;
 }
-
-export type InMemoryHistory = History & SessionHistory;
-export type PendingInMemoryHistory = PendingHistory<InMemoryHistory>;

--- a/packages/in-memory/types/index.d.ts
+++ b/packages/in-memory/types/index.d.ts
@@ -1,3 +1,4 @@
-import { Options, PendingInMemoryHistory } from "./types";
+import { ResponseHandler } from "@hickory/root";
+import { InMemoryOptions, InMemoryHistory } from "./types";
 export * from "./types";
-export declare function InMemory(options?: Options): PendingInMemoryHistory;
+export declare function InMemory(fn: ResponseHandler, options?: InMemoryOptions): InMemoryHistory;

--- a/packages/in-memory/types/types.d.ts
+++ b/packages/in-memory/types/types.d.ts
@@ -1,14 +1,12 @@
-import { PendingHistory, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation, LocationUtilOptions } from "@hickory/root";
-export { PendingHistory, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
 export declare type InputLocation = string | PartialLocation;
 export declare type InputLocations = Array<InputLocation>;
 export interface SessionOptions {
     locations?: InputLocations;
     index?: number;
 }
-export declare type Options = LocationUtilOptions & SessionOptions;
-export interface SessionHistory {
+export declare type InMemoryOptions = HistoryOptions & SessionOptions;
+export interface InMemoryHistory extends History {
     reset(options?: SessionOptions): void;
 }
-export declare type InMemoryHistory = History & SessionHistory;
-export declare type PendingInMemoryHistory = PendingHistory<InMemoryHistory>;

--- a/packages/root/src/types/hickory.ts
+++ b/packages/root/src/types/hickory.ts
@@ -1,9 +1,12 @@
 import { SessionLocation, AnyLocation } from "./location";
 import { ResponseHandler, ToArgument, NavType } from "./navigate";
+import { LocationUtilOptions } from "./locationUtils";
 
-export type PendingHistory<H extends History = History> = (
-  fn: ResponseHandler
-) => H;
+export type HistoryOptions = LocationUtilOptions;
+export type HistoryConstructor = (
+  fn: ResponseHandler,
+  o?: HistoryOptions
+) => History;
 
 export interface History {
   location: SessionLocation;

--- a/packages/root/src/types/index.ts
+++ b/packages/root/src/types/index.ts
@@ -1,4 +1,4 @@
-export { PendingHistory, History } from "./hickory";
+export { HistoryOptions, HistoryConstructor, History } from "./hickory";
 
 export {
   LocationComponents,

--- a/packages/root/src/types/locationUtils.ts
+++ b/packages/root/src/types/locationUtils.ts
@@ -1,4 +1,4 @@
-import { Location, SessionLocation, PartialLocation, Key } from "./location";
+import { RawLocation, SessionLocation, PartialLocation, Key } from "./location";
 
 export interface QueryFunctions {
   parse: (query?: string) => any;
@@ -15,8 +15,8 @@ export interface LocationUtilOptions {
 }
 
 export interface LocationUtils {
-  keyed(location: Location, key: Key): SessionLocation;
-  genericLocation(value: string | object, state?: any): Location;
+  keyed(location: RawLocation, key: Key): SessionLocation;
+  genericLocation(value: string | object, state?: any): RawLocation;
   stringifyLocation(location: SessionLocation): string;
   stringifyLocation(location: PartialLocation): string;
 }

--- a/packages/root/src/types/navigationConfirmation.ts
+++ b/packages/root/src/types/navigationConfirmation.ts
@@ -1,5 +1,5 @@
 import { SessionLocation } from "./location";
-import { Action } from "./navigation";
+import { Action } from "./navigate";
 
 export interface NavigationInfo {
   to: SessionLocation;

--- a/packages/root/types/types/hickory.d.ts
+++ b/packages/root/types/types/hickory.d.ts
@@ -1,6 +1,8 @@
 import { SessionLocation, AnyLocation } from "./location";
 import { ResponseHandler, ToArgument, NavType } from "./navigate";
-export declare type PendingHistory<H extends History = History> = (fn: ResponseHandler) => H;
+import { LocationUtilOptions } from "./locationUtils";
+export declare type HistoryOptions = LocationUtilOptions;
+export declare type HistoryConstructor = (fn: ResponseHandler, o?: HistoryOptions) => History;
 export interface History {
     location: SessionLocation;
     toHref(to: AnyLocation): string;

--- a/packages/root/types/types/index.d.ts
+++ b/packages/root/types/types/index.d.ts
@@ -1,4 +1,4 @@
-export { PendingHistory, History } from "./hickory";
+export { HistoryOptions, HistoryConstructor, History } from "./hickory";
 export { LocationComponents, PartialLocation, SessionLocation, AnyLocation, RawLocation } from "./location";
 export { KeyFns } from "./keyGenerator";
 export { LocationUtilOptions, QueryFunctions, RawPathname, LocationUtils } from "./locationUtils";

--- a/packages/root/types/types/locationUtils.d.ts
+++ b/packages/root/types/types/locationUtils.d.ts
@@ -1,4 +1,4 @@
-import { Location, SessionLocation, PartialLocation, Key } from "./location";
+import { RawLocation, SessionLocation, PartialLocation, Key } from "./location";
 export interface QueryFunctions {
     parse: (query?: string) => any;
     stringify: (query?: any) => string;
@@ -11,8 +11,8 @@ export interface LocationUtilOptions {
     raw?: RawPathname;
 }
 export interface LocationUtils {
-    keyed(location: Location, key: Key): SessionLocation;
-    genericLocation(value: string | object, state?: any): Location;
+    keyed(location: RawLocation, key: Key): SessionLocation;
+    genericLocation(value: string | object, state?: any): RawLocation;
     stringifyLocation(location: SessionLocation): string;
     stringifyLocation(location: PartialLocation): string;
 }

--- a/packages/root/types/types/navigationConfirmation.d.ts
+++ b/packages/root/types/types/navigationConfirmation.d.ts
@@ -1,5 +1,5 @@
 import { SessionLocation } from "./location";
-import { Action } from "./navigation";
+import { Action } from "./navigate";
 export interface NavigationInfo {
     to: SessionLocation;
     from: SessionLocation;

--- a/tests/cases/cancel/cancel-call.ts
+++ b/tests/cases/cancel/cancel-call.ts
@@ -6,9 +6,9 @@ export default {
   msg: "cancels the pending navigation",
   async: true,
   assertions: 1,
-  fn: function({ pendingHistory, resolve }: AsyncTestCaseArgs) {
+  fn: function({ constructor, resolve, options = {} }: AsyncTestCaseArgs) {
     let calls = 0;
-    const history = pendingHistory(pending => {
+    const history = constructor(pending => {
       let localHistory = history;
       switch (calls++) {
         case 0:
@@ -46,7 +46,7 @@ export default {
             resolve();
           }, 25);
       }
-    });
+    }, options);
     history.current();
   }
 };

--- a/tests/cases/go/cancel-with-pop.ts
+++ b/tests/cases/go/cancel-with-pop.ts
@@ -6,9 +6,9 @@ export default {
   msg: "pop is cancelled if there is a pop before pending response finishes",
   async: true,
   assertions: 1,
-  fn: function({ pendingHistory, resolve }: AsyncTestCaseArgs) {
+  fn: function({ constructor, resolve, options = {} }: AsyncTestCaseArgs) {
     let calls = 0;
-    const history = pendingHistory(pending => {
+    const history = constructor(pending => {
       let localHistory = history;
       switch (calls++) {
         case 0:
@@ -46,7 +46,7 @@ export default {
           });
           resolve();
       }
-    });
+    }, options);
     history.current();
   }
 };

--- a/tests/cases/go/cancel-with-push.ts
+++ b/tests/cases/go/cancel-with-push.ts
@@ -6,9 +6,9 @@ export default {
   msg: "pop is cancelled if there is a push before pending response finishes",
   async: true,
   assertions: 1,
-  fn: function({ pendingHistory, resolve }: AsyncTestCaseArgs) {
+  fn: function({ constructor, resolve, options = {} }: AsyncTestCaseArgs) {
     let calls = 0;
-    const history = pendingHistory(pending => {
+    const history = constructor(pending => {
       switch (calls++) {
         case 0:
           pending.finish();
@@ -45,7 +45,7 @@ export default {
           });
           resolve();
       }
-    });
+    }, options);
     history.current();
   }
 };

--- a/tests/cases/go/cancel-with-replace.ts
+++ b/tests/cases/go/cancel-with-replace.ts
@@ -7,9 +7,9 @@ export default {
     "pop is cancelled if there is a replace before pending response finishes",
   async: true,
   assertions: 1,
-  fn: function({ pendingHistory, resolve }: AsyncTestCaseArgs) {
+  fn: function({ constructor, resolve, options = {} }: AsyncTestCaseArgs) {
     let calls = 0;
-    const history = pendingHistory(pending => {
+    const history = constructor(pending => {
       let localHistory = history;
       switch (calls++) {
         case 0:
@@ -47,7 +47,7 @@ export default {
           });
           resolve();
       }
-    });
+    }, options);
     history.current();
   }
 };

--- a/tests/cases/go/finishing-pop.ts
+++ b/tests/cases/go/finishing-pop.ts
@@ -6,9 +6,9 @@ export default {
   msg: "finishing pop sets location",
   async: true,
   assertions: 1,
-  fn: function({ pendingHistory, resolve }: AsyncTestCaseArgs) {
+  fn: function({ constructor, resolve, options = {} }: AsyncTestCaseArgs) {
     let calls = 0;
-    const history = pendingHistory(pending => {
+    const history = constructor(pending => {
       let localHistory = history;
       switch (calls++) {
         case 0:
@@ -26,7 +26,7 @@ export default {
           });
           resolve();
       }
-    });
+    }, options);
     history.current();
   }
 };

--- a/tests/cases/go/response-handler.ts
+++ b/tests/cases/go/response-handler.ts
@@ -6,9 +6,9 @@ export default {
   msg: `calls response handler with expected location and action`,
   async: true,
   assertions: 2,
-  fn: function({ pendingHistory, resolve }: AsyncTestCaseArgs) {
+  fn: function({ constructor, resolve, options = {} }: AsyncTestCaseArgs) {
     let calls = 0;
-    const history = pendingHistory(pending => {
+    const history = constructor(pending => {
       let localHistory = history;
       switch (calls++) {
         case 0:
@@ -43,7 +43,7 @@ export default {
           expect(pending.action).toBe("pop");
           resolve();
       }
-    });
+    }, options);
     history.current();
   }
 };

--- a/tests/cases/navigate/cancel-call-location.ts
+++ b/tests/cases/navigate/cancel-call-location.ts
@@ -2,12 +2,12 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "calling cancel maintains current location",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(history.location.pathname).toBe("/one");
       pending.cancel();
       expect(history.location.pathname).toBe("/one");
-    });
+    }, options);
     history.navigate("/two", "replace");
   }
 };

--- a/tests/cases/navigate/finish-call-sets-location.ts
+++ b/tests/cases/navigate/finish-call-sets-location.ts
@@ -3,12 +3,12 @@ import { TestCaseArgs } from "../../types";
 // should this be an integration test?
 export default {
   msg: "updates history's location when finish function is called",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(history.location.pathname).toBe("/one");
       pending.finish();
       expect(history.location.pathname).toBe("/two");
-    });
+    }, options);
     history.navigate("/two");
   }
 };

--- a/tests/cases/navigate/finish-not-called.ts
+++ b/tests/cases/navigate/finish-not-called.ts
@@ -2,8 +2,8 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "does nothing if pending.finish() is not called",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {});
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {}, options);
     history.navigate("/two");
     expect(history.location.pathname).toBe("/one");
   }

--- a/tests/cases/navigate/finish-sets-location.ts
+++ b/tests/cases/navigate/finish-sets-location.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "calling pending.finish() sets history's location",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       pending.finish();
-    });
+    }, options);
     history.navigate("/next");
     expect(history.location).toMatchObject({
       pathname: "/next"

--- a/tests/cases/navigate/invalid-method.ts
+++ b/tests/cases/navigate/invalid-method.ts
@@ -2,8 +2,8 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "throws when given an invalid nav method",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {});
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {}, options);
 
     expect(() => {
       // @ts-ignore

--- a/tests/cases/navigate/navigate-anchor-new-location.ts
+++ b/tests/cases/navigate/navigate-anchor-new-location.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "navigate with anchor method pushes for new locations",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(pending.action).toBe("push");
-    });
+    }, options);
     history.navigate("/two", "anchor");
   }
 };

--- a/tests/cases/navigate/navigate-anchor-same-location.ts
+++ b/tests/cases/navigate/navigate-anchor-same-location.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "navigate with anchor method replaces for same location",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(pending.action).toBe("replace");
-    });
+    }, options);
     history.navigate("/one", "anchor");
   }
 };

--- a/tests/cases/navigate/navigate-no-method-new-location.ts
+++ b/tests/cases/navigate/navigate-no-method-new-location.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "navigate with no method pushes for new locations",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(pending.action).toBe("push");
-    });
+    }, options);
     history.navigate("/two");
   }
 };

--- a/tests/cases/navigate/navigate-no-method-same-location.ts
+++ b/tests/cases/navigate/navigate-no-method-same-location.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "navigate with no method replaces for same location",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(pending.action).toBe("replace");
-    });
+    }, options);
     history.navigate("/one");
   }
 };

--- a/tests/cases/navigate/navigate-push.ts
+++ b/tests/cases/navigate/navigate-push.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "navigate with push method pushes",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(pending.action).toBe("push");
-    });
+    }, options);
     history.navigate("/two", "push");
   }
 };

--- a/tests/cases/navigate/navigate-replace.ts
+++ b/tests/cases/navigate/navigate-replace.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "navigate with replace method replaces",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(pending.action).toBe("replace");
-    });
+    }, options);
     history.navigate("/two", "replace");
   }
 };

--- a/tests/cases/navigate/push-increments-key-major.ts
+++ b/tests/cases/navigate/push-increments-key-major.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "push increments major key",
-  fn: function({ pendingHistory }: TestCaseArgs) {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
     let calls = 0;
     let initMajorNum;
-    const history = pendingHistory(pending => {
+    const history = constructor(pending => {
       pending.finish();
       switch (calls++) {
         case 0:
@@ -18,7 +18,7 @@ export default {
           expect(currentMajor).toEqual(initMajorNum + 1);
           expect(currentMinor).toBe(0);
       }
-    });
+    }, options);
     history.navigate("/next");
   }
 };

--- a/tests/cases/navigate/replace-increments-key-minor.ts
+++ b/tests/cases/navigate/replace-increments-key-minor.ts
@@ -2,10 +2,10 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "replace increments minor key",
-  fn: function({ pendingHistory }: TestCaseArgs) {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
     let calls = 0;
     let initMajorNum, initMinorNum;
-    const history = pendingHistory(pending => {
+    const history = constructor(pending => {
       pending.finish();
       switch (calls++) {
         case 0:
@@ -20,8 +20,7 @@ export default {
           expect(currentMajor).toEqual(initMajorNum);
           expect(currentMinor).toBe(initMinorNum + 1);
       }
-    });
-
+    }, options);
     history.navigate("/one");
   }
 };

--- a/tests/cases/navigate/to-is-object.ts
+++ b/tests/cases/navigate/to-is-object.ts
@@ -4,13 +4,13 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "works with object locations",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(pending.location).toMatchObject({
         pathname: "/two",
         hash: "test"
       });
-    });
+    }, options);
     history.navigate({ pathname: "/two", hash: "test" });
   }
 };

--- a/tests/cases/navigate/to-is-string.ts
+++ b/tests/cases/navigate/to-is-string.ts
@@ -4,13 +4,13 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "works with string locations",
-  fn: function({ pendingHistory }: TestCaseArgs) {
-    const history = pendingHistory(pending => {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    const history = constructor(pending => {
       expect(pending.location).toMatchObject({
         pathname: "/two",
         query: "test=ing"
       });
-    });
+    }, options);
     history.navigate("/two?test=ing");
   }
 };

--- a/tests/cases/navigate/with-response-handler.ts
+++ b/tests/cases/navigate/with-response-handler.ts
@@ -2,9 +2,9 @@ import { TestCaseArgs } from "../../types";
 
 export default {
   msg: "triggers a response handler call if handler is registered",
-  fn: function({ pendingHistory }: TestCaseArgs) {
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
     const router = jest.fn();
-    const history = pendingHistory(router);
+    const history = constructor(router, options);
     history.navigate("/two");
     expect(router.mock.calls.length).toBe(1);
   }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,7 +1,8 @@
-import { PendingHistory } from "@hickory/root";
+import { HistoryConstructor, HistoryOptions } from "@hickory/root";
 
 export interface TestCaseArgs {
-  pendingHistory: PendingHistory;
+  constructor: HistoryConstructor;
+  options?: HistoryOptions;
 }
 
 export interface AsyncTestCaseArgs extends TestCaseArgs {


### PR DESCRIPTION
History objects are now created with a response handler function. This gets rid of the "pending" history.