### PR TITLE
lowercase exported history constructors

### DIFF
--- a/docs/about/choosing.md
+++ b/docs/about/choosing.md
@@ -37,7 +37,7 @@ location = {
 }
 ```
 
-Generally speaking, if you are running your application in a browser, you will want to use the browser history. However, whether or not you _can_ use it depends on the server that is serving your application. If you can configure your server to respond to any possible pathname request, then you can use the `Browser` history. However, if your application is hosted on a static file server, then you will have to use the `Hash` history.
+Generally speaking, if you are running your application in a browser, you will want to use the browser history. However, whether or not you _can_ use it depends on the server that is serving your application. If you can configure your server to respond to any possible pathname request, then you can use the `browser` history. However, if your application is hosted on a static file server, then you will have to use the `hash` history.
 
 ### Setting up your server to support browser history.
 
@@ -79,9 +79,9 @@ npm install @hickory/in-memory
 ```
 
 ```js
-import InMemory from "@hickory/in-memory";
+import { in_memory } from "@hickory/in-memory";
 
-const history = InMemory();
+const history = in_memory(responseHandler);
 ```
 
 The in-memory history does not have a browser to rely on to keep track of visited locations, so it does this itself. This is done by storing visited locations in an array and keeping an index value to track the current position. This mimics the behavior of a browser, but the code can be run anywhere. This makes in-memory a great choice if you are doing server side rendering for an application, testing out some code that needs to be location-aware, or running in a mobile application. The in-memory history could also be used in a browser if you have an application that needs to perform navigation, but you don't want it to affect the URI.
@@ -89,7 +89,7 @@ The in-memory history does not have a browser to rely on to keep track of visite
 There is a small amount of additional functionality that the in-memory history provides. When creating an in-memory history, you can pass initial locations and the initial index. This can be helpful for restoring a session. You are also able to directly access these values as the `locations` and `index` properties of the history object.
 
 ```js
-const history = InMemory({
+const history = in_memory(responseHandler, {
   locations: ["/one", "/two", { pathname: "/three" }],
   index: 2
 });

--- a/docs/about/introduction.md
+++ b/docs/about/introduction.md
@@ -4,12 +4,12 @@ Hickory provides a three packages that allow you to easily power navigation with
 
 ## Creation
 
-At the root of your project, you will create a history object. There are three choices: `Browser`, `Hash`, and `InMemory`. You can read more about how to pick the right one for your application in the [choosing your history type](./choosing.md) documentation. For simplicity, all example code here will use the `Browser` history type.
+At the root of your project, you will create a history object. There are three choices: `browser`, `hash`, and `in_memory`. (There is also a fourth, lightweight option for server rendering). You can read more about how to pick the right one for your application in the [choosing your history type](./choosing.md) documentation. For simplicity, all example code here will use the `browser` history type.
 
 ```js
-import Browser from "@hickory/Browser";
+import { browser } from "@hickory/browser";
 
-const history = Browser(responseHandler, options);
+const history = browser(responseHandler, options);
 ```
 
 When creating a history object, it must be passed a response handler function. This is a function that will be called whenever there is navigation (as well as immediately with the initial location).

--- a/docs/api/browser.md
+++ b/docs/api/browser.md
@@ -1,9 +1,9 @@
 # Browser API
 
 ```js
-import { Browser } from "@hickory/browser";
+import { browser } from "@hickory/browser";
 
-const history = Browser(responseHandler, options);
+const history = browser(responseHandler, options);
 ```
 
 ## Response Handler

--- a/docs/api/create_server_history.md
+++ b/docs/api/create_server_history.md
@@ -1,0 +1,19 @@
+# Server-Side Rendering API
+
+With server-side rendering, a history object only needs to support limited functionality. It needs to be able to create and stringify locations, but there is no need for navigation.
+
+A new history object is created for every render. Once a render is completed, the history object is thrown away.
+
+While the `in_memory` history could work, it is also more expensive than is necessary because it creates a full history object.
+
+The `create_server_history` function is used to create a lightweight history function. Note that that says function and not object. In your module, you will call `create_server_history` in the global scope. This will save you from having to re-create the object creation/stringifying functions for every new render.
+
+```js
+import { create_server_history } from "@hickory/in-memory";
+
+const server_history = create_server_history();
+
+function handler(req, res) {
+  const history = server_history({ location: req.url });
+}
+```

--- a/docs/api/hash.md
+++ b/docs/api/hash.md
@@ -1,9 +1,9 @@
-# InMemory API
+# Hash API
 
 ```js
-import { InMemory } from "@hickory/in-memory";
+import { hash } from "@hickory/hash";
 
