### PR TITLE
Update history.href

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 4748,
-    "minified": 1826,
-    "gzipped": 793,
+    "bundled": 4716,
+    "minified": 1806,
+    "gzipped": 781,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 4791,
-    "minified": 1865,
-    "gzipped": 840
+    "bundled": 4759,
+    "minified": 1845,
+    "gzipped": 831
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 15283,
-    "minified": 4389,
-    "gzipped": 1783
+    "bundled": 15534,
+    "minified": 4443,
+    "gzipped": 1814
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 15283,
-    "minified": 4389,
-    "gzipped": 1783
+    "bundled": 15534,
+    "minified": 4443,
+    "gzipped": 1814
   }
 }

--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 831
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 15534,
-    "minified": 4443,
-    "gzipped": 1814
+    "bundled": 15592,
+    "minified": 4445,
+    "gzipped": 1809
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 15534,
-    "minified": 4443,
-    "gzipped": 1814
+    "bundled": 15592,
+    "minified": 4445,
+    "gzipped": 1809
   }
 }

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+- Rename `to_href` to `href`.
+- `href` function can take a location object or a string.
+
 ## 2.0.0-beta.7
 
 - Remove `pathname` option.

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   SessionLocation,
-  AnyLocation,
+  Hrefable,
   ResponseHandler,
   ToArgument,
   NavType,
@@ -38,12 +38,12 @@ export function browser(
       key = keygen.major();
       window.history.replaceState({ key, state }, "", path);
     }
-    const location = location_utilities.generic_location(path, state);
+    const location = location_utilities.location(path, state);
     return location_utilities.keyed(location, key);
   }
 
