### PR TITLE
Rename raw option to pathname

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 4781,
-    "minified": 1865,
+    "bundled": 4791,
+    "minified": 1875,
     "gzipped": 824,
     "treeshaked": {
       "rollup": {
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 4969,
-    "minified": 2012,
-    "gzipped": 907
+    "bundled": 4979,
+    "minified": 2022,
+    "gzipped": 909
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 16176,
-    "minified": 4713,
-    "gzipped": 1988
+    "bundled": 16284,
+    "minified": 4728,
+    "gzipped": 1984
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 16176,
-    "minified": 4713,
-    "gzipped": 1988
+    "bundled": 16284,
+    "minified": 4728,
+    "gzipped": 1984
   }
 }

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Rename `raw` option to `pathname`.
+
 ## 2.0.0-beta.3
 
 - Use `encodeurl` package to ensure proper encoding across browsers.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -28,8 +28,8 @@ export function Browser(
     throw new Error("Cannot use @hickory/browser without a DOM");
   }
 
-  if (!options.raw) {
-    options.raw = encodePathname;
+  if (!options.pathname) {
+    options.pathname = encodePathname;
   }
 
   const locationUtilities = locationUtils(options);

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 6966,
-    "minified": 2693,
-    "gzipped": 1047,
+    "bundled": 6976,
+    "minified": 2703,
+    "gzipped": 1048,
     "treeshaked": {
       "rollup": {
         "code": 99,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 7303,
-    "minified": 2984,
+    "bundled": 7313,
+    "minified": 2994,
     "gzipped": 1136
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 18181,
-    "minified": 5235,
-    "gzipped": 2125
+    "bundled": 18289,
+    "minified": 5250,
+    "gzipped": 2123
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 18181,
-    "minified": 5235,
-    "gzipped": 2125
+    "bundled": 18289,
+    "minified": 5250,
+    "gzipped": 2123
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Rename `raw` option to `pathname`.
+
 ## 2.0.0-beta.3
 
 - Use `encodeurl` package to ensure proper encoding across browsers.

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -31,8 +31,8 @@ export function Hash(
     throw new Error("Cannot use @hickory/hash without a DOM");
   }
 
-  if (!options.raw) {
-    options.raw = encodePathname;
+  if (!options.pathname) {
+    options.pathname = encodePathname;
   }
 
   const locationUtilities = locationUtils(options);

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 790
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15340,
-    "minified": 4356,
-    "gzipped": 1758
+    "bundled": 15438,
+    "minified": 4361,
+    "gzipped": 1756
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15340,
-    "minified": 4356,
-    "gzipped": 1758
+    "bundled": 15438,
+    "minified": 4361,
+    "gzipped": 1756
   }
 }

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 8524,
-    "minified": 3113,
-    "gzipped": 1289,
+    "bundled": 8622,
+    "minified": 3134,
+    "gzipped": 1288,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 8625,
-    "minified": 3200,
+    "bundled": 8723,
+    "minified": 3221,
     "gzipped": 1324
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 10417,
-    "minified": 3081,
-    "gzipped": 1357
+    "bundled": 10515,
+    "minified": 3086,
+    "gzipped": 1356
   },
   "dist/hickory-root.min.js": {
-    "bundled": 10417,
-    "minified": 3081,
-    "gzipped": 1357
+    "bundled": 10515,
+    "minified": 3086,
+    "gzipped": 1356
   }
 }

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Rename `raw` option to `pathname`.
+
 ## 2.0.0-beta.2
 
 - Remove `location.rawPathname`. Rely on the `raw` option to correctly format the provided pathname.

--- a/packages/root/src/locationUtils.ts
+++ b/packages/root/src/locationUtils.ts
@@ -16,14 +16,14 @@ import { ToArgument } from "./types/navigate";
 import {
   LocationUtilOptions,
   LocationUtils,
-  RawPathname
+  ModifyPathname
 } from "./types/locationUtils";
 
