### PR TITLE
location.pathname is set using raw, remove decoding

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 864
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 15416,
-    "minified": 4538,
-    "gzipped": 1867
+    "bundled": 15561,
+    "minified": 4569,
+    "gzipped": 1876
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 15416,
-    "minified": 4538,
-    "gzipped": 1867
+    "bundled": 15561,
+    "minified": 4569,
+    "gzipped": 1876
   }
 }

--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 864
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 16348,
-    "minified": 4883,
-    "gzipped": 2053
+    "bundled": 15416,
+    "minified": 4538,
+    "gzipped": 1867
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 16348,
-    "minified": 4883,
-    "gzipped": 2053
+    "bundled": 15416,
+    "minified": 4538,
+    "gzipped": 1867
   }
 }

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+- Remove `location.rawPathname`. Rely on the `raw` option to correctly format the provided pathname.
+- Remove `RawLocation` type.
+
 ## 2.0.0-beta.0
 
 - Pass `ResponseHandler` as first argument to `Browser`.

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -5,7 +5,6 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  RawLocation,
   AnyLocation
 } from "@hickory/root";
 
@@ -16,7 +15,6 @@ export {
   SessionLocation,
   PartialLocation,
   AnyLocation,
-  RawLocation,
   LocationComponents
 };
 

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -23,7 +23,7 @@ describe("browser integration tests", () => {
       (<jasmine.Spy>window.history.replaceState).calls.reset();
     });
 
-    it("new URL uses rawPathname, not pathname", () => {
+    it("new URL is encoded", () => {
       testHistory = Browser(pending => {
         pending.finish();
       });
@@ -31,7 +31,7 @@ describe("browser integration tests", () => {
         pathname: "/encoded-percent%25"
       });
       expect(window.location.pathname).toEqual("/encoded-percent%25");
-      expect(testHistory.location.pathname).toEqual("/encoded-percent%");
+      expect(testHistory.location.pathname).toEqual("/encoded-percent%25");
     });
 
     describe("push navigation", () => {

--- a/packages/browser/types/types.d.ts
+++ b/packages/browser/types/types.d.ts
@@ -1,4 +1,4 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation } from "@hickory/root";
-export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
 export declare type BrowserHistoryOptions = HistoryOptions;
 export declare type BrowserHistory = History;

--- a/packages/dom-utils/.size-snapshot.json
+++ b/packages/dom-utils/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-dom-utils.es.js": {
-    "bundled": 877,
-    "minified": 438,
-    "gzipped": 269,
+    "bundled": 1002,
+    "minified": 469,
+    "gzipped": 291,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-dom-utils.js": {
-    "bundled": 1060,
-    "minified": 605,
-    "gzipped": 328
+    "bundled": 1185,
+    "minified": 636,
+    "gzipped": 349
   },
   "dist/hickory-dom-utils.umd.js": {
-    "bundled": 1420,
-    "minified": 622,
-    "gzipped": 398
+    "bundled": 1555,
+    "minified": 653,
+    "gzipped": 420
   },
   "dist/hickory-dom-utils.min.js": {
-    "bundled": 1420,
-    "minified": 622,
-    "gzipped": 398
+    "bundled": 1555,
+    "minified": 653,
+    "gzipped": 420
   }
 }

--- a/packages/dom-utils/src/index.ts
+++ b/packages/dom-utils/src/index.ts
@@ -1,7 +1,12 @@
 export function ensureEncodedPathname(pathname: string): string {
   const a = document.createElement("a");
   a.setAttribute("href", pathname);
-  return a.pathname;
+  const encoded = a.pathname;
+  if (encoded.charAt(0) !== "/") {
+    // IE11 fix
+    return "/" + encoded;
+  }
+  return encoded;
 }
 
 export function domExists(): boolean {

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 1094
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 17519,
-    "minified": 5060,
-    "gzipped": 2014
+    "bundled": 17664,
+    "minified": 5091,
+    "gzipped": 2026
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 17519,
-    "minified": 5060,
-    "gzipped": 2014
+    "bundled": 17664,
+    "minified": 5091,
+    "gzipped": 2026
   }
 }

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 1094
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 18451,
-    "minified": 5405,
-    "gzipped": 2202
+    "bundled": 17519,
+    "minified": 5060,
+    "gzipped": 2014
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 18451,
-    "minified": 5405,
-    "gzipped": 2202
+    "bundled": 17519,
+    "minified": 5060,
+    "gzipped": 2014
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+- Remove `location.rawPathname`. Rely on the `raw` option to correctly format the provided pathname.
+- Remove `RawLocation` type.
+
 ## 2.0.0-beta.0
 
 - Pass `ResponseHandler` as first argument to `Hash`.

