### PR TITLE
Add blocking versions of histories

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 4863,
-    "minified": 1899,
-    "gzipped": 819,
+    "bundled": 10263,
+    "minified": 3949,
+    "gzipped": 1077,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 4890,
-    "minified": 1923,
-    "gzipped": 863
+    "bundled": 10357,
+    "minified": 4039,
+    "gzipped": 1125
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 17548,
-    "minified": 4840,
-    "gzipped": 2004
+    "bundled": 24323,
+    "minified": 6951,
+    "gzipped": 2387
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 17548,
-    "minified": 4840,
-    "gzipped": 2004
+    "bundled": 24323,
+    "minified": 6951,
+    "gzipped": 2387
   }
 }

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -4,7 +4,7 @@ const getDeps = require("../../rollup/deps");
 const pkg = require("./package.json");
 const deps = getDeps(pkg);
 
-const input = "src/browser.ts";
+const input = "src/index.ts";
 const sourcemap = false;
 const name = "HickoryBrowser";
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./types";
+
+import { browser } from "./browser";
+import { blocking_browser } from "./blocking_browser";
+
+export { browser, blocking_browser };

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -5,7 +5,8 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  AnyLocation
+  AnyLocation,
+  ConfirmationFunction
 } from "@hickory/root";
 
 export {
@@ -20,3 +21,7 @@ export {
 
 export type BrowserHistoryOptions = HistoryOptions;
 export type BrowserHistory = History;
+export interface BlockingBrowserHistory extends BrowserHistory {
+  confirm_with(fn?: ConfirmationFunction): void;
+  remove_confirmation(): void;
+}

--- a/packages/browser/tests/integration/blocking_browser.ts
+++ b/packages/browser/tests/integration/blocking_browser.ts
@@ -1,7 +1,7 @@
 ///<reference types="jasmine"/>
-import { browser } from "../../src";
+import { blocking_browser } from "../../src";
 
-describe("browser integration tests", () => {
+describe("blocking_browser integration tests", () => {
   let test_history;
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
@@ -24,7 +24,7 @@ describe("browser integration tests", () => {
     });
 
     it("new URL is encoded", () => {
-      test_history = browser(pending => {
+      test_history = blocking_browser(pending => {
         pending.finish();
       });
       test_history.navigate({
@@ -36,7 +36,7 @@ describe("browser integration tests", () => {
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
-        test_history = browser(pending => {
+        test_history = blocking_browser(pending => {
           pending.finish();
         });
         test_history.navigate("/the-new-location", "push");
@@ -49,7 +49,7 @@ describe("browser integration tests", () => {
       });
 
       it("sets the state", () => {
-        test_history = browser(pending => {
+        test_history = blocking_browser(pending => {
           pending.finish();
         });
         const provided_state = { is_set: true };
@@ -68,7 +68,7 @@ describe("browser integration tests", () => {
 
     describe("replace navigation", () => {
       it("uses history.replaceState", () => {
-        test_history = browser(pending => {
+        test_history = blocking_browser(pending => {
           pending.finish();
         });
         test_history.navigate("/the-same-location", "replace");
@@ -80,7 +80,7 @@ describe("browser integration tests", () => {
       });
 
       it("sets the state", () => {
-        test_history = browser(pending => {
+        test_history = blocking_browser(pending => {
           pending.finish();
         });
         const provided_state = { is_set: true };
@@ -101,7 +101,7 @@ describe("browser integration tests", () => {
   describe("go", () => {
     it("is detectable through a popstate listener", done => {
       let calls = 0;
-      test_history = browser(pending => {
+      test_history = blocking_browser(pending => {
         let local_history = test_history;
         switch (calls++) {
           case 0:
@@ -135,7 +135,7 @@ describe("browser integration tests", () => {
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
       let calls = 0;
-      test_history = browser(pending => {
+      test_history = blocking_browser(pending => {
         let local_history = test_history;
         switch (calls++) {
           case 0:

--- a/packages/browser/tests/unit/blocking_browser.spec.ts
+++ b/packages/browser/tests/unit/blocking_browser.spec.ts
@@ -1,0 +1,154 @@
+import "jest";
+import { blocking_browser } from "../../src";
+
+import { with_dom, async_with_dom } from "../../../../tests/utils/dom";
+import {
+  navigate_suite,
+  go_suite,
+  cancel_suite,
+  blocking_suite
+} from "../../../../tests/cases";
+
+import { TestCase, Suite } from "../../../../tests/types";
+
+function run_async_test(test: TestCase) {
+  it(test.msg, async () => {
+    expect.assertions(test.assertions);
+    await async_with_dom(
+      { url: "http://example.com/one" },
+      ({ window, resolve }) => {
+        test.fn({
+          constructor: blocking_browser,
+          resolve
+        });
+      }
+    );
+  });
+}
+
+function run_test(test: TestCase) {
+  it(test.msg, () => {
+    with_dom({ url: "http://example.com/one" }, ({ window }) => {
+      test.fn({
+        constructor: blocking_browser
+      });
+    });
+  });
+}
+
+function run_suite(suite: Suite) {
+  suite.forEach(test => {
+    if (test.async) {
+      run_async_test(test);
+    } else {
+      run_test(test);
+    }
+  });
+}
+
+describe("blocking_browser", () => {
+  it("initializes using window.location", () => {
+    with_dom({ url: "http://example.com/one" }, ({ window }) => {
+      const test_history = blocking_browser(pending => {
+        pending.finish();
+      });
+      expect(test_history.location).toMatchObject({
+        pathname: "/one",
+        hash: "",
+        query: ""
+      });
+    });
+  });
+
+  it("throws if there is no DOM", () => {
+    with_dom({ url: "http://example.com/one", set_global: false }, () => {
+      expect(() => {
+        const test_history = blocking_browser(pending => {
+          pending.finish();
+        });
+      }).toThrow();
+    });
+  });
+
+  it('sets initial action to "push" when page has not been previously visited', () => {
+    with_dom({ url: "http://example.com/one" }, ({ window }) => {
+      window.history.pushState(null, "", "/has-no-key");
+      const test_history = blocking_browser(pending => {
+        expect(pending.action).toBe("push");
+        pending.finish();
+      });
+    });
+  });
+
+  it('sets initial action to "pop" when page has been previously visited', () => {
+    with_dom({ url: "http://example.com/one" }, ({ window }) => {
+      window.history.pushState({ key: "17.0" }, "", "/has-key");
+      const test_history = blocking_browser(pending => {
+        expect(pending.action).toBe("pop");
+        pending.finish();
+      });
+    });
+  });
+});
+
+describe("cancel", () => {
+  run_suite(cancel_suite);
+});
+
+describe("navigate()", () => {
+  run_suite(navigate_suite);
+});
+
+describe("blocking", () => {
+  run_suite(blocking_suite);
+});
+
+describe("go", () => {
+  run_suite(go_suite);
+});
+
+describe("browser history.navigate", () => {
+  it("throws if trying to navigate with a non-encoded pathname", () => {
+    with_dom({ url: "http://example.com/one" }, ({ window }) => {
+      const test_history = blocking_browser(pending => {
+        pending.finish();
+      });
+      expect(() => {
+        test_history.navigate("/test ing");
+      }).toThrow();
+    });
+  });
+});
+
+describe("browser history.go", () => {
+  // integration?
+  it("calls window.history.go with provided value", () => {
+    with_dom({ url: "http://example.com/one" }, ({ window }) => {
+      const real_go = window.history.go;
+      const mock_go = (window.history.go = jest.fn());
+      const test_history = blocking_browser(pending => {
+        pending.finish();
+      });
+
+      [undefined, 0, 1, -1].forEach((value, index) => {
+        test_history.go(value);
+        expect(mock_go.mock.calls[index][0]).toBe(value);
+      });
+    });
+  });
+});
+
+describe("to_href", () => {
+  it("returns the location formatted as a string", () => {
+    with_dom({ url: "http://example.com/one" }, () => {
+      const test_history = blocking_browser(pending => {
+        pending.finish();
+      });
+      const path = test_history.to_href({
+        pathname: "/one",
+        query: "test=query"
+      });
+      expect(path).toBe("/one?test=query");
+    });
+  });
+});

--- a/packages/browser/types/blocking_browser.d.ts
+++ b/packages/browser/types/blocking_browser.d.ts
@@ -1,0 +1,3 @@
+import { ResponseHandler } from "@hickory/root";
+import { BrowserHistoryOptions, BlockingBrowserHistory } from "./types";
+export declare function blocking_browser(fn: ResponseHandler, options?: BrowserHistoryOptions): BlockingBrowserHistory;

--- a/packages/browser/types/browser.d.ts
+++ b/packages/browser/types/browser.d.ts
@@ -1,4 +1,3 @@
 import { ResponseHandler } from "@hickory/root";
 import { BrowserHistoryOptions, BrowserHistory } from "./types";
-export * from "./types";
 export declare function browser(fn: ResponseHandler, options?: BrowserHistoryOptions): BrowserHistory;

--- a/packages/browser/types/index.d.ts
+++ b/packages/browser/types/index.d.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+import { browser } from "./browser";
+import { blocking_browser } from "./blocking_browser";
+export { browser, blocking_browser };

--- a/packages/browser/types/types.d.ts
+++ b/packages/browser/types/types.d.ts
@@ -1,4 +1,8 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation, ConfirmationFunction } from "@hickory/root";
 export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
 export declare type BrowserHistoryOptions = HistoryOptions;
 export declare type BrowserHistory = History;
+export interface BlockingBrowserHistory extends BrowserHistory {
+    confirm_with(fn?: ConfirmationFunction): void;
+    remove_confirmation(): void;
+}

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 7094,
-    "minified": 2752,
-    "gzipped": 1049,
+    "bundled": 12511,
+    "minified": 4912,
+    "gzipped": 1347,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 7269,
-    "minified": 2919,
-    "gzipped": 1101
+    "bundled": 12741,
+    "minified": 5133,
+    "gzipped": 1398
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 19695,
-    "minified": 5363,
-    "gzipped": 2157
+    "bundled": 26488,
+    "minified": 7550,
+    "gzipped": 2569
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 19695,
-    "minified": 5363,
-    "gzipped": 2157
+    "bundled": 26488,
+    "minified": 7550,
+    "gzipped": 2569
   }
 }

--- a/packages/hash/rollup.config.js
+++ b/packages/hash/rollup.config.js
@@ -4,7 +4,7 @@ const getDeps = require("../../rollup/deps");
 const pkg = require("./package.json");
 const deps = getDeps(pkg);
 
-const input = "src/hash.ts";
+const input = "src/index.ts";
 const sourcemap = false;
 const name = "HickoryHash";
 

--- a/packages/hash/src/hash.ts
+++ b/packages/hash/src/hash.ts
@@ -16,8 +16,6 @@ import {
 } from "@hickory/root";
 import { HashOptions, HashHistory } from "./types";
 
-export * from "./types";
-
 function ensure_hash(encode: (path: string) => string): void {
   if (window.location.hash === "") {
     window.history.replaceState(null, "", encode("/"));

--- a/packages/hash/src/index.ts
+++ b/packages/hash/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./types";
+
+import { hash } from "./hash";
+import { blocking_hash } from "./blocking_hash";
+
+export { hash, blocking_hash };

--- a/packages/hash/src/types.ts
+++ b/packages/hash/src/types.ts
@@ -5,7 +5,8 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  AnyLocation
+  AnyLocation,
+  ConfirmationFunction
 } from "@hickory/root";
 
 export {
@@ -23,3 +24,7 @@ export interface HashTypeOptions {
 }
 export type HashOptions = HistoryOptions & HashTypeOptions;
 export type HashHistory = History;
+export interface BlockingHashHistory extends HashHistory {
+  confirm_with(fn?: ConfirmationFunction): void;
+  remove_confirmation(): void;
+}

--- a/packages/hash/tests/integration/blocking_hash.ts
+++ b/packages/hash/tests/integration/blocking_hash.ts
@@ -1,11 +1,12 @@
 ///<reference types="jasmine"/>
-import { browser } from "../../src";
+import { blocking_hash } from "../../src";
 
-describe("browser integration tests", () => {
+describe("blocking_hash integration tests", () => {
   let test_history;
+
   beforeEach(() => {
     // we cannot fully reset the history, but this can give us a blank state
-    window.history.pushState({ key: [0, 0] }, "", "/");
+    window.history.pushState({ key: [0, 0] }, "", "/#/");
   });
 
   afterEach(() => {
@@ -24,24 +25,26 @@ describe("browser integration tests", () => {
     });
 
     it("new URL is encoded", () => {
-      test_history = browser(pending => {
+      test_history = blocking_hash(pending => {
         pending.finish();
       });
-      test_history.navigate({
-        pathname: "/encoded-percent%25"
-      });
-      expect(window.location.pathname).toEqual("/encoded-percent%25");
+      test_history.navigate(
+        {
+          pathname: "/encoded-percent%25"
+        },
+        "push"
+      );
+      expect(window.location.hash).toEqual("#/encoded-percent%25");
       expect(test_history.location.pathname).toEqual("/encoded-percent%25");
     });
 
     describe("push navigation", () => {
       it("uses history.pushState", () => {
-        test_history = browser(pending => {
+        test_history = blocking_hash(pending => {
           pending.finish();
         });
-        test_history.navigate("/the-new-location", "push");
-
-        expect(window.location.pathname).toEqual("/the-new-location");
+        test_history.navigate("/a-new-position", "push");
+        expect(window.location.hash).toEqual("#/a-new-position");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(1);
         expect((<jasmine.Spy>window.history.replaceState).calls.count()).toBe(
           0
@@ -49,7 +52,7 @@ describe("browser integration tests", () => {
       });
 
       it("sets the state", () => {
-        test_history = browser(pending => {
+        test_history = blocking_hash(pending => {
           pending.finish();
         });
         const provided_state = { is_set: true };
@@ -68,11 +71,11 @@ describe("browser integration tests", () => {
 
     describe("replace navigation", () => {
       it("uses history.replaceState", () => {
-        test_history = browser(pending => {
+        test_history = blocking_hash(pending => {
           pending.finish();
         });
-        test_history.navigate("/the-same-location", "replace");
-        expect(window.location.pathname).toEqual("/the-same-location");
+        test_history.navigate("/the-same-position", "replace");
+        expect(window.location.hash).toEqual("#/the-same-position");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(0);
         expect((<jasmine.Spy>window.history.replaceState).calls.count()).toBe(
           1
@@ -80,7 +83,7 @@ describe("browser integration tests", () => {
       });
 
       it("sets the state", () => {
-        test_history = browser(pending => {
+        test_history = blocking_hash(pending => {
           pending.finish();
         });
         const provided_state = { is_set: true };
@@ -101,20 +104,20 @@ describe("browser integration tests", () => {
   describe("go", () => {
     it("is detectable through a popstate listener", done => {
       let calls = 0;
-      test_history = browser(pending => {
+      test_history = blocking_hash(pending => {
         let local_history = test_history;
         switch (calls++) {
           case 0:
             pending.finish();
-            local_history.navigate("/one", "push");
+            local_history.navigate("/eins", "push");
             break;
           case 1:
             pending.finish();
-            local_history.navigate("/two", "push");
+            local_history.navigate("/zwei", "push");
             break;
           case 2:
             pending.finish();
-            local_history.navigate("/three", "push");
+            local_history.navigate("/drei", "push");
             break;
           case 3:
             pending.finish();
@@ -122,7 +125,7 @@ describe("browser integration tests", () => {
             break;
           case 4:
             pending.finish();
-            expect(pending.location.pathname).toEqual("/one");
+            expect(pending.location.pathname).toEqual("/eins");
 
             local_history.destroy();
             done();
@@ -135,7 +138,7 @@ describe("browser integration tests", () => {
   describe("browser navigation", () => {
     it("can detect navigation triggered by the browser", done => {
       let calls = 0;
-      test_history = browser(pending => {
+      test_history = blocking_hash(pending => {
         let local_history = test_history;
         switch (calls++) {
           case 0:

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -1,5 +1,5 @@
 ///<reference types="jasmine"/>
-import { hash } from "../../src/hash";
+import { hash } from "../../src";
 
 describe("hash integration tests", () => {
   let test_history;

--- a/packages/hash/tests/unit/blocking_hash.spec.ts
+++ b/packages/hash/tests/unit/blocking_hash.spec.ts
@@ -1,11 +1,12 @@
 import "jest";
-import { hash } from "../../src";
+import { blocking_hash } from "../../src";
 
 import { with_dom, async_with_dom } from "../../../../tests/utils/dom";
 import {
   navigate_suite,
   go_suite,
-  cancel_suite
+  cancel_suite,
+  blocking_suite
 } from "../../../../tests/cases";
 
 import { TestCase, Suite } from "../../../../tests/types";
@@ -17,7 +18,7 @@ function run_async_test(test: TestCase) {
       { url: "http://example.com/#/one" },
       ({ window, resolve }) => {
         test.fn({
-          constructor: hash,
+          constructor: blocking_hash,
           resolve
         });
       }
@@ -29,7 +30,7 @@ function run_test(test: TestCase) {
   it(test.msg, () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       test.fn({
-        constructor: hash
+        constructor: blocking_hash
       });
     });
   });
@@ -48,7 +49,7 @@ function run_suite(suite: Suite) {
 describe("hash constructor", () => {
   it("initializes using window.location", () => {
     with_dom({ url: "http://example.com/#/one" }, () => {
-      const test_history = hash(pending => {
+      const test_history = blocking_hash(pending => {
         pending.finish();
       });
       expect(test_history.location).toMatchObject({
@@ -62,7 +63,7 @@ describe("hash constructor", () => {
   it("throws if there is no DOM", () => {
     with_dom({ url: "http://example.com/#/one", set_global: false }, () => {
       expect(() => {
-        const test_history = hash(pending => {
+        const test_history = blocking_hash(pending => {
           pending.finish();
         });
       }).toThrow();
@@ -72,7 +73,7 @@ describe("hash constructor", () => {
   it('sets initial action to "push" when page has not been previously visited', () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       window.history.pushState(null, "", "/#has-no-key");
-      const test_history = hash(pending => {
+      const test_history = blocking_hash(pending => {
         expect(pending.action).toBe("push");
         pending.finish();
       });
@@ -82,7 +83,7 @@ describe("hash constructor", () => {
   it('sets initial action to "pop" when page has been previously visited', () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       window.history.pushState({ key: "17.0" }, "", "/#has-key");
-      const test_history = hash(pending => {
+      const test_history = blocking_hash(pending => {
         expect(pending.action).toBe("pop");
         pending.finish();
       });
@@ -94,7 +95,7 @@ describe("hash constructor", () => {
       it("sets the expected hash format", () => {
         with_dom({ url: "http://example.com/" }, ({ window }) => {
           expect(window.location.hash).toBe("");
-          const test_history = hash(pending => {
+          const test_history = blocking_hash(pending => {
             pending.finish();
           });
           expect(window.location.hash).toBe("#/");
@@ -106,7 +107,7 @@ describe("hash constructor", () => {
       it("sets the expected hash format", () => {
         with_dom({ url: "http://example.com/" }, ({ window }) => {
           expect(window.location.hash).toBe("");
-          const test_history = hash(
+          const test_history = blocking_hash(
             pending => {
               pending.finish();
             },
@@ -121,7 +122,7 @@ describe("hash constructor", () => {
       it("sets the expected hash format", () => {
         with_dom({ url: "http://example.com/" }, ({ window }) => {
           expect(window.location.hash).toBe("");
-          const test_history = hash(
+          const test_history = blocking_hash(
             pending => {
               pending.finish();
             },
@@ -136,7 +137,7 @@ describe("hash constructor", () => {
       it("sets the expected hash format", () => {
         with_dom({ url: "http://example.com/" }, ({ window }) => {
           expect(window.location.hash).toBe("");
-          const test_history = hash(
+          const test_history = blocking_hash(
             pending => {
               pending.finish();
             },
@@ -151,7 +152,7 @@ describe("hash constructor", () => {
   describe("decodes from browser based on options.hash_type", () => {
     it("works with no hash_type (default)", () => {
       with_dom({ url: "http://example.com/#/the-path" }, () => {
-        const test_history = hash(pending => {
+        const test_history = blocking_hash(pending => {
           pending.finish();
         });
         expect(test_history.location).toMatchObject({
@@ -162,7 +163,7 @@ describe("hash constructor", () => {
 
     it("works with default hash_type", () => {
       with_dom({ url: "http://example.com/#/the-path" }, () => {
-        const test_history = hash(
+        const test_history = blocking_hash(
           pending => {
             pending.finish();
           },
@@ -177,7 +178,7 @@ describe("hash constructor", () => {
     it("works with bang hash_type", () => {
       // bang expects an exclamation point before the leading slash
       with_dom({ url: "http://example.com/#!/the-path" }, () => {
-        const test_history = hash(
+        const test_history = blocking_hash(
           pending => {
             pending.finish();
           },
@@ -192,7 +193,7 @@ describe("hash constructor", () => {
     it("works with default hash_type", () => {
       // clean expects no leading slash
       with_dom({ url: "http://example.com/#the-path" }, () => {
-        const test_history = hash(
+        const test_history = blocking_hash(
           pending => {
             pending.finish();
           },
@@ -214,6 +215,10 @@ describe("navigate()", () => {
   run_suite(navigate_suite);
 });
 
+describe("blocking", () => {
+  run_suite(blocking_suite);
+});
+
 describe("go suite", () => {
   run_suite(go_suite);
 });
@@ -221,7 +226,7 @@ describe("go suite", () => {
 describe("hash history.navigate", () => {
   it("throws if trying to navigate with a non-encoded pathname", () => {
     with_dom({ url: "http://example.com/one" }, ({ window }) => {
-      const test_history = hash(pending => {
+      const test_history = blocking_hash(pending => {
         pending.finish();
       });
       expect(() => {
@@ -236,7 +241,7 @@ describe("go", () => {
   it("calls window.history.go with provided value", () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       const mock_go = (window.history.go = jest.fn());
-      const test_history = hash(pending => {
+      const test_history = blocking_hash(pending => {
         pending.finish();
       });
       [undefined, 0, 1, -1].forEach((value, index) => {
@@ -250,7 +255,7 @@ describe("go", () => {
 describe("to_href", () => {
   it("returns the location formatted as a string", () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-      const test_history = hash(pending => {
+      const test_history = blocking_hash(pending => {
         pending.finish();
       });
       const current_path = test_history.to_href({
@@ -267,7 +272,7 @@ describe("to_href", () => {
     describe("[none provided]", () => {
       it("outputs expected string", () => {
         with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-          const test_history = hash(pending => {
+          const test_history = blocking_hash(pending => {
             pending.finish();
           });
           expect(test_history.to_href(location)).toBe("#/simple-path");
@@ -278,7 +283,7 @@ describe("to_href", () => {
     describe("default", () => {
       it("outputs expected string", () => {
         with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-          const test_history = hash(
+          const test_history = blocking_hash(
             pending => {
               pending.finish();
             },
@@ -292,7 +297,7 @@ describe("to_href", () => {
     describe("bang", () => {
       it("outputs expected string", () => {
         with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-          const test_history = hash(
+          const test_history = blocking_hash(
             pending => {
               pending.finish();
             },
@@ -306,7 +311,7 @@ describe("to_href", () => {
     describe("clean", () => {
       it("outputs expected string", () => {
         with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
-          const test_history = hash(
+          const test_history = blocking_hash(
             pending => {
               pending.finish();
             },

--- a/packages/hash/types/blocking_hash.d.ts
+++ b/packages/hash/types/blocking_hash.d.ts
@@ -1,0 +1,3 @@
+import { ResponseHandler } from "@hickory/root";
+import { HashOptions, BlockingHashHistory } from "./types";
+export declare function blocking_hash(fn: ResponseHandler, options?: HashOptions): BlockingHashHistory;

--- a/packages/hash/types/hash.d.ts
+++ b/packages/hash/types/hash.d.ts
@@ -1,4 +1,3 @@
 import { ResponseHandler } from "@hickory/root";
 import { HashOptions, HashHistory } from "./types";
-export * from "./types";
 export declare function hash(fn: ResponseHandler, options?: HashOptions): HashHistory;

--- a/packages/hash/types/index.d.ts
+++ b/packages/hash/types/index.d.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+import { hash } from "./hash";
+import { blocking_hash } from "./blocking_hash";
+export { hash, blocking_hash };

--- a/packages/hash/types/types.d.ts
+++ b/packages/hash/types/types.d.ts
@@ -1,7 +1,11 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation, ConfirmationFunction } from "@hickory/root";
 export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
 export interface HashTypeOptions {
     hash_type?: string;
 }
 export declare type HashOptions = HistoryOptions & HashTypeOptions;
 export declare type HashHistory = History;
+export interface BlockingHashHistory extends HashHistory {
+    confirm_with(fn?: ConfirmationFunction): void;
+    remove_confirmation(): void;
+}

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5462,
-    "minified": 1837,
-    "gzipped": 735,
+    "bundled": 10596,
+    "minified": 3509,
+    "gzipped": 1029,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5561,
-    "minified": 1929,
-    "gzipped": 788
+    "bundled": 10719,
+    "minified": 3624,
+    "gzipped": 1083
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15779,
-    "minified": 4449,
-    "gzipped": 1766
+    "bundled": 22252,
+    "minified": 6231,
+    "gzipped": 2147
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15779,
-    "minified": 4449,
-    "gzipped": 1766
+    "bundled": 22252,
+    "minified": 6231,
+    "gzipped": 2147
   }
 }

--- a/packages/in-memory/src/blocking_in_memory.ts
+++ b/packages/in-memory/src/blocking_in_memory.ts
@@ -1,0 +1,197 @@
+import {
+  location_utils,
+  key_generator,
+  navigate_with,
+  navigation_confirmation
+} from "@hickory/root";
+
+import {
+  SessionLocation,
+  AnyLocation,
+  ToArgument,
+  ResponseHandler,
+  NavType,
+  Action
+} from "@hickory/root";
+
+import {
+  InMemoryOptions,
+  BlockingInMemoryHistory,
+  InputLocation,
+  InputLocations,
+  SessionOptions
+} from "./types";
+
+function noop() {}
+
+export function blocking_in_memory(
+  fn: ResponseHandler,
+  options: InMemoryOptions = {}
+): BlockingInMemoryHistory {
+  const location_utilities = location_utils(options);
+  const keygen = key_generator();
+  const blocking = navigation_confirmation();
+
+  let locations = initialize_locations(options.locations);
+  let index = valid_index(options.index) ? options.index : 0;
+
+  function valid_index(value: number | undefined): value is number {
+    return value !== undefined && value >= 0 && value < locations.length;
+  }
+  function initialize_locations(
+    locs: InputLocations = ["/"]
+  ): Array<SessionLocation> {
+    return locs.map((loc: InputLocation) =>
+      location_utilities.keyed(
+        location_utilities.generic_location(loc),
+        keygen.major()
+      )
+    );
+  }
+
+  const destroy_locations = () => {
+    locations = [];
+    index = -1;
+  };
+
+  function to_href(location: AnyLocation): string {
+    return location_utilities.stringify_location(location);
+  }
+
+  let last_action: Action = "push";
+
+  const {
+    emit_navigation,
+    cancel_pending,
+    create_navigation,
+    prepare
+  } = navigate_with({
+    response_handler: fn,
+    location_utils: location_utilities,
+    keygen,
+    current: () => memory_history.location,
+    push: {
+      finish(location: SessionLocation) {
+        return () => {
+          memory_history.location = location;
+          index++;
+          locations = [...locations.slice(0, index), location];
+          last_action = "push";
+        };
+      },
+      cancel: noop
+    },
+    replace: {
+      finish(location: SessionLocation) {
+        return () => {
+          memory_history.location = location;
+          locations[index] = memory_history.location;
+          last_action = "replace";
+        };
+      },
+      cancel: noop
+    }
+  });
+
+  const memory_history: BlockingInMemoryHistory = {
+    location: locations[index],
+    current() {
+      const nav = create_navigation(
+        memory_history.location,
+        last_action,
+        noop,
+        noop
+      );
+      emit_navigation(nav);
+    },
+    confirm_with: blocking.confirm_with,
+    remove_confirmation: blocking.remove_confirmation,
+    to_href,
+    cancel() {
+      cancel_pending();
+    },
+    destroy(): void {
+      destroy_locations();
+    },
+    navigate(to: ToArgument, nav_type: NavType = "anchor"): void {
+      const navigation = prepare(to, nav_type);
+      cancel_pending(navigation.action);
+      blocking.confirm_navigation(
+        {
+          to: navigation.location,
+          from: memory_history.location,
+          action: navigation.action
+        },
+        () => {
+          emit_navigation(navigation);
+        }
+      );
+    },
+    go(num?: number): void {
+      if (num == null || num === 0) {
+        const navigation = create_navigation(
+          memory_history.location,
+          "pop",
+          () => {
+            last_action = "pop";
+          },
+          noop
+        );
+        emit_navigation(navigation);
+      } else {
+        const original_index = index;
+        const new_index = original_index + num;
+        if (new_index < 0 || new_index >= locations.length) {
+          return;
+        }
+
+        // Immediately update the index; this simulates browser behavior.
+        index = new_index;
+
+        const location: SessionLocation = locations[new_index];
+
+        blocking.confirm_navigation(
+          {
+            to: location,
+            from: memory_history.location,
+            action: "pop"
+          },
+          () => {
+            const navigation = create_navigation(
+              location,
+              "pop",
+              () => {
+                memory_history.location = location;
+                last_action = "pop";
+              },
+              (next_action?: Action) => {
+                if (next_action === "pop") {
+                  return;
+                }
+                index = original_index;
+              }
+            );
+            emit_navigation(navigation);
+          }
+        );
+      }
+    },
+    reset(options: SessionOptions = {}) {
+      locations = initialize_locations(options.locations);
+      index = valid_index(options.index) ? options.index : 0;
+      memory_history.location = locations[index];
+      last_action = "push";
+
+      cancel_pending();
+      const navigation = create_navigation(
+        memory_history.location,
+        last_action,
+        noop,
+        noop
+      );
+      emit_navigation(navigation);
+    }
+  };
+
+  return memory_history;
+}

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types";
 
 import { in_memory } from "./in_memory";
+import { blocking_in_memory } from "./blocking_in_memory";
 import { create_server_history } from "./create_server_history";
 
-export { in_memory, create_server_history };
+export { in_memory, blocking_in_memory, create_server_history };

--- a/packages/in-memory/src/types.ts
+++ b/packages/in-memory/src/types.ts
@@ -5,7 +5,8 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  AnyLocation
+  AnyLocation,
+  ConfirmationFunction
 } from "@hickory/root";
 
 export {
@@ -29,6 +30,12 @@ export interface SessionOptions {
 export type InMemoryOptions = HistoryOptions & SessionOptions;
 export interface InMemoryHistory extends History {
   reset(options?: SessionOptions): void;
+}
+
+export interface BlockingInMemoryHistory extends InMemoryHistory {
+  reset(options?: SessionOptions): void;
+  confirm_with(fn?: ConfirmationFunction): void;
+  remove_confirmation(): void;
 }
 
 export interface LocationOptions {

--- a/packages/in-memory/tests/blocking_in_memory.spec.ts
+++ b/packages/in-memory/tests/blocking_in_memory.spec.ts
@@ -1,0 +1,401 @@
+import "jest";
+import { blocking_in_memory } from "../src";
+
+import {
+  navigate_suite,
+  go_suite,
+  cancel_suite,
+  blocking_suite
+} from "../../../tests/cases";
+
+import { TestCase, Suite } from "../../../tests/types";
+
+import { InMemoryOptions, HistoryConstructor } from "@hickory/in-memory";
+
+interface FnOptions {
+  constructor: HistoryConstructor<InMemoryOptions>;
+  options: InMemoryOptions;
+}
+
+interface AsyncFnOptions extends FnOptions {
+  resolve: (value?: {} | PromiseLike<{}>) => void;
+}
+
+function run_async_test(test: TestCase) {
+  it(test.msg, async () => {
+    expect.assertions(test.assertions);
+    await new Promise(resolve => {
+      test.fn({
+        constructor: blocking_in_memory,
+        options: {
+          locations: ["/one"]
+        },
+        resolve
+      } as AsyncFnOptions);
+    });
+  });
+}
+
+function run_test(test: TestCase) {
+  it(test.msg, () => {
+    test.fn({
+      constructor: blocking_in_memory,
+      options: {
+        locations: ["/one"]
+      }
+    } as FnOptions);
+  });
+}
+
+function run_suite(suite: Suite) {
+  suite.forEach(test => {
+    if (test.async) {
+      run_async_test(test);
+    } else {
+      run_test(test);
+    }
+  });
+}
+
+describe("Memory constructor", () => {
+  it("initializes with root location (/) if none provided", () => {
+    const test_history = blocking_in_memory(pending => {
+      pending.finish();
+    });
+    expect(test_history.location).toMatchObject({
+      pathname: "/",
+      hash: "",
+      query: ""
+    });
+  });
+
+  it("works with string locations", () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        pending.finish();
+      },
+      {
+        locations: ["/one#step"]
+      }
+    );
+    expect(test_history.location).toMatchObject({
+      pathname: "/one",
+      hash: "step"
+    });
+  });
+
+  it("works with object locations", () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        pending.finish();
+      },
+      {
+        locations: [{ pathname: "/two", hash: "daloo" }]
+      }
+    );
+    expect(test_history.location).toMatchObject({
+      pathname: "/two",
+      hash: "daloo"
+    });
+  });
+
+  it("uses the provided index to select initial location", () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        pending.finish();
+      },
+      {
+        locations: ["/one", "/two", "/three"],
+        index: 2
+      }
+    );
+    expect(test_history.location).toMatchObject({
+      pathname: "/three"
+    });
+  });
+
+  it("defaults to index 0 if provided index is out of bounds", () => {
+    [-1, 3].forEach(value => {
+      const test_history = blocking_in_memory(
+        pending => {
+          pending.finish();
+        },
+        {
+          locations: ["/one", "/two", "/three"],
+          index: value
+        }
+      );
+      expect(test_history.location).toMatchObject({
+        pathname: "/one"
+      });
+    });
+  });
+
+  it('sets initial action to "push"', () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        expect(pending.action).toBe("push");
+        pending.finish();
+      },
+      {
+        locations: ["/one", "/two", "/three"],
+        index: 0
+      }
+    );
+  });
+});
+
+describe("cancel", () => {
+  run_suite(cancel_suite);
+});
+
+describe("navigate()", () => {
+  run_suite(navigate_suite);
+});
+
+describe("blocking", () => {
+  run_suite(blocking_suite);
+});
+
+describe("go suite", () => {
+  run_suite(go_suite);
+});
+
+describe("go", () => {
+  describe("with no value", () => {
+    it('calls response handler with current location and "pop" action', done => {
+      const test_history = blocking_in_memory(pending => {
+        expect(pending.location).toMatchObject({
+          pathname: "/"
+        });
+        expect(pending.action).toBe("pop");
+        done();
+        pending.finish();
+      });
+      test_history.go();
+    });
+  });
+
+  describe("with a value", () => {
+    it("does nothing if the value is outside of the range", () => {
+      const router = jest.fn();
+      const test_history = blocking_in_memory(router);
+      test_history.go(10);
+      // just verifying that a popstate event hasn't emitted to
+      // trigger the history's event handler
+      expect(router.mock.calls.length).toBe(0);
+    });
+  });
+});
+
+describe("to_href", () => {
+  it("returns the location formatted as a string", () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        pending.finish();
+      },
+      {
+        locations: [{ pathname: "/one", query: "test=query" }]
+      }
+    );
+    const currentPath = test_history.to_href(test_history.location);
+    expect(currentPath).toBe("/one?test=query");
+  });
+});
+
+describe("reset()", () => {
+  describe("locations", () => {
+    it("works with string locations", () => {
+      const test_history = blocking_in_memory(
+        pending => {
+          pending.finish();
+        },
+        {
+          locations: ["/one", "/two", "/three"]
+        }
+      );
+      expect(test_history.location).toMatchObject({
+        pathname: "/one"
+      });
+
+      test_history.reset({
+        locations: ["/uno", "/dos"]
+      });
+      expect(test_history.location).toMatchObject({
+        pathname: "/uno"
+      });
+    });
+
+    it("works with object locations", () => {
+      const test_history = blocking_in_memory(
+        pending => {
+          pending.finish();
+        },
+        {
+          locations: ["/one", "/two", "/three"]
+        }
+      );
+      expect(test_history.location).toMatchObject({
+        pathname: "/one"
+      });
+
+      test_history.reset({
+        locations: [{ pathname: "/uno" }, { pathname: "/dos" }]
+      });
+      expect(test_history.location).toMatchObject({
+        pathname: "/uno"
+      });
+    });
+
+    it("uses default '/' location if no locations are provided", () => {
+      const test_history = blocking_in_memory(
+        pending => {
+          pending.finish();
+        },
+        {
+          locations: ["/one", "/two", "/three"]
+        }
+      );
+      expect(test_history.location).toMatchObject({
+        pathname: "/one"
+      });
+
+      test_history.reset();
+      expect(test_history.location).toMatchObject({
+        pathname: "/"
+      });
+    });
+
+    it("reset removes existing locations", () => {
+      const router = jest.fn();
+      const test_history = blocking_in_memory(router, {
+        locations: ["/one", "/two", "/three"]
+      });
+
+      // reset the call from attaching the router
+      router.mockReset();
+
+      test_history.go(2);
+
+      // response handler is called because we can pop
+      expect(router.mock.calls.length).toBe(1);
+
+      test_history.reset({ locations: ["/uno"] });
+      router.mockReset();
+
+      test_history.go(2);
+
+      // response handler is not called because there is no location
+      // to pop to
+      expect(router.mock.calls.length).toBe(0);
+    });
+  });
+
+  it("sets location using provided index value", () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        pending.finish();
+      },
+      {
+        locations: ["/one", "/two", "/three"],
+        index: 1
+      }
+    );
+    expect(test_history.location.pathname).toBe("/two");
+
+    test_history.reset({
+      locations: ["/uno", "/dos", "/tres"],
+      index: 2
+    });
+    expect(test_history.location.pathname).toBe("/tres");
+  });
+
+  it("uses location at index 0 if index is not provided", () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        pending.finish();
+      },
+      {
+        locations: ["/one", "/two", "/three"],
+        index: 1
+      }
+    );
+    expect(test_history.location.pathname).toBe("/two");
+
+    test_history.reset({
+      locations: ["/uno", "/dos", "/tres"]
+    });
+    expect(test_history.location.pathname).toBe("/uno");
+  });
+
+  it("uses location at index 0 if provided index < 0", () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        pending.finish();
+      },
+      {
+        locations: ["/one", "/two", "/three"],
+        index: 1
+      }
+    );
+    expect(test_history.location.pathname).toBe("/two");
+
+    test_history.reset({
+      locations: ["/uno", "/dos", "/tres"],
+      index: -1
+    });
+    expect(test_history.location.pathname).toBe("/uno");
+  });
+
+  it("uses location at index 0 if index is larger than length of locations array", () => {
+    const test_history = blocking_in_memory(
+      pending => {
+        pending.finish();
+      },
+      {
+        locations: ["/one", "/two", "/three"],
+        index: 1
+      }
+    );
+    expect(test_history.location.pathname).toBe("/two");
+
+    test_history.reset({
+      locations: ["/uno", "/dos", "/tres"],
+      index: 7
+    });
+    expect(test_history.location.pathname).toBe("/uno");
+  });
+
+  describe("emitting new location", () => {
+    it("emits the new location", () => {
+      const router = jest.fn();
+      const test_history = blocking_in_memory(router, {
+        locations: ["/one", "/two", "/three"]
+      });
+
+      test_history.reset({
+        locations: ["/uno", "/dos"]
+      });
+      expect(router.mock.calls.length).toBe(1);
+      expect(router.mock.calls[0][0]).toMatchObject({
+        location: {
+          pathname: "/uno"
+        }
+      });
+    });
+
+    it('emits the action as "push"', () => {
+      const router = jest.fn();
+      const test_history = blocking_in_memory(router, {
+        locations: ["/one", "/two", "/three"]
+      });
+
+      test_history.reset({
+        locations: ["/uno", "/dos"]
+      });
+      expect(router.mock.calls[0][0]).toMatchObject({
+        action: "push"
+      });
+    });
+  });
+});

--- a/packages/in-memory/types/blocking_in_memory.d.ts
+++ b/packages/in-memory/types/blocking_in_memory.d.ts
@@ -1,0 +1,3 @@
+import { ResponseHandler } from "@hickory/root";
+import { InMemoryOptions, BlockingInMemoryHistory } from "./types";
+export declare function blocking_in_memory(fn: ResponseHandler, options?: InMemoryOptions): BlockingInMemoryHistory;

--- a/packages/in-memory/types/index.d.ts
+++ b/packages/in-memory/types/index.d.ts
@@ -1,4 +1,5 @@
 export * from "./types";
 import { in_memory } from "./in_memory";
+import { blocking_in_memory } from "./blocking_in_memory";
 import { create_server_history } from "./create_server_history";
-export { in_memory, create_server_history };
+export { in_memory, blocking_in_memory, create_server_history };

--- a/packages/in-memory/types/types.d.ts
+++ b/packages/in-memory/types/types.d.ts
@@ -1,4 +1,4 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation, ConfirmationFunction } from "@hickory/root";
 export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
 export declare type InputLocation = string | PartialLocation;
 export declare type InputLocations = Array<InputLocation>;
@@ -9,6 +9,11 @@ export interface SessionOptions {
 export declare type InMemoryOptions = HistoryOptions & SessionOptions;
 export interface InMemoryHistory extends History {
     reset(options?: SessionOptions): void;
+}
+export interface BlockingInMemoryHistory extends InMemoryHistory {
+    reset(options?: SessionOptions): void;
+    confirm_with(fn?: ConfirmationFunction): void;
+    remove_confirmation(): void;
 }
 export interface LocationOptions {
     location: InputLocation;

--- a/tests/cases/blocking/index.ts
+++ b/tests/cases/blocking/index.ts
@@ -1,0 +1,12 @@
+import PopConfirmNavigation from "./pop-confirm-navigation";
+import PopPreventNavigation from "./pop-prevent-navigation";
+import NavigateConfirmNavigation from "./navigate-confirm-navigation";
+import NavigatePreventNavigation from "./navigate-prevent-navigation";
+import { Suite } from "../../types";
+
+export const blocking_suite: Suite = [
+  PopConfirmNavigation,
+  PopPreventNavigation,
+  NavigateConfirmNavigation,
+  NavigatePreventNavigation
+];

--- a/tests/cases/blocking/navigate-confirm-navigation.ts
+++ b/tests/cases/blocking/navigate-confirm-navigation.ts
@@ -1,0 +1,33 @@
+import "jest";
+
+import { TestCaseArgs } from "../../types";
+
+export default {
+  msg:
+    "calls response handler after the user confirms the navigate() navigation",
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    let calls = 0;
+    const history = constructor(pending => {
+      calls++;
+      pending.finish();
+    }, options);
+    expect(calls).toBe(0);
+
+    history.navigate("/two", "push");
+    expect(calls).toBe(1);
+
+    history.navigate("/three", "push");
+    expect(calls).toBe(2);
+
+    history.confirm_with((info, confirm, prevent) => {
+      confirm();
+    });
+
+    history.navigate("/four");
+    expect(calls).toBe(3);
+    expect(history.location).toMatchObject({
+      pathname: "/four",
+      key: [3, 0]
+    });
+  }
+};

--- a/tests/cases/blocking/navigate-prevent-navigation.ts
+++ b/tests/cases/blocking/navigate-prevent-navigation.ts
@@ -1,0 +1,33 @@
+import "jest";
+
+import { TestCaseArgs } from "../../types";
+
+export default {
+  msg:
+    "does not call response handler when the user prevents the navigate() navigation",
+  fn: function({ constructor, options = {} }: TestCaseArgs) {
+    let calls = 0;
+    const history = constructor(pending => {
+      calls++;
+      pending.finish();
+    }, options);
+    expect(calls).toBe(0);
+
+    history.navigate("/two", "push");
+    expect(calls).toBe(1);
+
+    history.navigate("/three", "push");
+    expect(calls).toBe(2);
+
+    history.confirm_with((info, confirm, prevent) => {
+      prevent();
+    });
+
+    history.navigate("/four");
+    expect(calls).toBe(2);
+    expect(history.location).toMatchObject({
+      pathname: "/three",
+      key: [2, 0]
+    });
+  }
+};

--- a/tests/cases/blocking/pop-confirm-navigation.ts
+++ b/tests/cases/blocking/pop-confirm-navigation.ts
@@ -1,0 +1,37 @@
+import "jest";
+
+import { AsyncTestCaseArgs } from "../../types";
+
+export default {
+  msg: "calls response handler after the user confirms the pop navigation",
+  async: true,
+  assertions: 5,
+  fn: function({ constructor, resolve, options = {} }: AsyncTestCaseArgs) {
+    let calls = 0;
+    const history = constructor(pending => {
+      calls++;
+      pending.finish();
+    }, options);
+    expect(calls).toBe(0);
+
+    history.navigate("/two", "push");
+    expect(calls).toBe(1);
+
+    history.navigate("/three", "push");
+    expect(calls).toBe(2);
+
+    history.confirm_with((info, confirm, prevent) => {
+      confirm();
+    });
+
+    history.go(-2);
+    setTimeout(() => {
+      expect(calls).toBe(3);
+      expect(history.location).toMatchObject({
+        pathname: "/one",
+        key: [0, 0]
+      });
+      resolve();
+    }, 10);
+  }
+};

--- a/tests/cases/blocking/pop-prevent-navigation.ts
+++ b/tests/cases/blocking/pop-prevent-navigation.ts
@@ -1,0 +1,38 @@
+import "jest";
+
+import { AsyncTestCaseArgs } from "../../types";
+
+export default {
+  msg:
+    "does not call response handler when the user prevents the pop navigation",
+  async: true,
+  assertions: 5,
+  fn: function({ constructor, resolve, options = {} }: AsyncTestCaseArgs) {
+    let calls = 0;
+    const history = constructor(pending => {
+      calls++;
+      pending.finish();
+    }, options);
+    expect(calls).toBe(0);
+
+    history.navigate("/two", "push");
+    expect(calls).toBe(1);
+
+    history.navigate("/three", "push");
+    expect(calls).toBe(2);
+
+    history.confirm_with((info, confirm, prevent) => {
+      prevent();
+    });
+
+    history.go(-2);
+    setTimeout(() => {
+      expect(calls).toBe(2);
+      expect(history.location).toMatchObject({
+        pathname: "/three",
+        key: [2, 0]
+      });
+      resolve();
+    }, 10);
+  }
+};

--- a/tests/cases/index.ts
+++ b/tests/cases/index.ts
@@ -1,5 +1,6 @@
 import { navigate_suite } from "./navigate";
 import { go_suite } from "./go";
 import { cancel_suite } from "./cancel";
+import { blocking_suite } from "./blocking";
 
-export { navigate_suite, go_suite, cancel_suite };
+export { navigate_suite, go_suite, cancel_suite, blocking_suite };


### PR DESCRIPTION
While blocking is generally discouraged, it can be useful. This PR adds history functions for creating blocking histories.

This increases Hickory's bundle sizes, but with tree-shaking only the imported history type will be included in an application's bundle.