-const history = InMemory(responseHandler, options);
+const history = hash(responseHandler, options);
 ```
 
 ## Response Handler
@@ -19,10 +19,6 @@ The response handler function will be passed a "pending navigation" object. This
 
 ## Options
 
-- `locations` - An array of location objects or strings.
-
-- `index` - The index of the "current" location in the locations array.
-
 - `query` - An object with two required properties: `parse` and `stringify`.
 
   - `parse` - A function that will convert a search string to a query value. This function should return a default value when it is called with no arguments.
@@ -31,9 +27,32 @@ The response handler function will be passed a "pending navigation" object. This
 
 - `decode` - Whether or not to automatically decode the `pathname` when creating a location. This should almost always be `true`, but if you have a reason to use invalid URIs, then you _can_ set this to `false` (possibly to your own peril). (default: `true`)
 
-- `pathname` - A function that will be used to modify the `pathname` property of location objects. The default behavior is to return the provided string.
+- `hashType` - The `hashType` specifies how we translate `window.location.hash` to a location (and vice versa). The options are `default`, `bang`. and `clean`.
+
+  - `default` - The encoded path begins with `#/`. If you do not provide a `hashType` option, this one will be used.
+
+  - `bang` - The encoded path begins with `#!/`.
+
+  - `clean` - The encoded path begins with `#` (no leading slash). This has one exception, which is the root location because there has to be at least one charater after the pound sign for a valid hash string.
+
+- `pathname` - A function that will be used to modify the `pathname` property of location objects. The default behavior is to fully encode a location's `pathname`.
 
 - `base_segment` - This is a string that begins with a forward slash and ends with a non-foward slash character. It should be provided if your application is not being served from the root of your server.
+
+**Note:** While you _can_ use the `base_segment` with a `hash` history, you probably should not. The `base_segment` only affects the `pathname` of location objects (and the URIs those produce). For example, if you create a history like this:
+
+```js
+const history = hash({ base_segment: "/test" });
+```
+
+The `/test` segment will be stripped from and included in the hash segment of the full URI.
+
+```js
+const uri = history.to_href({ pathname: "/pathname" });
+// uri === '#/test/pathname'
+```
+
+Any pathname segments that exist prior to the hash section (or the full URI) will be ignored.
 
 ## Properties
 
@@ -116,32 +135,14 @@ The `go` function is used to jump forward and backward to already visited locati
 
 `num` - The number of steps forward or backward to go.
 
-### reset()
-
-```js
-history.reset({
-  locations: ["/one", "/two"],
-  index: 1
-});
-```
-
-Reset the location state of the `history` instance.
-
-#### arguments
-
-An object with the following (optional) properties:
-
-- `locations` - An array of location objects or strings.
-- `index` - The index of the "current" location in the locations array.
-
 ### to_href()
 
 ```js
 history.to_href({ pathname: "/spamalot" });
-// /spamalot
+// #/spamalot
 ```
 
-The `to_href` function generates the string representation of the location object.
+The `to_href` function generates the string representation of the location object. This string could be parsed to create the same location object, which means that for a hash history, it will be prepended with the pound sign (`#`).
 
 #### arguments
 

--- a/docs/api/in-memory.md
+++ b/docs/api/in-memory.md
@@ -1,9 +1,9 @@
-# Hash API
+# In Memory API
 
 ```js
-import { Hash } from "@hickory/hash";
+import { in_memory } from "@hickory/in-memory";
 
-const history = Hash(responseHandler, options);
+const history = in_memory(responseHandler, options);
 ```
 
 ## Response Handler
@@ -19,6 +19,10 @@ The response handler function will be passed a "pending navigation" object. This
 
 ## Options
 
+- `locations` - An array of location objects or strings.
+
+- `index` - The index of the "current" location in the locations array.
+
 - `query` - An object with two required properties: `parse` and `stringify`.
 
   - `parse` - A function that will convert a search string to a query value. This function should return a default value when it is called with no arguments.
@@ -27,32 +31,9 @@ The response handler function will be passed a "pending navigation" object. This
 
 - `decode` - Whether or not to automatically decode the `pathname` when creating a location. This should almost always be `true`, but if you have a reason to use invalid URIs, then you _can_ set this to `false` (possibly to your own peril). (default: `true`)
 
-- `hashType` - The `hashType` specifies how we translate `window.location.hash` to a location (and vice versa). The options are `default`, `bang`. and `clean`.
-
-  - `default` - The encoded path begins with `#/`. If you do not provide a `hashType` option, this one will be used.
-
-  - `bang` - The encoded path begins with `#!/`.
-
-  - `clean` - The encoded path begins with `#` (no leading slash). This has one exception, which is the root location because there has to be at least one charater after the pound sign for a valid hash string.
-
-- `pathname` - A function that will be used to modify the `pathname` property of location objects. The default behavior is to fully encode a location's `pathname`.
+- `pathname` - A function that will be used to modify the `pathname` property of location objects. The default behavior is to return the provided string.
 
 - `base_segment` - This is a string that begins with a forward slash and ends with a non-foward slash character. It should be provided if your application is not being served from the root of your server.