--- a/packages/hash/src/types.ts
+++ b/packages/hash/src/types.ts
@@ -5,7 +5,6 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  RawLocation,
   AnyLocation
 } from "@hickory/root";
 
@@ -16,7 +15,6 @@ export {
   SessionLocation,
   PartialLocation,
   AnyLocation,
-  RawLocation,
   LocationComponents
 };
 

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -24,7 +24,7 @@ describe("hash integration tests", () => {
       (<jasmine.Spy>window.history.replaceState).calls.reset();
     });
 
-    it("new URL uses rawPathname, not pathname", () => {
+    it("new URL is encoded", () => {
       testHistory = Hash(pending => {
         pending.finish();
       });
@@ -35,7 +35,7 @@ describe("hash integration tests", () => {
         "push"
       );
       expect(window.location.hash).toEqual("#/encoded-percent%25");
-      expect(testHistory.location.pathname).toEqual("/encoded-percent%");
+      expect(testHistory.location.pathname).toEqual("/encoded-percent%25");
     });
 
     describe("push navigation", () => {

--- a/packages/hash/types/types.d.ts
+++ b/packages/hash/types/types.d.ts
@@ -1,5 +1,5 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation } from "@hickory/root";
-export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
 export interface HashTypeOptions {
     hashType?: string;
 }

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 790
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 16272,
-    "minified": 4701,
-    "gzipped": 1944
+    "bundled": 15340,
+    "minified": 4356,
+    "gzipped": 1758
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 16272,
-    "minified": 4701,
-    "gzipped": 1944
+    "bundled": 15340,
+    "minified": 4356,
+    "gzipped": 1758
   }
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Next
 
+- Remove `location.rawPathname`. Rely on the `raw` option to correctly format the provided pathname.
+- Remove `RawLocation` type.
+
+## 2.0.0-beta.1
+
 - Export `createServerHistory` function, for creating many lightweight history constructors, for server-side rendering.
 
 ## 2.0.0-beta.0

--- a/packages/in-memory/src/types.ts
+++ b/packages/in-memory/src/types.ts
@@ -5,7 +5,6 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  RawLocation,
   AnyLocation
 } from "@hickory/root";
 
@@ -16,7 +15,6 @@ export {
   SessionLocation,
   PartialLocation,
   AnyLocation,
-  RawLocation,
   LocationComponents
 };
 

--- a/packages/in-memory/types/types.d.ts
+++ b/packages/in-memory/types/types.d.ts
@@ -1,5 +1,5 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, RawLocation, AnyLocation } from "@hickory/root";
-export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, RawLocation, LocationComponents };
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
 export declare type InputLocation = string | PartialLocation;
 export declare type InputLocations = Array<InputLocation>;
 export interface SessionOptions {

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 9388,
-    "minified": 3465,
-    "gzipped": 1477,
+    "bundled": 8524,
+    "minified": 3113,
+    "gzipped": 1289,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 9489,
-    "minified": 3552,
-    "gzipped": 1511
+    "bundled": 8625,
+    "minified": 3200,
+    "gzipped": 1324
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 11349,
-    "minified": 3426,
-    "gzipped": 1546
+    "bundled": 10417,
+    "minified": 3081,
+    "gzipped": 1357
   },
   "dist/hickory-root.min.js": {
-    "bundled": 11349,
-    "minified": 3426,
-    "gzipped": 1546
+    "bundled": 10417,
+    "minified": 3081,
+    "gzipped": 1357
   }
 }

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Remove `location.rawPathname`. Rely on the `raw` option to correctly format the provided pathname.
+
 ## 2.0.0-beta.0
 
 - `HistoryOptions` and `HistoryConstructor` types.

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - Remove `location.rawPathname`. Rely on the `raw` option to correctly format the provided pathname.
+- Remove `RawLocation` type.
 
 ## 2.0.0-beta.0
 

--- a/packages/root/src/navigate.ts
+++ b/packages/root/src/navigate.ts
@@ -1,4 +1,4 @@
-import { SessionLocation, RawLocation } from "./types/location";
+import { SessionLocation, LocationComponents } from "./types/location";
 import {
   PendingNavigation,
   FinishNavigation,
@@ -87,7 +87,7 @@ export default function navigationHandler(args: NavigateArgs): NavigateHelpers {
     }
   }
 