-  function to_href(location: AnyLocation): string {
-    return location_utilities.stringify_location(location);
+  function href(location: Hrefable): string {
+    return location_utilities.stringify(location);
   }
 
   // set action before location because location_from_browser enforces
@@ -64,7 +64,7 @@ export function browser(
     push: {
       finish(location: SessionLocation) {
         return () => {
-          const path = to_href(location);
+          const path = href(location);
           const { key, state } = location;
           try {
             window.history.pushState({ key, state }, "", path);
@@ -80,7 +80,7 @@ export function browser(
     replace: {
       finish(location: SessionLocation) {
         return () => {
-          const path = to_href(location);
+          const path = href(location);
           const { key, state } = location;
           try {
             window.history.replaceState({ key, state }, "", path);
@@ -141,7 +141,7 @@ export function browser(
       );
       emit_navigation(nav);
     },
-    to_href,
+    href,
     cancel() {
       cancel_pending();
     },

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -5,7 +5,7 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  AnyLocation
+  Hrefable
 } from "@hickory/root";
 
 export {
@@ -14,7 +14,7 @@ export {
   History,
   SessionLocation,
   PartialLocation,
-  AnyLocation,
+  Hrefable,
   LocationComponents
 };
 

--- a/packages/browser/tests/unit/browser.spec.ts
+++ b/packages/browser/tests/unit/browser.spec.ts
@@ -120,13 +120,13 @@ describe("browser history.go", () => {
   });
 });
 
-describe("to_href", () => {
+describe("href", () => {
   it("returns the location formatted as a string", () => {
     with_dom({ url: "http://example.com/one" }, () => {
       const test_history = browser(pending => {
         pending.finish();
       });
-      const path = test_history.to_href({
+      const path = test_history.href({
         pathname: "/one",
         query: "test=query"
       });

--- a/packages/browser/types/types.d.ts
+++ b/packages/browser/types/types.d.ts
@@ -1,4 +1,4 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
-export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, Hrefable } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, Hrefable, LocationComponents };
 export declare type BrowserHistoryOptions = HistoryOptions;
 export declare type BrowserHistory = History;

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 6979,
-    "minified": 2679,
-    "gzipped": 1022,
+    "bundled": 6947,
+    "minified": 2659,
+    "gzipped": 1014,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 7170,
-    "minified": 2861,
-    "gzipped": 1075
+    "bundled": 7138,
+    "minified": 2841,
+    "gzipped": 1066
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 17430,
-    "minified": 4912,
-    "gzipped": 1939
+    "bundled": 17681,
+    "minified": 4966,
+    "gzipped": 1960
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 17430,
-    "minified": 4912,
-    "gzipped": 1939
+    "bundled": 17681,
+    "minified": 4966,
+    "gzipped": 1960
   }
 }

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 1066
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 17681,
-    "minified": 4966,
-    "gzipped": 1960
+    "bundled": 17739,
+    "minified": 4968,
+    "gzipped": 1959
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 17681,
-    "minified": 4966,
-    "gzipped": 1960
+    "bundled": 17739,
+    "minified": 4968,
+    "gzipped": 1959
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+- Rename `to_href` to `href`.
+- `href` function can take a location object or a string.
+
 ## 2.0.0-beta.7
 
 - Remove `pathname` option.

--- a/packages/hash/src/hash.ts
+++ b/packages/hash/src/hash.ts
@@ -4,7 +4,7 @@ import hash_encoder_and_decoder from "./hashTypes";
 
 import {
   SessionLocation,
-  AnyLocation,
+  Hrefable,
   ToArgument,
   ResponseHandler,
   Action,
@@ -49,14 +49,11 @@ export function hash(
       // replace with the hash we received, not the decoded path
       window.history.replaceState({ key, state }, "", hash);
     }
-    return location_utilities.keyed(
-      location_utilities.generic_location(path),
-      key
-    );
+    return location_utilities.keyed(location_utilities.location(path), key);
   }
 
-  function to_href(location: AnyLocation): string {
-    return encode_hash_path(location_utilities.stringify_location(location));
+  function href(location: Hrefable): string {
+    return encode_hash_path(location_utilities.stringify(location));
   }
 
   let last_action: Action =
@@ -75,7 +72,7 @@ export function hash(
     push: {
       finish(location: SessionLocation) {
         return () => {
-          const path = to_href(location);
+          const path = href(location);
           const { key, state } = location;
           try {
             window.history.pushState({ key, state }, "", path);
@@ -91,7 +88,7 @@ export function hash(
     replace: {
       finish(location: SessionLocation) {
         return () => {
-          const path = to_href(location);
+          const path = href(location);
           const { key, state } = location;
           try {
             window.history.replaceState({ key, state }, "", path);
@@ -148,7 +145,7 @@ export function hash(
       );
       emit_navigation(nav);
     },
-    to_href,
+    href,
     cancel() {
       cancel_pending();
     },

--- a/packages/hash/src/types.ts
+++ b/packages/hash/src/types.ts
@@ -5,7 +5,7 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  AnyLocation
+  Hrefable
 } from "@hickory/root";
 
 export {
@@ -14,7 +14,7 @@ export {
   History,
   SessionLocation,
   PartialLocation,
-  AnyLocation,
+  Hrefable,
   LocationComponents
 };
 

--- a/packages/hash/tests/unit/hash.spec.ts
+++ b/packages/hash/tests/unit/hash.spec.ts
@@ -234,13 +234,13 @@ describe("go", () => {
   });
 });
 
-describe("to_href", () => {
+describe("href", () => {
   it("returns the location formatted as a string", () => {
     with_dom({ url: "http://example.com/#/one" }, ({ window }) => {
       const test_history = hash(pending => {
         pending.finish();
       });
-      const current_path = test_history.to_href({
+      const current_path = test_history.href({
         pathname: "/one",
         query: "test=query"
       });
@@ -257,7 +257,7 @@ describe("to_href", () => {
           const test_history = hash(pending => {
             pending.finish();
           });
-          expect(test_history.to_href(location)).toBe("#/simple-path");
+          expect(test_history.href(location)).toBe("#/simple-path");
         });
       });
     });
@@ -271,7 +271,7 @@ describe("to_href", () => {
             },
             { hash_type: "default" }
           );
-          expect(test_history.to_href(location)).toBe("#/simple-path");
+          expect(test_history.href(location)).toBe("#/simple-path");
         });
       });
     });
@@ -285,7 +285,7 @@ describe("to_href", () => {
             },
             { hash_type: "bang" }
           );
-          expect(test_history.to_href(location)).toBe("#!/simple-path");
+          expect(test_history.href(location)).toBe("#!/simple-path");
         });
       });
     });
@@ -299,7 +299,7 @@ describe("to_href", () => {
             },
             { hash_type: "clean" }
           );
-          expect(test_history.to_href(location)).toBe("#simple-path");
+          expect(test_history.href(location)).toBe("#simple-path");
         });
       });
     });

--- a/packages/hash/types/types.d.ts
+++ b/packages/hash/types/types.d.ts
@@ -1,5 +1,5 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
-export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, Hrefable } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, Hrefable, LocationComponents };
 export interface HashTypeOptions {
     hash_type?: string;
 }

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5462,
-    "minified": 1837,
-    "gzipped": 735,
+    "bundled": 5410,
+    "minified": 1797,
+    "gzipped": 726,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5561,
-    "minified": 1929,
-    "gzipped": 788
+    "bundled": 5509,
+    "minified": 1889,
+    "gzipped": 779
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15491,
-    "minified": 4321,
-    "gzipped": 1732
+    "bundled": 15722,
+    "minified": 4355,
+    "gzipped": 1749
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15491,
-    "minified": 4321,
-    "gzipped": 1732
+    "bundled": 15722,
+    "minified": 4355,
+    "gzipped": 1749
   }
 }

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 779
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15722,
-    "minified": 4355,
+    "bundled": 15780,
+    "minified": 4357,
     "gzipped": 1749
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15722,
-    "minified": 4355,
+    "bundled": 15780,
+    "minified": 4357,
     "gzipped": 1749
   }
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+- Rename `to_href` to `href`.
+- `href` function can take a location object or a string.
+
 ## 2.0.0-beta.6
 
 - Lowercase export (`InMemory` to `in_memory`).

--- a/packages/in-memory/src/create_server_history.ts
+++ b/packages/in-memory/src/create_server_history.ts
@@ -1,7 +1,7 @@
 import { location_utils } from "@hickory/root";
 
 import {
-  AnyLocation,
+  Hrefable,
   ResponseHandler,
   HistoryConstructor,
   HistoryOptions,
@@ -16,13 +16,13 @@ export function create_server_history(
   factory_options: HistoryOptions = {}
 ): HistoryConstructor<LocationOptions> {
   const location_utilities = location_utils(factory_options);
-  function to_href(location: AnyLocation): string {
-    return location_utilities.stringify_location(location);
+  function href(location: Hrefable): string {
+    return location_utilities.stringify(location);
   }
 
   return function(fn: ResponseHandler, options: LocationOptions): History {
     const location = location_utilities.keyed(
-      location_utilities.generic_location(options.location),
+      location_utilities.location(options.location),
       [0, 0]
     );
 
@@ -36,7 +36,7 @@ export function create_server_history(
           cancel: noop
         });
       },
-      to_href,
+      href,
       cancel: noop,
       destroy: noop,
       navigate: noop,

--- a/packages/in-memory/src/in_memory.ts
+++ b/packages/in-memory/src/in_memory.ts
@@ -2,7 +2,7 @@ import { location_utils, key_generator, navigate_with } from "@hickory/root";
 
 import {
   SessionLocation,
-  AnyLocation,
+  Hrefable,
   ToArgument,
   ResponseHandler,
   NavType,
@@ -12,7 +12,6 @@ import {
 import {
   InMemoryOptions,
   InMemoryHistory,
-  InputLocation,
   InputLocations,
   SessionOptions
 } from "./types";
@@ -35,11 +34,8 @@ export function in_memory(
   function initialize_locations(
     locs: InputLocations = ["/"]
   ): Array<SessionLocation> {
-    return locs.map((loc: InputLocation) =>
-      location_utilities.keyed(
-        location_utilities.generic_location(loc),
-        keygen.major()
-      )
+    return locs.map((loc: Hrefable) =>
+      location_utilities.keyed(location_utilities.location(loc), keygen.major())
     );
   }
 
@@ -48,8 +44,8 @@ export function in_memory(
     index = -1;
   };
 
-  function to_href(location: AnyLocation): string {
-    return location_utilities.stringify_location(location);
+  function href(location: Hrefable): string {
+    return location_utilities.stringify(location);
   }
 
   let last_action: Action = "push";
@@ -98,7 +94,7 @@ export function in_memory(
       );
       emit_navigation(nav);
     },
-    to_href,
+    href,
     cancel() {
       cancel_pending();
     },

--- a/packages/in-memory/src/types.ts
+++ b/packages/in-memory/src/types.ts
@@ -5,7 +5,7 @@ import {
   LocationComponents,
   SessionLocation,
   PartialLocation,
-  AnyLocation
+  Hrefable
 } from "@hickory/root";
 
 export {
@@ -14,12 +14,11 @@ export {
   History,
   SessionLocation,
   PartialLocation,
-  AnyLocation,
+  Hrefable,
   LocationComponents
 };
 
-export type InputLocation = string | PartialLocation;
-export type InputLocations = Array<InputLocation>;
+export type InputLocations = Array<Hrefable>;
 
 export interface SessionOptions {
   locations?: InputLocations;
@@ -32,5 +31,5 @@ export interface InMemoryHistory extends History {
 }
 
 export interface LocationOptions {
-  location: InputLocation;
+  location: Hrefable;
 }

--- a/packages/in-memory/tests/create_server_history.spec.ts
+++ b/packages/in-memory/tests/create_server_history.spec.ts
@@ -134,7 +134,7 @@ describe("no-op functions", () => {
   });
 });
 
-describe("to_href", () => {
+describe("href", () => {
   it("returns the location formatted as a string", () => {
     const history = create_server_history();
     const test_history = history(
@@ -145,7 +145,7 @@ describe("to_href", () => {
         location: { pathname: "/one", query: "test=query" }
       }
     );
-    const currentPath = test_history.to_href(test_history.location);
+    const currentPath = test_history.href(test_history.location);
     expect(currentPath).toBe("/one?test=query");
   });
 
@@ -164,7 +164,7 @@ describe("to_href", () => {
         location: "/"
       }
     );
-    const href = test_history.to_href({ pathname: "/yo", query: { one: 1 } });
+    const href = test_history.href({ pathname: "/yo", query: { one: 1 } });
     expect(href).toEqual("/yo?one=1");
   });
 });

--- a/packages/in-memory/tests/in_memory.spec.ts
+++ b/packages/in-memory/tests/in_memory.spec.ts
@@ -179,7 +179,7 @@ describe("go", () => {
   });
 });
 
-describe("to_href", () => {
+describe("href", () => {
   it("returns the location formatted as a string", () => {
     const test_history = in_memory(
       pending => {
@@ -189,7 +189,7 @@ describe("to_href", () => {
         locations: [{ pathname: "/one", query: "test=query" }]
       }
     );
-    const currentPath = test_history.to_href(test_history.location);
+    const currentPath = test_history.href(test_history.location);
     expect(currentPath).toBe("/one?test=query");
   });
 });

--- a/packages/in-memory/types/types.d.ts
+++ b/packages/in-memory/types/types.d.ts
@@ -1,7 +1,6 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, AnyLocation } from "@hickory/root";
-export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, AnyLocation, LocationComponents };
-export declare type InputLocation = string | PartialLocation;
-export declare type InputLocations = Array<InputLocation>;
+import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, Hrefable } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, Hrefable, LocationComponents };
+export declare type InputLocations = Array<Hrefable>;
 export interface SessionOptions {
     locations?: InputLocations;
     index?: number;
@@ -11,5 +10,5 @@ export interface InMemoryHistory extends History {
     reset(options?: SessionOptions): void;
 }
 export interface LocationOptions {
-    location: InputLocation;
+    location: Hrefable;
 }

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 8590,
-    "minified": 3088,
-    "gzipped": 1245,
+    "bundled": 8841,
+    "minified": 3152,
+    "gzipped": 1273,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 8686,
-    "minified": 3170,
-    "gzipped": 1283
+    "bundled": 8951,
+    "minified": 3248,
+    "gzipped": 1309
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 10491,
-    "minified": 3040,
-    "gzipped": 1325
+    "bundled": 10774,
+    "minified": 3114,
+    "gzipped": 1360
   },
   "dist/hickory-root.min.js": {
-    "bundled": 10491,
-    "minified": 3040,
-    "gzipped": 1325
+    "bundled": 10774,
+    "minified": 3114,
+    "gzipped": 1360
   }
 }

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 8841,
-    "minified": 3152,
-    "gzipped": 1273,
+    "bundled": 8895,
+    "minified": 3154,
+    "gzipped": 1272,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 8951,
-    "minified": 3248,
-    "gzipped": 1309
+    "bundled": 9005,
+    "minified": 3250,
+    "gzipped": 1308
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 10774,
-    "minified": 3114,
-    "gzipped": 1360
+    "bundled": 10832,
+    "minified": 3116,
+    "gzipped": 1358
   },
   "dist/hickory-root.min.js": {
-    "bundled": 10774,
-    "minified": 3114,
-    "gzipped": 1360
+    "bundled": 10832,
+    "minified": 3116,
+    "gzipped": 1358
   }
 }

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+- The `stringify` function from `location_utils` can receive a location object or a string.
+- Remove `AnyLocation` type, add `Hrefable` type.
+
 ## 2.0.0-beta.7
 
 - Remove `pathname` option.

--- a/packages/root/src/location_utils.ts
+++ b/packages/root/src/location_utils.ts
@@ -8,7 +8,7 @@ import {
 import {
   SessionLocation,
   PartialLocation,
-  AnyLocation,
+  Hrefable,
   LocationComponents,
   Key
 } from "./types/location";
@@ -110,10 +110,7 @@ export default function location_factory(
     return details;
   }
 
-  function generic_location(
-    value: ToArgument,
-    state?: any
-  ): LocationComponents {
+  function location(value: ToArgument, state?: any): LocationComponents {
     if (state === undefined) {
       state = null;
     }
@@ -131,7 +128,15 @@ export default function location_factory(
     };
   }
 
-  function stringify_location(location: AnyLocation): string {
+  function stringify(location: Hrefable): string {
+    if (typeof location === "string") {
+      const first_char = location.charAt(0);
+      let href = location;
+      if (first_char !== "/" && first_char !== "#" && first_char !== "?") {
+        href = complete_pathname(href);
+      }
+      return base_segment + href;
+    }
     // ensure that pathname begins with a forward slash, query begins
     // with a question mark, and hash begins with a pound sign
     return (
@@ -142,5 +147,5 @@ export default function location_factory(
     );
   }
 
-  return { generic_location, keyed, stringify_location };
+  return { location, keyed, stringify };
 }

--- a/packages/root/src/location_utils.ts
+++ b/packages/root/src/location_utils.ts
@@ -131,17 +131,18 @@ export default function location_factory(
   function stringify(location: Hrefable): string {
     if (typeof location === "string") {
       const first_char = location.charAt(0);
-      let href = location;
-      if (first_char !== "/" && first_char !== "#" && first_char !== "?") {
-        href = complete_pathname(href);
+      // keep hash/query only strings relative
+      if (first_char === "#" || first_char === "?") {
+        return location;
       }
-      return base_segment + href;
+      return base_segment + complete_pathname(location);
     }
     // ensure that pathname begins with a forward slash, query begins
     // with a question mark, and hash begins with a pound sign
     return (
-      base_segment +
-      complete_pathname(location.pathname || "") +
+      (location.pathname !== undefined
+        ? base_segment + complete_pathname(location.pathname)
+        : "") +
       complete_query(stringify_query(location.query)) +
       complete_hash(location.hash)
     );

--- a/packages/root/src/navigate.ts
+++ b/packages/root/src/navigate.ts
@@ -73,11 +73,11 @@ export default function navigation_handler(
   }
 
   function prepare(to: ToArgument, nav_type: NavType) {
-    const location = location_utils.generic_location(to);
+    const location = location_utils.location(to);
     switch (nav_type) {
       case "anchor":
-        return location_utils.stringify_location(location) ===
-          location_utils.stringify_location(current())
+        return location_utils.stringify(location) ===
+          location_utils.stringify(current())
           ? replace_nav(location)
           : push_nav(location);
       case "push":

--- a/packages/root/src/types/hickory.ts
+++ b/packages/root/src/types/hickory.ts
@@ -1,4 +1,4 @@
-import { SessionLocation, AnyLocation } from "./location";
+import { SessionLocation, Hrefable } from "./location";
 import { ResponseHandler, ToArgument, NavType } from "./navigate";
 import { LocationUtilOptions } from "./location_utils";
 
@@ -10,7 +10,7 @@ export type HistoryConstructor<O> = (
 
 export interface History {
   location: SessionLocation;
-  to_href(to: AnyLocation): string;
+  href(to: Hrefable): string;
   current(): void;
   cancel(): void;
   destroy(): void;

--- a/packages/root/src/types/index.ts
+++ b/packages/root/src/types/index.ts
@@ -4,7 +4,7 @@ export {
   LocationComponents,
   PartialLocation,
   SessionLocation,
-  AnyLocation,
+  Hrefable,
   Key
 } from "./location";
 

--- a/packages/root/src/types/location.ts
+++ b/packages/root/src/types/location.ts
@@ -13,4 +13,4 @@ export interface SessionLocation extends LocationComponents {
   key: Key;
 }
 
-export type AnyLocation = SessionLocation | PartialLocation;
+export type Hrefable = PartialLocation | string;

--- a/packages/root/src/types/location_utils.ts
+++ b/packages/root/src/types/location_utils.ts
@@ -1,9 +1,4 @@
-import {
-  LocationComponents,
-  SessionLocation,
-  PartialLocation,
-  Key
-} from "./location";
+import { LocationComponents, SessionLocation, Hrefable, Key } from "./location";
 
 export interface QueryFunctions {
   parse: (query?: string) => any;
@@ -20,7 +15,6 @@ export interface LocationUtilOptions {
 
 export interface LocationUtils {
   keyed(location: LocationComponents, key: Key): SessionLocation;
-  generic_location(value: string | object, state?: any): LocationComponents;
-  stringify_location(location: SessionLocation): string;
-  stringify_location(location: PartialLocation): string;
+  location(value: string | object, state?: any): LocationComponents;
+  stringify(location: Hrefable): string;
 }

--- a/packages/root/tests/locationUtils.spec.ts
+++ b/packages/root/tests/locationUtils.spec.ts
@@ -31,9 +31,9 @@ describe("locationFactory", () => {
       describe("undefined", () => {
         it("returns object with default parse/stringify fns", () => {
           const common = location_utils();
-          const parsed = common.generic_location("/test?one=two");
+          const parsed = common.location("/test?one=two");
           expect(parsed.query).toBe("one=two");
-          const stringified = common.stringify_location({
+          const stringified = common.stringify({
             pathname: "/test",
             query: "?three=four"
           });
@@ -48,7 +48,7 @@ describe("locationFactory", () => {
           const common = location_utils({
             query: { parse, stringify }
           });
-          const location = common.generic_location("/test?two=dos");
+          const loc = common.location("/test?two=dos");
           expect(parse.mock.calls.length).toBe(1);
         });
 
@@ -58,37 +58,37 @@ describe("locationFactory", () => {
           const common = location_utils({
             query: { parse, stringify }
           });
-          const path = common.stringify_location({ pathname: "/test" });
+          const path = common.stringify({ pathname: "/test" });
           expect(stringify.mock.calls.length).toBe(1);
         });
       });
     });
   });
 
-  describe("generic_location", () => {
-    const { generic_location } = location_utils();
+  describe("location", () => {
+    const { location } = location_utils();
 
     describe("pathname", () => {
       describe("string argument", () => {
         it("is parsed from a string location", () => {
-          const loc = generic_location("/pathname?query=this#hash");
+          const loc = location("/pathname?query=this#hash");
           expect(loc.pathname).toBe("/pathname");
         });
 
         describe("base_segment", () => {
-          const { generic_location } = location_utils({
+          const { location } = location_utils({
             base_segment: "/prefix"
           });
 
           it("strips the base_segment off of the string", () => {
-            const location = generic_location("/prefix/this/is/the/rest");
-            expect(location.pathname).toBe("/this/is/the/rest");
+            const loc = location("/prefix/this/is/the/rest");
+            expect(loc.pathname).toBe("/this/is/the/rest");
           });
         });
 
         it("attaches provided state", () => {
           const state = "hi!";
-          const loc = generic_location("/pathname", state);
+          const loc = location("/pathname", state);
           expect(loc.state).toBe(state);
         });
       });
@@ -100,7 +100,7 @@ describe("locationFactory", () => {
             query: "one=two",
             hash: "hello"
           };
-          const output = generic_location(input);
+          const output = location(input);
           expect(output.pathname).toBe("/test");
         });
 
@@ -109,7 +109,7 @@ describe("locationFactory", () => {
             query: "one=two",
             hash: "hello"
           };
-          const output = generic_location(input);
+          const output = location(input);
           expect(output.pathname).toBe("/");
         });
       });
@@ -117,22 +117,22 @@ describe("locationFactory", () => {
 
     describe("pathname", () => {
       it("is the provided string", () => {
-        const output = generic_location("/Beyoncé");
+        const output = location("/Beyoncé");
         expect(output.pathname).toBe("/Beyoncé");
       });
 
       it("is the provided pathname property", () => {
-        const output = generic_location({ pathname: "/Jay-Z" });
+        const output = location({ pathname: "/Jay-Z" });
         expect(output.pathname).toBe("/Jay-Z");
       });
 
       it("does not include a hash", () => {
-        const output = generic_location("/Kendrick#Lamar");
+        const output = location("/Kendrick#Lamar");
         expect(output.pathname).toBe("/Kendrick");
       });
 
       it("does not include a query", () => {
-        const output = generic_location("/Chance?the=Rapper");
+        const output = location("/Chance?the=Rapper");
         expect(output.pathname).toBe("/Chance");
       });
     });
@@ -140,7 +140,7 @@ describe("locationFactory", () => {
     describe("query", () => {
       describe("string argument", () => {
         it("is parsed from a string location", () => {
-          const loc = generic_location("/pathname?query=this#hash");
+          const loc = location("/pathname?query=this#hash");
           expect(loc.query).toBe("query=this");
         });
       });
@@ -152,7 +152,7 @@ describe("locationFactory", () => {
             query: "one=two",
             hash: "hello"
           };
-          const output = generic_location(input);
+          const output = location(input);
           expect(output.query).toBe("one=two");
         });
 
@@ -161,20 +161,20 @@ describe("locationFactory", () => {
             pathname: "/test",
             hash: "hello"
           };
-          const output = generic_location(input);
+          const output = location(input);
           expect(output.query).toBe("");
         });
       });
 
       describe("query.parse option", () => {
         it("uses the provided query parsing function to make the query value", () => {
-          const { generic_location } = location_utils({
+          const { location } = location_utils({
             query: {
               parse: qs.parse,
               stringify: qs.stringify
             }
           });
-          const loc = generic_location("/pathname?query=this#hash");
+          const loc = location("/pathname?query=this#hash");
           expect(loc.query).toEqual({ query: "this" });
         });
       });
@@ -183,7 +183,7 @@ describe("locationFactory", () => {
     describe("hash", () => {
       describe("string argument", () => {
         it("is parsed from a string location", () => {
-          const loc = generic_location("/pathname?query=this#hash");
+          const loc = location("/pathname?query=this#hash");
           expect(loc.hash).toBe("hash");
         });
       });
@@ -195,7 +195,7 @@ describe("locationFactory", () => {
             query: "one=two",
             hash: "hello"
           };
-          const output = generic_location(input);
+          const output = location(input);
           expect(output.hash).toBe("hello");
         });
 
@@ -204,7 +204,7 @@ describe("locationFactory", () => {
             pathname: "/test",
             search: "one=two"
           };
-          const output = generic_location(input);
+          const output = location(input);
           expect(output.hash).toBe("");
         });
       });
@@ -219,7 +219,7 @@ describe("locationFactory", () => {
           const state = {
             omg: "bff"
           };
-          const output = generic_location(input, state);
+          const output = location(input, state);
           expect(output.state).toBeDefined();
           expect(output.state).toEqual(state);
         });
@@ -228,14 +228,14 @@ describe("locationFactory", () => {
       describe("object argument", () => {
         it("adds state if provided", () => {
           const state = { from_location: false };
-          const output = generic_location({ pathname: "/" }, state);
+          const output = location({ pathname: "/" }, state);
           expect(output.state).toEqual(state);
         });
 
         it("prefers location.state over state argument", () => {
           const loc_state = { from_location: true };
           const just_state = { from_location: false };
-          const output = generic_location(
+          const output = location(
             { pathname: "/", state: loc_state },
             just_state
           );
@@ -244,38 +244,38 @@ describe("locationFactory", () => {
       });
 
       it("is undefined if not provided", () => {
-        const output = generic_location("/");
+        const output = location("/");
         expect(output.state).toBeUndefined();
       });
     });
   });
 
   describe("keyed", () => {
-    const { keyed, generic_location } = location_utils();
+    const { keyed, location } = location_utils();
 
     it("attaches a key to a keyless location", () => {
       const key: Key = [3, 14];
-      const keyless_location = generic_location("/test");
-      const location = keyed(keyless_location, key);
-      expect(location.key).toBe(key);
+      const keyless_location = location("/test");
+      const loc = keyed(keyless_location, key);
+      expect(loc.key).toBe(key);
     });
   });
 
-  describe("stringify_location", () => {
-    const { stringify_location } = location_utils();
+  describe("stringify", () => {
+    const { stringify } = location_utils();
 
     describe("pathname", () => {
       it("begins the returned URI with the pathname", () => {
         const input = {
           pathname: "/test"
         };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output).toBe("/test");
       });
 
       it("uses empty string for pathname if pathname is not provided", () => {
         const input = { hash: "test" };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output).toBe("#test");
       });
 
@@ -283,21 +283,21 @@ describe("locationFactory", () => {
         const input = {
           pathname: "test"
         };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output).toBe("/test");
       });
 
       describe("base_segment", () => {
         it("adds the base_segment to the generated string", () => {
-          const { stringify_location } = location_utils({
+          const { stringify } = location_utils({
             base_segment: "/prefix"
           });
-          const location = {
+          const loc = {
             pathname: "/one/two/three",
             search: "",
             hash: "four"
           };
-          const path = stringify_location(location);
+          const path = stringify(loc);
           expect(path).toBe("/prefix/one/two/three#four");
         });
       });
@@ -309,7 +309,7 @@ describe("locationFactory", () => {
           pathname: "/",
           query: "one=two"
         };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output).toBe("/?one=two");
       });
 
@@ -318,7 +318,7 @@ describe("locationFactory", () => {
           pathname: "/",
           query: "?one=two"
         };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output).toBe("/?one=two");
       });
 
@@ -326,13 +326,13 @@ describe("locationFactory", () => {
         const input = {
           pathname: "/"
         };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output.indexOf("?")).toBe(-1);
       });
 
       describe("query.stringify option", () => {
         it("uses the provided stringify function to turn query into a string", () => {
-          const { stringify_location } = location_utils({
+          const { stringify } = location_utils({
             query: {
               parse: qs.parse,
               stringify: qs.stringify
@@ -342,7 +342,7 @@ describe("locationFactory", () => {
             pathname: "/",
             query: { one: "two" }
           };
-          const output = stringify_location(input);
+          const output = stringify(input);
           expect(output).toBe("/?one=two");
         });
       });
@@ -354,7 +354,7 @@ describe("locationFactory", () => {
           pathname: "/",
           hash: "yes"
         };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output).toBe("/#yes");
       });
 
@@ -363,14 +363,14 @@ describe("locationFactory", () => {
           pathname: "/",
           hash: "#no"
         };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output).toBe("/#no");
       });
 
       it("does not include the hash if it is falsy", () => {
         const falsy_values = ["", null, undefined];
         falsy_values.forEach(v => {
-          const output = stringify_location({ pathname: "/", hash: v });
+          const output = stringify({ pathname: "/", hash: v });
           expect(output.indexOf("#")).toBe(-1);
         });
       });
@@ -381,8 +381,38 @@ describe("locationFactory", () => {
           query: "before=true",
           hash: "after"
         };
-        const output = stringify_location(input);
+        const output = stringify(input);
         expect(output.indexOf("?")).toBeLessThan(output.indexOf("#"));
+      });
+    });
+
+    describe("string", () => {
+      it("returns the provided string", () => {
+        expect(stringify("/test")).toBe("/test");
+      });
+
+      describe("prefixed forward slash", () => {
+        it("prefixes pathname that is missing a forward slash", () => {
+          expect(stringify("test")).toBe("/test");
+        });
+
+        it("does not prefix if string begins with a query", () => {
+          expect(stringify("?test=true")).toBe("?test=true");
+        });
+
+        it("does not prefix if string begins with a hash", () => {
+          expect(stringify("#test")).toBe("#test");
+        });
+      });
+
+      describe("base_segment", () => {
+        it("prefixes the string with the the base_segment", () => {
+          const { stringify } = location_utils({
+            base_segment: "/prefix"
+          });
+          const path = stringify("/one/two/three#four");
+          expect(path).toBe("/prefix/one/two/three#four");
+        });
       });
     });
   });

--- a/packages/root/tests/locationUtils.spec.ts
+++ b/packages/root/tests/locationUtils.spec.ts
@@ -202,7 +202,7 @@ describe("locationFactory", () => {
         it("sets hash to empty string if none is provided", () => {
           const input = {
             pathname: "/test",
-            search: "one=two"
+            query: "one=two"
           };
           const output = location(input);
           expect(output.hash).toBe("");
@@ -294,11 +294,23 @@ describe("locationFactory", () => {
           });
           const loc = {
             pathname: "/one/two/three",
-            search: "",
+            query: "",
             hash: "four"
           };
           const path = stringify(loc);
           expect(path).toBe("/prefix/one/two/three#four");
+        });
+
+        it("does not include the base_segment if there is no pathname", () => {
+          const { stringify } = location_utils({
+            base_segment: "/prefix"
+          });
+          const loc = {
+            query: "?test=ing",
+            hash: "four"
+          };
+          const path = stringify(loc);
+          expect(path).toBe("?test=ing#four");
         });
       });
     });
@@ -391,27 +403,55 @@ describe("locationFactory", () => {
         expect(stringify("/test")).toBe("/test");
       });
 
-      describe("prefixed forward slash", () => {
+      describe("beginning with a pathname", () => {
         it("prefixes pathname that is missing a forward slash", () => {
           expect(stringify("test")).toBe("/test");
         });
 
-        it("does not prefix if string begins with a query", () => {
-          expect(stringify("?test=true")).toBe("?test=true");
-        });
-
-        it("does not prefix if string begins with a hash", () => {
-          expect(stringify("#test")).toBe("#test");
-        });
-      });
-
-      describe("base_segment", () => {
-        it("prefixes the string with the the base_segment", () => {
+        it("prefixes with base_segment", () => {
           const { stringify } = location_utils({
             base_segment: "/prefix"
           });
           const path = stringify("/one/two/three#four");
           expect(path).toBe("/prefix/one/two/three#four");
+        });
+
+        it("prefixes pathname when joining with base_segment", () => {
+          const { stringify } = location_utils({
+            base_segment: "/prefix"
+          });
+          const path = stringify("one");
+          expect(path).toBe("/prefix/one");
+        });
+      });
+
+      describe("beginning with a query", () => {
+        it("returns the provided string", () => {
+          const { stringify } = location_utils();
+          expect(stringify("?test=true")).toBe("?test=true");
+        });
+
+        it("if there is a base_segment, it is not prepended", () => {
+          const { stringify } = location_utils({
+            base_segment: "/prefix"
+          });
+          const path = stringify("?test=true");
+          expect(path).toBe("?test=true");
+        });
+      });
+
+      describe("beginning with a hash", () => {
+        it("returns the provided string", () => {
+          const { stringify } = location_utils();
+          expect(stringify("#test")).toBe("#test");
+        });
+
+        it("if there is a base_segment, it is not prepended", () => {
+          const { stringify } = location_utils({
+            base_segment: "/prefix"
+          });
+          const path = stringify("#test");
+          expect(path).toBe("#test");
         });
       });
     });

--- a/packages/root/types/types/hickory.d.ts
+++ b/packages/root/types/types/hickory.d.ts
@@ -1,11 +1,11 @@
-import { SessionLocation, AnyLocation } from "./location";
+import { SessionLocation, Hrefable } from "./location";
 import { ResponseHandler, ToArgument, NavType } from "./navigate";
 import { LocationUtilOptions } from "./location_utils";
 export declare type HistoryOptions = LocationUtilOptions;
 export declare type HistoryConstructor<O> = (fn: ResponseHandler, options: O) => History;
 export interface History {
     location: SessionLocation;
-    to_href(to: AnyLocation): string;
+    href(to: Hrefable): string;
     current(): void;
     cancel(): void;
     destroy(): void;

--- a/packages/root/types/types/index.d.ts
+++ b/packages/root/types/types/index.d.ts
@@ -1,5 +1,5 @@
 export { HistoryOptions, HistoryConstructor, History } from "./hickory";
-export { LocationComponents, PartialLocation, SessionLocation, AnyLocation, Key } from "./location";
+export { LocationComponents, PartialLocation, SessionLocation, Hrefable, Key } from "./location";
 export { KeyFns } from "./key_generator";
 export { LocationUtilOptions, QueryFunctions, VerifyPathname, LocationUtils } from "./location_utils";
 export { NavigationInfo, ConfirmationFunction, ConfirmationMethods, BlockingHistory } from "./navigation_confirmation";

--- a/packages/root/types/types/location.d.ts
+++ b/packages/root/types/types/location.d.ts
@@ -9,4 +9,4 @@ export declare type Key = [number, number];
 export interface SessionLocation extends LocationComponents {
     key: Key;
 }
-export declare type AnyLocation = SessionLocation | PartialLocation;
+export declare type Hrefable = PartialLocation | string;

--- a/packages/root/types/types/location_utils.d.ts
+++ b/packages/root/types/types/location_utils.d.ts
@@ -1,4 +1,4 @@
-import { LocationComponents, SessionLocation, PartialLocation, Key } from "./location";
+import { LocationComponents, SessionLocation, Hrefable, Key } from "./location";
 export interface QueryFunctions {
     parse: (query?: string) => any;
     stringify: (query?: any) => string;
@@ -11,7 +11,6 @@ export interface LocationUtilOptions {
 }
 export interface LocationUtils {
     keyed(location: LocationComponents, key: Key): SessionLocation;
-    generic_location(value: string | object, state?: any): LocationComponents;
-    stringify_location(location: SessionLocation): string;
-    stringify_location(location: PartialLocation): string;
+    location(value: string | object, state?: any): LocationComponents;
+    stringify(location: Hrefable): string;
 }


### PR DESCRIPTION
1. Rename `to_href` to `href`.
2. Accept strings
3. Don't prepend `base_segment` if the location doesn't have a `pathname`. For string arguments, there is no `pathname` if the string starts with a `?` or `#`.