-
-**Note:** While you _can_ use the `base_segment` with a `Hash` history, you probably should not. The `base_segment` only affects the `pathname` of location objects (and the URIs those produce). For example, if you create a history like this:
-
-```js
-const history = Hash({ base_segment: "/test" });
-```
-
-The `/test` segment will be stripped from and included in the hash segment of the full URI.
-
-```js
-const uri = history.to_href({ pathname: "/pathname" });
-// uri === '#/test/pathname'
-```
-
-Any pathname segments that exist prior to the hash section (or the full URI) will be ignored.
 
 ## Properties
 
@@ -135,14 +116,32 @@ The `go` function is used to jump forward and backward to already visited locati
 
 `num` - The number of steps forward or backward to go.
 
+### reset()
+
+```js
+history.reset({
+  locations: ["/one", "/two"],
+  index: 1
+});
+```
+
+Reset the location state of the `history` instance.
+
+#### arguments
+
+An object with the following (optional) properties:
+
+- `locations` - An array of location objects or strings.
+- `index` - The index of the "current" location in the locations array.
+
 ### to_href()
 
 ```js
 history.to_href({ pathname: "/spamalot" });
-// #/spamalot
+// /spamalot
 ```
 
-The `to_href` function generates the string representation of the location object. This string could be parsed to create the same location object, which means that for a hash history, it will be prepended with the pound sign (`#`).
+The `to_href` function generates the string representation of the location object.
 
 #### arguments
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -225,7 +225,9 @@
       "version": "file:packages/browser",
       "requires": {
         "@hickory/dom-utils": "file:packages/dom-utils",
-        "@hickory/root": "file:packages/root"
+        "@hickory/root": "file:packages/root",
+        "@types/encodeurl": "^1.0.0",
+        "encodeurl": "^1.0.2"
       }
     },
     "@hickory/dom-utils": {
@@ -236,7 +238,9 @@
       "requires": {
         "@hickory/dom-utils": "file:packages/dom-utils",
         "@hickory/location-utils": "file:packages/location-utils",
-        "@hickory/root": "file:packages/root"
+        "@hickory/root": "file:packages/root",
+        "@types/encodeurl": "^1.0.0",
+        "encodeurl": "^1.0.2"
       }
     },
     "@hickory/in-memory": {
@@ -1222,6 +1226,11 @@
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       }
+    },
+    "@types/encodeurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/encodeurl/-/encodeurl-1.0.0.tgz",
+      "integrity": "sha512-iO2Q6xQOJ5DtOB6wJ2KIetFq9JRTbpzcKTe2aS6CCsa+W9KNWX2yXx9KeB5sY/nBfAWN43LkPg6SFB+ldsW9ZA=="
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -3965,8 +3974,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.12",
@@ -5049,9 +5057,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -5078,7 +5086,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5104,7 +5112,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5143,7 +5151,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5192,7 +5200,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5212,12 +5220,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -5282,17 +5290,17 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5316,7 +5324,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5327,18 +5335,18 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -5355,13 +5363,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5438,12 +5446,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -5473,16 +5481,16 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5500,7 +5508,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5553,17 +5561,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -5574,12 +5582,12 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -5589,7 +5597,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -9727,554 +9735,6 @@
             "to-regex-range": "^2.1.0"
           }
         },