-function defaultParseQuery(query?: string): any {
+function default_parse_query(query?: string): any {
   return query ? query : "";
 }
 
-function defaultStringifyQuery(query?: any): string {
+function default_stringify_query(query?: any): string {
   return query ? query : "";
 }
 
@@ -35,7 +35,7 @@ function isValidBase(baseSegment: string): boolean {
   );
 }
 
-function defaultRaw(p: string): string {
+function default_modify(p: string): string {
   return p;
 }
 
@@ -44,11 +44,11 @@ export default function locationFactory(
 ): LocationUtils {
   const {
     query: {
-      parse: parseQuery = defaultParseQuery,
-      stringify: stringifyQuery = defaultStringifyQuery
+      parse: parseQuery = default_parse_query,
+      stringify: stringifyQuery = default_stringify_query
     } = {},
     baseSegment = "",
-    raw = defaultRaw
+    pathname: modifyPathname = default_modify
   } = options;
 
   if (baseSegment !== "" && !isValidBase(baseSegment)) {
@@ -64,7 +64,7 @@ export default function locationFactory(
   function parsePath(
     value: string,
     state: any,
-    raw: RawPathname
+    modifyPathname: ModifyPathname
   ): LocationComponents {
     // hash is always after query, so split it off first
     const hashIndex = value.indexOf("#");
@@ -88,7 +88,7 @@ export default function locationFactory(
     const details: LocationComponents = {
       hash,
       query,
-      pathname: raw(stripBaseSegment(value, baseSegment))
+      pathname: modifyPathname(stripBaseSegment(value, baseSegment))
     };
 
     if (state) {
@@ -101,10 +101,12 @@ export default function locationFactory(
   function getDetails(
     partial: PartialLocation,
     state: any,
-    raw: RawPathname
+    modifyPathname: ModifyPathname
   ): LocationComponents {
     const details: LocationComponents = {
-      pathname: raw(partial.pathname == null ? "/" : partial.pathname),
+      pathname: modifyPathname(
+        partial.pathname == null ? "/" : partial.pathname
+      ),
       hash: partial.hash == null ? "" : partial.hash,
       query: partial.query == null ? parseQuery() : partial.query
     };
@@ -123,8 +125,8 @@ export default function locationFactory(
       state = null;
     }
     return typeof value === "string"
-      ? parsePath(value, state, raw)
-      : getDetails(value, state, raw);
+      ? parsePath(value, state, modifyPathname)
+      : getDetails(value, state, modifyPathname);
   }
 
   function keyed(location: LocationComponents, key: Key): SessionLocation {

--- a/packages/root/src/types/index.ts
+++ b/packages/root/src/types/index.ts
@@ -13,7 +13,7 @@ export { KeyFns } from "./keyGenerator";
 export {
   LocationUtilOptions,
   QueryFunctions,
-  RawPathname,
+  ModifyPathname,
   LocationUtils
 } from "./locationUtils";
 

--- a/packages/root/src/types/locationUtils.ts
+++ b/packages/root/src/types/locationUtils.ts
@@ -10,12 +10,12 @@ export interface QueryFunctions {
   stringify: (query?: any) => string;
 }
 
-export type RawPathname = (pathname: string) => string;
+export type ModifyPathname = (pathname: string) => string;
 
 export interface LocationUtilOptions {
   query?: QueryFunctions;
   baseSegment?: string;
-  raw?: RawPathname;
+  pathname?: ModifyPathname;
 }
 
 export interface LocationUtils {

--- a/packages/root/tests/locationUtils.spec.ts
+++ b/packages/root/tests/locationUtils.spec.ts
@@ -116,18 +116,18 @@ describe("locationFactory", () => {
     });
 
     describe("pathname", () => {
-      it("is result of user provided `raw` option", () => {
+      it("is result of user provided `pathname` option", () => {
         function ensureEncodedPathname(pathname: string): string {
           return encodeURI(pathname);
         }
         const { genericLocation } = locationUtils({
-          raw: ensureEncodedPathname
+          pathname: ensureEncodedPathname
         });
         const output = genericLocation("/Beyoncé");
         expect(output.pathname).toBe("/Beyonc%C3%A9");
       });
 
-      it("uses provided string if `raw` option is not provided", () => {
+      it("is the provided string if `pathname` option is not provided", () => {
         const output = genericLocation("/Beyoncé");
         expect(output.pathname).toBe("/Beyoncé");
       });

--- a/packages/root/types/types/index.d.ts
+++ b/packages/root/types/types/index.d.ts
@@ -1,6 +1,6 @@
 export { HistoryOptions, HistoryConstructor, History } from "./hickory";
 export { LocationComponents, PartialLocation, SessionLocation, AnyLocation, Key } from "./location";
 export { KeyFns } from "./keyGenerator";
-export { LocationUtilOptions, QueryFunctions, RawPathname, LocationUtils } from "./locationUtils";
+export { LocationUtilOptions, QueryFunctions, ModifyPathname, LocationUtils } from "./locationUtils";
 export { NavigationInfo, ConfirmationFunction, ConfirmationMethods, BlockingHistory } from "./navigationConfirmation";
 export { ToArgument, Action, NavType, FinishNavigation, CancelNavigation, PendingNavigation, ResponseHandler, Preparer, FinishCancel, NavigateArgs, NavigateHelpers } from "./navigate";

--- a/packages/root/types/types/locationUtils.d.ts
+++ b/packages/root/types/types/locationUtils.d.ts
@@ -3,11 +3,11 @@ export interface QueryFunctions {
     parse: (query?: string) => any;
     stringify: (query?: any) => string;
 }
-export declare type RawPathname = (pathname: string) => string;
+export declare type ModifyPathname = (pathname: string) => string;
 export interface LocationUtilOptions {
     query?: QueryFunctions;
     baseSegment?: string;
-    raw?: RawPathname;
+    pathname?: ModifyPathname;
 }
 export interface LocationUtils {
     keyed(location: LocationComponents, key: Key): SessionLocation;


### PR DESCRIPTION
`raw` didn't really make sense since the function can be used to do anything with the provided `pathname`. Since the function is used to modify the `pathname` and there is a `query` option used to modify the `query`, it makes sense to name it `pathname`.