-  function replaceNav(location: RawLocation): PendingNavigation {
+  function replaceNav(location: LocationComponents): PendingNavigation {
     const keyedLocation = locationUtils.keyed(
       location,
       keygen.minor(current().key)
@@ -100,7 +100,7 @@ export default function navigationHandler(args: NavigateArgs): NavigateHelpers {
     );
   }
 
-  function pushNav(location: RawLocation): PendingNavigation {
+  function pushNav(location: LocationComponents): PendingNavigation {
     const keyedLocation = locationUtils.keyed(
       location,
       keygen.major(current().key)

--- a/packages/root/src/types/index.ts
+++ b/packages/root/src/types/index.ts
@@ -5,7 +5,6 @@ export {
   PartialLocation,
   SessionLocation,
   AnyLocation,
-  RawLocation,
   Key
 } from "./location";
 

--- a/packages/root/src/types/location.ts
+++ b/packages/root/src/types/location.ts
@@ -7,13 +7,9 @@ export interface LocationComponents {
 
 export type PartialLocation = Partial<LocationComponents>;
 
-export interface RawLocation extends LocationComponents {
-  rawPathname: string;
-}
-
 export type Key = [number, number];
 
-export interface SessionLocation extends RawLocation {
+export interface SessionLocation extends LocationComponents {
   key: Key;
 }
 

--- a/packages/root/src/types/locationUtils.ts
+++ b/packages/root/src/types/locationUtils.ts
@@ -1,4 +1,9 @@
-import { RawLocation, SessionLocation, PartialLocation, Key } from "./location";
+import {
+  LocationComponents,
+  SessionLocation,
+  PartialLocation,
+  Key
+} from "./location";
 
 export interface QueryFunctions {
   parse: (query?: string) => any;
@@ -9,14 +14,13 @@ export type RawPathname = (pathname: string) => string;
 
 export interface LocationUtilOptions {
   query?: QueryFunctions;
-  decode?: boolean;
   baseSegment?: string;
   raw?: RawPathname;
 }
 
 export interface LocationUtils {
-  keyed(location: RawLocation, key: Key): SessionLocation;
-  genericLocation(value: string | object, state?: any): RawLocation;
+  keyed(location: LocationComponents, key: Key): SessionLocation;
+  genericLocation(value: string | object, state?: any): LocationComponents;
   stringifyLocation(location: SessionLocation): string;
   stringifyLocation(location: PartialLocation): string;
 }

--- a/packages/root/tests/locationUtils.spec.ts
+++ b/packages/root/tests/locationUtils.spec.ts
@@ -113,69 +113,23 @@ describe("locationFactory", () => {
           expect(output.pathname).toBe("/");
         });
       });
-
-      describe("decode option", () => {
-        it("decodes the pathname by default", () => {
-          const input = {
-            pathname: "/t%C3%B6rt%C3%A9nelem"
-          };
-          const output = genericLocation(input);
-          expect(output.pathname).toBe("/történelem");
-        });
-
-        it("does not decode when decode=false", () => {
-          const { genericLocation } = locationUtils({ decode: false });
-          const input = {
-            pathname: "/t%C3%B6rt%C3%A9nelem"
-          };
-          const output = genericLocation(input);
-          expect(output.pathname).toBe("/t%C3%B6rt%C3%A9nelem");
-        });
-
-        describe("bad encoding", () => {
-          it("throws URIError with clearer message when decoding fails", () => {
-            const input = {
-              pathname: "/bad%"
-            };
-            expect(() => {
-              const output = genericLocation(input);
-            }).toThrow(
-              'Pathname "/bad%" could not be decoded. ' +
-                "This is most likely due to a bad percent-encoding. For more information, " +
-                "see the third paragraph here https://tools.ietf.org/html/rfc3986#section-2.4"
-            );
-          });
-
-          it("does not throw URIError when decode=false", () => {
-            const { genericLocation } = locationUtils({ decode: false });
-            const input = {
-              pathname: "/bad%"
-            };
-            expect(() => {
-              const output = genericLocation(input);
-            }).not.toThrow();
-          });
-        });
-      });
     });
 
-    describe("rawPathname", () => {
+    describe("pathname", () => {
       it("is result of user provided `raw` option", () => {
+        function ensureEncodedPathname(pathname: string): string {
+          return encodeURI(pathname);
+        }
         const { genericLocation } = locationUtils({
-          raw: path =>
-            path
-              .split("")
-              .reverse()
-              .join("")
+          raw: ensureEncodedPathname
         });
-        const output = genericLocation("/test");
-        expect(output.rawPathname).toBe("tset/");
+        const output = genericLocation("/Beyoncé");
+        expect(output.pathname).toBe("/Beyonc%C3%A9");
       });
 
-      it("uses default fn if `raw` option is not provided", () => {
-        const output = genericLocation("/test%20ing");
-        expect(output.pathname).toBe("/test ing");
-        expect(output.rawPathname).toBe("/test%20ing");
+      it("uses provided string if `raw` option is not provided", () => {
+        const output = genericLocation("/Beyoncé");
+        expect(output.pathname).toBe("/Beyoncé");
       });
     });
 
@@ -313,15 +267,6 @@ describe("locationFactory", () => {
         };
         const output = stringifyLocation(input);
         expect(output).toBe("/test");
-      });
-
-      it("prefers rawPathname", () => {
-        const input = {
-          rawPathname: "/rawPathname",
-          pathname: "/pathname"
-        } as SessionLocation;
-        const output = stringifyLocation(input);
-        expect(output).toBe("/rawPathname");
       });
 
       it("uses empty string for pathname if neither pathname or rawPathname provided", () => {

--- a/packages/root/tests/locationUtils.spec.ts
+++ b/packages/root/tests/locationUtils.spec.ts
@@ -269,7 +269,7 @@ describe("locationFactory", () => {
         expect(output).toBe("/test");
       });
 
-      it("uses empty string for pathname if neither pathname or rawPathname provided", () => {
+      it("uses empty string for pathname if pathname is not provided", () => {
         const input = { hash: "test" };
         const output = stringifyLocation(input);
         expect(output).toBe("#test");

--- a/packages/root/tests/navigationHandler.spec.ts
+++ b/packages/root/tests/navigationHandler.spec.ts
@@ -11,24 +11,21 @@ const initialLocation: SessionLocation = {
   pathname: "/",
   hash: "",
   query: "",
-  key: [0, 0],
-  rawPathname: "/"
+  key: [0, 0]
 };
 
 const locationOne: SessionLocation = {
   pathname: "/one",
   hash: "",
   query: "",
-  key: [1, 0],
-  rawPathname: "/one"
+  key: [1, 0]
 };
 
 const locationTwo: SessionLocation = {
   pathname: "/two",
   hash: "",
   query: "",
-  key: [2, 0],
-  rawPathname: "/two"
+  key: [2, 0]
 };
 
 function historyHelpers(initial: SessionLocation) {

--- a/packages/root/types/types/index.d.ts
+++ b/packages/root/types/types/index.d.ts
@@ -1,5 +1,5 @@
 export { HistoryOptions, HistoryConstructor, History } from "./hickory";
-export { LocationComponents, PartialLocation, SessionLocation, AnyLocation, RawLocation, Key } from "./location";
+export { LocationComponents, PartialLocation, SessionLocation, AnyLocation, Key } from "./location";
 export { KeyFns } from "./keyGenerator";
 export { LocationUtilOptions, QueryFunctions, RawPathname, LocationUtils } from "./locationUtils";
 export { NavigationInfo, ConfirmationFunction, ConfirmationMethods, BlockingHistory } from "./navigationConfirmation";

--- a/packages/root/types/types/location.d.ts
+++ b/packages/root/types/types/location.d.ts
@@ -5,11 +5,8 @@ export interface LocationComponents {
     state?: any;
 }
 export declare type PartialLocation = Partial<LocationComponents>;
-export interface RawLocation extends LocationComponents {
-    rawPathname: string;
-}
 export declare type Key = [number, number];
-export interface SessionLocation extends RawLocation {
+export interface SessionLocation extends LocationComponents {
     key: Key;
 }
 export declare type AnyLocation = SessionLocation | PartialLocation;

--- a/packages/root/types/types/locationUtils.d.ts
+++ b/packages/root/types/types/locationUtils.d.ts
@@ -1,4 +1,4 @@
-import { RawLocation, SessionLocation, PartialLocation, Key } from "./location";
+import { LocationComponents, SessionLocation, PartialLocation, Key } from "./location";
 export interface QueryFunctions {
     parse: (query?: string) => any;
     stringify: (query?: any) => string;
@@ -6,13 +6,12 @@ export interface QueryFunctions {
 export declare type RawPathname = (pathname: string) => string;
 export interface LocationUtilOptions {
     query?: QueryFunctions;
-    decode?: boolean;
     baseSegment?: string;
     raw?: RawPathname;
 }
 export interface LocationUtils {
-    keyed(location: RawLocation, key: Key): SessionLocation;
-    genericLocation(value: string | object, state?: any): RawLocation;
+    keyed(location: LocationComponents, key: Key): SessionLocation;
+    genericLocation(value: string | object, state?: any): LocationComponents;
     stringifyLocation(location: SessionLocation): string;
     stringifyLocation(location: PartialLocation): string;
 }


### PR DESCRIPTION
Simplify the `location` object by setting `location.pathname` to the result of calling the `raw` function. For browser/hash histories, this is the result of setting the provided `pathname` as the `href` of an anchor tag, which should encode un-encoded strings while leaving already encoded strings untouched. For in-memory histories, the default behavior is to leave the `pathname` as provided.

This also removes the `location.rawPathname` property.