-        "fsevents": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-          "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "nan": "^2.9.2",
-            "node-pre-gyp": "^0.10.0"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "chownr": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "detect-libc": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "fs-minipass": {
-              "version": "1.2.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "iconv-lite": {
-              "version": "0.4.24",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "ini": {
-              "version": "1.3.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "minipass": {
-              "version": "2.3.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            },
-            "minizlib": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "needle": {
-              "version": "2.2.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "debug": "^2.1.2",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-              }
-            },
-            "node-pre-gyp": {
-              "version": "0.10.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.1",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.2.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "npm-packlist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "semver": {
-              "version": "5.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "4.4.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.4",
-                "minizlib": "^1.1.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "wide-align": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "string-width": "^1.0.2 || 2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
         "is-glob": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
@@ -11197,9 +10657,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true,
       "optional": true
     },

--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -2,7 +2,7 @@
   "dist/hickory-browser.es.js": {
     "bundled": 4871,
     "minified": 1906,
-    "gzipped": 823,
+    "gzipped": 821,
     "treeshaked": {
       "rollup": {
         "code": 67,
@@ -16,7 +16,7 @@
   "dist/hickory-browser.js": {
     "bundled": 5050,
     "minified": 2044,
-    "gzipped": 909
+    "gzipped": 908
   },
   "dist/hickory-browser.umd.js": {
     "bundled": 16479,

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Lowercase export (`Browser` to `browser`).
+
 ## 2.0.0-beta.5
 
 - Rename `toHref` property to `to_href`.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -20,7 +20,7 @@ export * from "./types";
 
 function noop() {}
 
-export function Browser(
+export function browser(
   fn: ResponseHandler,
   options: BrowserHistoryOptions = {}
 ): BrowserHistory {

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -1,5 +1,5 @@
 ///<reference types="jasmine"/>
-import { Browser } from "../../src";
+import { browser } from "../../src";
 
 describe("browser integration tests", () => {
   let test_history;
@@ -24,7 +24,7 @@ describe("browser integration tests", () => {
     });
 
     it("new URL is encoded", () => {
-      test_history = Browser(pending => {
+      test_history = browser(pending => {
         pending.finish();
       });
       test_history.navigate({
@@ -36,7 +36,7 @@ describe("browser integration tests", () => {
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
-        test_history = Browser(pending => {
+        test_history = browser(pending => {
           pending.finish();
         });
         test_history.navigate("/the-new-location", "push");
@@ -49,7 +49,7 @@ describe("browser integration tests", () => {
       });
 
       it("sets the state", () => {
-        test_history = Browser(pending => {
+        test_history = browser(pending => {
           pending.finish();
         });
         const provided_state = { is_set: true };
@@ -68,7 +68,7 @@ describe("browser integration tests", () => {
 
     describe("replace navigation", () => {
       it("uses history.replaceState", () => {
-        test_history = Browser(pending => {
+        test_history = browser(pending => {
           pending.finish();
         });
         test_history.navigate("/the-same-location", "replace");
@@ -80,7 +80,7 @@ describe("browser integration tests", () => {
       });
 
       it("sets the state", () => {
-        test_history = Browser(pending => {
+        test_history = browser(pending => {
           pending.finish();
         });
         const provided_state = { is_set: true };
@@ -101,7 +101,7 @@ describe("browser integration tests", () => {
   describe("go", () => {
     it("is detectable through a popstate listener", done => {
       let calls = 0;
-      test_history = Browser(pending => {
+      test_history = browser(pending => {
         let local_history = test_history;
         switch (calls++) {
           case 0:
@@ -135,7 +135,7 @@ describe("browser integration tests", () => {
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
       let calls = 0;
-      test_history = Browser(pending => {
+      test_history = browser(pending => {
         let local_history = test_history;
         switch (calls++) {
           case 0:

--- a/packages/browser/tests/unit/browser.spec.ts
+++ b/packages/browser/tests/unit/browser.spec.ts
@@ -1,5 +1,5 @@
 import "jest";
-import { Browser } from "../../src";
+import { browser } from "../../src";
 
 import { with_dom, async_with_dom } from "../../../../tests/utils/dom";
 import {
@@ -17,7 +17,7 @@ function run_async_test(test: TestCase) {
       { url: "http://example.com/one" },
       ({ window, resolve }) => {
         test.fn({
-          constructor: Browser,
+          constructor: browser,
           resolve
         });
       }
@@ -29,7 +29,7 @@ function run_test(test: TestCase) {
   it(test.msg, () => {
     with_dom({ url: "http://example.com/one" }, ({ window }) => {
       test.fn({
-        constructor: Browser
+        constructor: browser
       });
     });
   });
@@ -45,10 +45,10 @@ function run_suite(suite: Suite) {
   });
 }
 
-describe("Browser", () => {
+describe("browser", () => {
   it("initializes using window.location", () => {
     with_dom({ url: "http://example.com/one" }, ({ window }) => {
-      const test_history = Browser(pending => {
+      const test_history = browser(pending => {
         pending.finish();
       });
       expect(test_history.location).toMatchObject({
@@ -62,7 +62,7 @@ describe("Browser", () => {
   it("throws if there is no DOM", () => {
     with_dom({ url: "http://example.com/one", set_global: false }, () => {
       expect(() => {
-        const test_history = Browser(pending => {
+        const test_history = browser(pending => {
           pending.finish();
         });
       }).toThrow();
@@ -72,7 +72,7 @@ describe("Browser", () => {
   it('sets initial action to "push" when page has not been previously visited', () => {
     with_dom({ url: "http://example.com/one" }, ({ window }) => {
       window.history.pushState(null, "", "/has-no-key");
-      const test_history = Browser(pending => {
+      const test_history = browser(pending => {
         expect(pending.action).toBe("push");
         pending.finish();
       });
@@ -82,7 +82,7 @@ describe("Browser", () => {
   it('sets initial action to "pop" when page has been previously visited', () => {
     with_dom({ url: "http://example.com/one" }, ({ window }) => {
       window.history.pushState({ key: "17.0" }, "", "/has-key");
-      const test_history = Browser(pending => {
+      const test_history = browser(pending => {
         expect(pending.action).toBe("pop");
         pending.finish();
       });
@@ -102,13 +102,13 @@ describe("go", () => {
   run_suite(go_suite);
 });
 
-describe("Browser history.go", () => {
+describe("browser history.go", () => {
   // integration?
   it("calls window.history.go with provided value", () => {
     with_dom({ url: "http://example.com/one" }, ({ window }) => {
       const real_go = window.history.go;
       const mock_go = (window.history.go = jest.fn());
-      const test_history = Browser(pending => {
+      const test_history = browser(pending => {
         pending.finish();
       });
 
@@ -123,7 +123,7 @@ describe("Browser history.go", () => {
 describe("to_href", () => {
   it("returns the location formatted as a string", () => {
     with_dom({ url: "http://example.com/one" }, () => {
-      const test_history = Browser(pending => {
+      const test_history = browser(pending => {
         pending.finish();
       });
       const path = test_history.to_href({

--- a/packages/browser/types/index.d.ts
+++ b/packages/browser/types/index.d.ts
@@ -1,4 +1,4 @@
 import { ResponseHandler } from "@hickory/root";
 import { BrowserHistoryOptions, BrowserHistory } from "./types";
 export * from "./types";
-export declare function Browser(fn: ResponseHandler, options?: BrowserHistoryOptions): BrowserHistory;
+export declare function browser(fn: ResponseHandler, options?: BrowserHistoryOptions): BrowserHistory;

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -2,7 +2,7 @@
   "dist/hickory-hash.es.js": {
     "bundled": 7102,
     "minified": 2759,
-    "gzipped": 1051,
+    "gzipped": 1050,
     "treeshaked": {
       "rollup": {
         "code": 99,
@@ -16,16 +16,16 @@
   "dist/hickory-hash.js": {
     "bundled": 7429,
     "minified": 3040,
-    "gzipped": 1142
+    "gzipped": 1140
   },
   "dist/hickory-hash.umd.js": {
     "bundled": 18528,
     "minified": 5272,
-    "gzipped": 2126
+    "gzipped": 2124
   },
   "dist/hickory-hash.min.js": {
     "bundled": 18528,
     "minified": 5272,
-    "gzipped": 2126
+    "gzipped": 2124
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Lowercase export (`Hash` to `hash`).
+
 ## 2.0.0-beta.5
 
 - Rename `toHref` property to `to_href`.

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -23,7 +23,7 @@ function ensure_hash(encode: (path: string) => string): void {
 
 function noop() {}
 
-export function Hash(
+export function hash(
   fn: ResponseHandler,
   options: HashOptions = {}
 ): HashHistory {

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -1,5 +1,5 @@
 ///<reference types="jasmine"/>
-import { Hash } from "../../src";
+import { hash } from "../../src";
 
 describe("hash integration tests", () => {
   let test_history;
@@ -25,7 +25,7 @@ describe("hash integration tests", () => {
     });
 
     it("new URL is encoded", () => {
-      test_history = Hash(pending => {
+      test_history = hash(pending => {
         pending.finish();
       });
       test_history.navigate(
@@ -40,7 +40,7 @@ describe("hash integration tests", () => {
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
-        test_history = Hash(pending => {
+        test_history = hash(pending => {
           pending.finish();
         });
         test_history.navigate("/a-new-position", "push");
@@ -52,7 +52,7 @@ describe("hash integration tests", () => {
       });
 
       it("sets the state", () => {
-        test_history = Hash(pending => {
+        test_history = hash(pending => {
           pending.finish();
         });
         const provided_state = { is_set: true };
@@ -71,7 +71,7 @@ describe("hash integration tests", () => {
 
     describe("replace navigation", () => {
       it("uses history.replaceState", () => {
-        test_history = Hash(pending => {
+        test_history = hash(pending => {
           pending.finish();
         });
         test_history.navigate("/the-same-position", "replace");
@@ -83,7 +83,7 @@ describe("hash integration tests", () => {
       });
 
       it("sets the state", () => {
-        test_history = Hash(pending => {
+        test_history = hash(pending => {
           pending.finish();
         });
         const provided_state = { is_set: true };
@@ -104,7 +104,7 @@ describe("hash integration tests", () => {
   describe("go", () => {
     it("is detectable through a popstate listener", done => {
       let calls = 0;
-      test_history = Hash(pending => {
+      test_history = hash(pending => {
         let local_history = test_history;
         switch (calls++) {
           case 0:
@@ -138,7 +138,7 @@ describe("hash integration tests", () => {
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
       let calls = 0;
-      test_history = Hash(pending => {
+      test_history = hash(pending => {
         let local_history = test_history;
         switch (calls++) {
           case 0:

--- a/packages/hash/tests/unit/hash.spec.ts
+++ b/packages/hash/tests/unit/hash.spec.ts
@@ -1,5 +1,5 @@
 import "jest";
-import { Hash } from "../../src";
+import { hash } from "../../src";
 
 import { with_dom, async_with_dom } from "../../../../tests/utils/dom";
 import {
@@ -17,7 +17,7 @@ function run_async_test(test: TestCase) {
       { url: "http://example.com/#/one" },
       ({ window, resolve }) => {
         test.fn({
-          constructor: Hash,
+          constructor: hash,
           resolve
         });
       }
@@ -29,7 +29,7 @@ function run_test(test: TestCase) {
   it(test.msg, () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       test.fn({
-        constructor: Hash
+        constructor: hash
       });
     });
   });
@@ -45,10 +45,10 @@ function run_suite(suite: Suite) {
   });
 }
 
-describe("Hash constructor", () => {
+describe("hash constructor", () => {
   it("initializes using window.location", () => {
     with_dom({ url: "http://example.com/#/one" }, () => {
-      const test_history = Hash(pending => {
+      const test_history = hash(pending => {
         pending.finish();
       });
       expect(test_history.location).toMatchObject({
@@ -62,7 +62,7 @@ describe("Hash constructor", () => {
   it("throws if there is no DOM", () => {
     with_dom({ url: "http://example.com/#/one", set_global: false }, () => {
       expect(() => {
-        const test_history = Hash(pending => {
+        const test_history = hash(pending => {
           pending.finish();
         });
       }).toThrow();
@@ -72,7 +72,7 @@ describe("Hash constructor", () => {
   it('sets initial action to "push" when page has not been previously visited', () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       window.history.pushState(null, "", "/#has-no-key");
-      const test_history = Hash(pending => {
+      const test_history = hash(pending => {
         expect(pending.action).toBe("push");
         pending.finish();
       });
@@ -82,7 +82,7 @@ describe("Hash constructor", () => {
   it('sets initial action to "pop" when page has been previously visited', () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       window.history.pushState({ key: "17.0" }, "", "/#has-key");
-      const test_history = Hash(pending => {
+      const test_history = hash(pending => {
         expect(pending.action).toBe("pop");
         pending.finish();
       });
@@ -94,7 +94,7 @@ describe("Hash constructor", () => {
       it("sets the expected hash format", () => {
         with_dom({ url: "http://example.com/" }, ({ window }) => {
           expect(window.location.hash).toBe("");
-          const test_history = Hash(pending => {
+          const test_history = hash(pending => {
             pending.finish();
           });
           expect(window.location.hash).toBe("#/");
@@ -106,7 +106,7 @@ describe("Hash constructor", () => {
       it("sets the expected hash format", () => {
         with_dom({ url: "http://example.com/" }, ({ window }) => {
           expect(window.location.hash).toBe("");
-          const test_history = Hash(
+          const test_history = hash(
             pending => {
               pending.finish();
             },
@@ -121,7 +121,7 @@ describe("Hash constructor", () => {
       it("sets the expected hash format", () => {
         with_dom({ url: "http://example.com/" }, ({ window }) => {
           expect(window.location.hash).toBe("");
-          const test_history = Hash(
+          const test_history = hash(
             pending => {
               pending.finish();
             },
@@ -136,7 +136,7 @@ describe("Hash constructor", () => {
       it("sets the expected hash format", () => {
         with_dom({ url: "http://example.com/" }, ({ window }) => {
           expect(window.location.hash).toBe("");
-          const test_history = Hash(
+          const test_history = hash(
             pending => {
               pending.finish();
             },
@@ -151,7 +151,7 @@ describe("Hash constructor", () => {
   describe("decodes from browser based on options.hash_type", () => {
     it("works with no hash_type (default)", () => {
       with_dom({ url: "http://example.com/#/the-path" }, () => {
-        const test_history = Hash(pending => {
+        const test_history = hash(pending => {
           pending.finish();
         });
         expect(test_history.location).toMatchObject({
@@ -162,7 +162,7 @@ describe("Hash constructor", () => {
 
     it("works with default hash_type", () => {
       with_dom({ url: "http://example.com/#/the-path" }, () => {
-        const test_history = Hash(
+        const test_history = hash(
           pending => {
             pending.finish();
           },
@@ -177,7 +177,7 @@ describe("Hash constructor", () => {
     it("works with bang hash_type", () => {
       // bang expects an exclamation point before the leading slash
       with_dom({ url: "http://example.com/#!/the-path" }, () => {
-        const test_history = Hash(
+        const test_history = hash(
           pending => {
             pending.finish();
           },
@@ -192,7 +192,7 @@ describe("Hash constructor", () => {
     it("works with default hash_type", () => {
       // clean expects no leading slash
       with_dom({ url: "http://example.com/#the-path" }, () => {
-        const test_history = Hash(
+        const test_history = hash(
           pending => {
             pending.finish();
           },
@@ -223,7 +223,7 @@ describe("go", () => {
   it("calls window.history.go with provided value", () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       const mock_go = (window.history.go = jest.fn());
-      const test_history = Hash(pending => {
+      const test_history = hash(pending => {
         pending.finish();
       });
       [undefined, 0, 1, -1].forEach((value, index) => {
@@ -237,7 +237,7 @@ describe("go", () => {
 describe("to_href", () => {
   it("returns the location formatted as a string", () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-      const test_history = Hash(pending => {
+      const test_history = hash(pending => {
         pending.finish();
       });
       const current_path = test_history.to_href({
@@ -254,7 +254,7 @@ describe("to_href", () => {
     describe("[none provided]", () => {
       it("outputs expected string", () => {
         with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-          const test_history = Hash(pending => {
+          const test_history = hash(pending => {
             pending.finish();
           });
           expect(test_history.to_href(location)).toBe("#/simple-path");
@@ -265,7 +265,7 @@ describe("to_href", () => {
     describe("default", () => {
       it("outputs expected string", () => {
         with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-          const test_history = Hash(
+          const test_history = hash(
             pending => {
               pending.finish();
             },
@@ -279,7 +279,7 @@ describe("to_href", () => {
     describe("bang", () => {
       it("outputs expected string", () => {
         with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-          const test_history = Hash(
+          const test_history = hash(
             pending => {
               pending.finish();
             },
@@ -293,7 +293,7 @@ describe("to_href", () => {
     describe("clean", () => {
       it("outputs expected string", () => {
         with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-          const test_history = Hash(
+          const test_history = hash(
             pending => {
               pending.finish();
             },

--- a/packages/hash/types/index.d.ts
+++ b/packages/hash/types/index.d.ts
@@ -1,4 +1,4 @@
 import { ResponseHandler } from "@hickory/root";
 import { HashOptions, HashHistory } from "./types";
 export * from "./types";
-export declare function Hash(fn: ResponseHandler, options?: HashOptions): HashHistory;
+export declare function hash(fn: ResponseHandler, options?: HashOptions): HashHistory;

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5460,
-    "minified": 1835,
-    "gzipped": 738,
+    "bundled": 5462,
+    "minified": 1837,
+    "gzipped": 735,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5558,
-    "minified": 1926,
-    "gzipped": 789
+    "bundled": 5561,
+    "minified": 1929,
+    "gzipped": 788
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15652,
-    "minified": 4387,
-    "gzipped": 1757
+    "bundled": 15655,
+    "minified": 4388,
+    "gzipped": 1760
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15652,
-    "minified": 4387,
-    "gzipped": 1757
+    "bundled": 15655,
+    "minified": 4388,
+    "gzipped": 1760
   }
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Lowercase export (`InMemory` to `in_memory`).
+
 ## 2.0.0-beta.5
 
 - Rename `toHref` property to `to_href`.

--- a/packages/in-memory/src/in_memory.ts
+++ b/packages/in-memory/src/in_memory.ts
@@ -19,7 +19,7 @@ import {
 
 function noop() {}
 
-export function InMemory(
+export function in_memory(
   fn: ResponseHandler,
   options: InMemoryOptions = {}
 ): InMemoryHistory {

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./types";
 
-import { InMemory } from "./InMemory";
+import { in_memory } from "./in_memory";
 import { create_server_history } from "./create_server_history";
 
-export { InMemory, create_server_history };
+export { in_memory, create_server_history };

--- a/packages/in-memory/tests/in_memory.spec.ts
+++ b/packages/in-memory/tests/in_memory.spec.ts
@@ -1,5 +1,5 @@
 import "jest";
-import { InMemory } from "../src";
+import { in_memory } from "../src";
 
 import { navigate_suite, go_suite, cancel_suite } from "../../../tests/cases";
 
@@ -21,7 +21,7 @@ function run_async_test(test: TestCase) {
     expect.assertions(test.assertions);
     await new Promise(resolve => {
       test.fn({
-        constructor: InMemory,
+        constructor: in_memory,
         options: {
           locations: ["/one"]
         },
@@ -34,7 +34,7 @@ function run_async_test(test: TestCase) {
 function run_test(test: TestCase) {
   it(test.msg, () => {
     test.fn({
-      constructor: InMemory,
+      constructor: in_memory,
       options: {
         locations: ["/one"]
       }
@@ -54,7 +54,7 @@ function run_suite(suite: Suite) {
 
 describe("Memory constructor", () => {
   it("initializes with root location (/) if none provided", () => {
-    const test_history = InMemory(pending => {
+    const test_history = in_memory(pending => {
       pending.finish();
     });
     expect(test_history.location).toMatchObject({
@@ -65,7 +65,7 @@ describe("Memory constructor", () => {
   });
 
   it("works with string locations", () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         pending.finish();
       },
@@ -80,7 +80,7 @@ describe("Memory constructor", () => {
   });
 
   it("works with object locations", () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         pending.finish();
       },
@@ -95,7 +95,7 @@ describe("Memory constructor", () => {
   });
 
   it("uses the provided index to select initial location", () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         pending.finish();
       },
@@ -111,7 +111,7 @@ describe("Memory constructor", () => {
 
   it("defaults to index 0 if provided index is out of bounds", () => {
     [-1, 3].forEach(value => {
-      const test_history = InMemory(
+      const test_history = in_memory(
         pending => {
           pending.finish();
         },
@@ -127,7 +127,7 @@ describe("Memory constructor", () => {
   });
 
   it('sets initial action to "push"', () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         expect(pending.action).toBe("push");
         pending.finish();
@@ -155,7 +155,7 @@ describe("go suite", () => {
 describe("go", () => {
   describe("with no value", () => {
     it('calls response handler with current location and "pop" action', done => {
-      const test_history = InMemory(pending => {
+      const test_history = in_memory(pending => {
         expect(pending.location).toMatchObject({
           pathname: "/"
         });
@@ -170,7 +170,7 @@ describe("go", () => {
   describe("with a value", () => {
     it("does nothing if the value is outside of the range", () => {
       const router = jest.fn();
-      const test_history = InMemory(router);
+      const test_history = in_memory(router);
       test_history.go(10);
       // just verifying that a popstate event hasn't emitted to
       // trigger the history's event handler
@@ -181,7 +181,7 @@ describe("go", () => {
 
 describe("to_href", () => {
   it("returns the location formatted as a string", () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         pending.finish();
       },
@@ -197,7 +197,7 @@ describe("to_href", () => {
 describe("reset()", () => {
   describe("locations", () => {
     it("works with string locations", () => {
-      const test_history = InMemory(
+      const test_history = in_memory(
         pending => {
           pending.finish();
         },
@@ -218,7 +218,7 @@ describe("reset()", () => {
     });
 
     it("works with object locations", () => {
-      const test_history = InMemory(
+      const test_history = in_memory(
         pending => {
           pending.finish();
         },
@@ -239,7 +239,7 @@ describe("reset()", () => {
     });
 
     it("uses default '/' location if no locations are provided", () => {
-      const test_history = InMemory(
+      const test_history = in_memory(
         pending => {
           pending.finish();
         },
@@ -259,7 +259,7 @@ describe("reset()", () => {
 
     it("reset removes existing locations", () => {
       const router = jest.fn();
-      const test_history = InMemory(router, {
+      const test_history = in_memory(router, {
         locations: ["/one", "/two", "/three"]
       });
 
@@ -283,7 +283,7 @@ describe("reset()", () => {
   });
 
   it("sets location using provided index value", () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         pending.finish();
       },
@@ -302,7 +302,7 @@ describe("reset()", () => {
   });
 
   it("uses location at index 0 if index is not provided", () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         pending.finish();
       },
@@ -320,7 +320,7 @@ describe("reset()", () => {
   });
 
   it("uses location at index 0 if provided index < 0", () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         pending.finish();
       },
@@ -339,7 +339,7 @@ describe("reset()", () => {
   });
 
   it("uses location at index 0 if index is larger than length of locations array", () => {
-    const test_history = InMemory(
+    const test_history = in_memory(
       pending => {
         pending.finish();
       },
@@ -360,7 +360,7 @@ describe("reset()", () => {
   describe("emitting new location", () => {
     it("emits the new location", () => {
       const router = jest.fn();
-      const test_history = InMemory(router, {
+      const test_history = in_memory(router, {
         locations: ["/one", "/two", "/three"]
       });
 
@@ -377,7 +377,7 @@ describe("reset()", () => {
 
     it('emits the action as "push"', () => {
       const router = jest.fn();
-      const test_history = InMemory(router, {
+      const test_history = in_memory(router, {
         locations: ["/one", "/two", "/three"]
       });
 

--- a/packages/in-memory/types/in_memory.d.ts
+++ b/packages/in-memory/types/in_memory.d.ts
@@ -1,3 +1,3 @@
 import { ResponseHandler } from "@hickory/root";
 import { InMemoryOptions, InMemoryHistory } from "./types";
-export declare function InMemory(fn: ResponseHandler, options?: InMemoryOptions): InMemoryHistory;
+export declare function in_memory(fn: ResponseHandler, options?: InMemoryOptions): InMemoryHistory;

--- a/packages/in-memory/types/index.d.ts
+++ b/packages/in-memory/types/index.d.ts
@@ -1,4 +1,4 @@
 export * from "./types";
-import { InMemory } from "./InMemory";
+import { in_memory } from "./in_memory";
 import { create_server_history } from "./create_server_history";
-export { InMemory, create_server_history };
+export { in_memory, create_server_history };


### PR DESCRIPTION
An extension of the snake case export changes.

Future blocking histories will probably be suffixed (e.g. `browser_blocking`).