### PR TITLE
history.navigate always takes object as first argument

### DIFF
--- a/docs/api/browser.md
+++ b/docs/api/browser.md
@@ -40,7 +40,7 @@ The current location object.
 ### navigate()
 
 ```js
-history.navigate("/the-producers");
+history.navigate({ url: "/the-producers" });
 history.navigate({
   pathname: "/oklahoma",
   state: { musical: true }
@@ -54,7 +54,7 @@ There are three ways that it can do this: `push`, `replace`, and `anchor`.
 1.  `push` navigation pushes the new location onto the session history after the current location. Any existing locations after the current location are dropped.
 
 ```js
-history.navigate("/lion-king", "push");
+history.navigate({ url: "/lion-king" }, "push");
 history.navigate(
   {
     pathname: "/wicked",
@@ -67,7 +67,7 @@ history.navigate(
 2.  `replace` navigation replaces the current location with the new location. Any existing locations after the current location are unaffected.
 
 ```js
-history.navigate("/cats", "replace");
+history.navigate({ url: "/cats" }, "replace");
 history.navigate(
   {
     pathname: "/rent",
@@ -80,7 +80,7 @@ history.navigate(
 3.  `anchor` mimics the behavior of clicking on an `<a>` element. When the new location's URL is exactly the same as the current location's, it will act like `replace`; when they are different, it will act like `push`.
 
 ```js
-history.navigate("/hairspray", "anchor");
+history.navigate({ url: "/hairspray" }, "anchor");
 history.navigate(
   {
     pathname: "/hamilton",

--- a/docs/api/hash.md
+++ b/docs/api/hash.md
@@ -63,7 +63,7 @@ The current location object.
 ### navigate()
 
 ```js
-history.navigate("/the-producers");
+history.navigate({ url: "/the-producers" });
 history.navigate({
   pathname: "/oklahoma",
   state: { musical: true }
@@ -77,7 +77,7 @@ There are three ways that it can do this: `push`, `replace`, and `anchor`.
 1.  `push` navigation pushes the new location onto the session history after the current location. Any existing locations after the current location are dropped.
 
 ```js
-history.navigate("/lion-king", "push");
+history.navigate({ url: "/lion-king" }, "push");
 history.navigate(
   {
     pathname: "/wicked",
@@ -90,7 +90,7 @@ history.navigate(
 2.  `replace` navigation replaces the current location with the new location. Any existing locations after the current location are unaffected.
 
 ```js
-history.navigate("/cats", "replace");
+history.navigate({ url: "/cats" }, "replace");
 history.navigate(
   {
     pathname: "/rent",
@@ -103,7 +103,7 @@ history.navigate(
 3.  `anchor` mimics the behavior of clicking on an `<a>` element. When the new location's URL is exactly the same as the current location's, it will act like `replace`; when they are different, it will act like `push`.
 
 ```js
-history.navigate("/hairspray", "anchor");
+history.navigate({ url: "/hairspray" }, "anchor");
 history.navigate(
   {
     pathname: "/hamilton",

--- a/docs/api/in-memory.md
+++ b/docs/api/in-memory.md
@@ -44,7 +44,7 @@ The current location object.
 ### navigate()
 
 ```js
-history.navigate("/the-producers");
+history.navigate({ url: "/the-producers" });
 history.navigate({
   pathname: "/oklahoma",
   state: { musical: true }
@@ -58,7 +58,7 @@ There are three ways that it can do this: `push`, `replace`, and `anchor`.
 1.  `push` navigation pushes the new location onto the session history after the current location. Any existing locations after the current location are dropped.
 
 ```js
-history.navigate("/lion-king", "push");
+history.navigate({ url: "/lion-king" }, "push");
 history.navigate(
   {
     pathname: "/wicked",
@@ -71,7 +71,7 @@ history.navigate(
 2.  `replace` navigation replaces the current location with the new location. Any existing locations after the current location are unaffected.
 
 ```js
-history.navigate("/cats", "replace");
+history.navigate({ url: "/cats" }, "replace");
 history.navigate(
   {
     pathname: "/rent",
@@ -84,7 +84,7 @@ history.navigate(
 3.  `anchor` mimics the behavior of clicking on an `<a>` element. When the new location's URL is exactly the same as the current location's, it will act like `replace`; when they are different, it will act like `push`.
 
 ```js
-history.navigate("/hairspray", "anchor");
+history.navigate({ url: "/hairspray" }, "anchor");
 history.navigate(
   {
     pathname: "/hamilton",

--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 4479,
-    "minified": 1760,
-    "gzipped": 778,
+    "bundled": 4492,
+    "minified": 1772,
+    "gzipped": 782,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 4531,
-    "minified": 1808,
-    "gzipped": 825
+    "bundled": 4544,
+    "minified": 1820,
+    "gzipped": 829
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 14971,
-    "minified": 4350,
-    "gzipped": 1797
+    "bundled": 14796,
+    "minified": 4329,
+    "gzipped": 1814
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 14971,
-    "minified": 4350,
-    "gzipped": 1797
+    "bundled": 14796,
+    "minified": 4329,
+    "gzipped": 1814
   }
 }

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- `history.navigate()` takes one argument, an object with an optional `state` property. The object can either contain URL components (`pathname`, `query`, and `hash`) or a URL string under the `url` property.
+
 ## 2.0.0-beta.10
 
 - Rename `base_segment` option to `base`.

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -32,13 +32,13 @@ export function browser(
 
   function fromBrowser(providedState?: object): SessionLocation {
     const { pathname, search, hash } = window.location;
-    const path = pathname + search + hash;
+    const url = pathname + search + hash;
     let { key, state } = providedState || getStateFromHistory();
     if (!key) {
       key = keygen.major();
-      window.history.replaceState({ key, state }, "", path);
+      window.history.replaceState({ key, state }, "", url);
     }
-    const location = utils.location(path, state);
+    const location = utils.location({ url, state });
     return utils.keyed(location, key);
   }
 

--- a/packages/browser/tests/integration/browser.ts
+++ b/packages/browser/tests/integration/browser.ts
@@ -39,7 +39,7 @@ describe("browser integration tests", () => {
         testHistory = browser(pending => {
           pending.finish();
         });
-        testHistory.navigate("/the-new-location", "push");
+        testHistory.navigate({ url: "/the-new-location" }, "push");
 
         expect(window.location.pathname).toEqual("/the-new-location");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(1);
@@ -71,7 +71,7 @@ describe("browser integration tests", () => {
         testHistory = browser(pending => {
           pending.finish();
         });
-        testHistory.navigate("/the-same-location", "replace");
+        testHistory.navigate({ url: "/the-same-location" }, "replace");
         expect(window.location.pathname).toEqual("/the-same-location");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(0);
         expect((<jasmine.Spy>window.history.replaceState).calls.count()).toBe(
@@ -106,15 +106,15 @@ describe("browser integration tests", () => {
         switch (calls++) {
           case 0:
             pending.finish();
-            localHistory.navigate("/one", "push");
+            localHistory.navigate({ url: "/one" }, "push");
             break;
           case 1:
             pending.finish();
-            localHistory.navigate("/two", "push");
+            localHistory.navigate({ url: "/two" }, "push");
             break;
           case 2:
             pending.finish();
-            localHistory.navigate("/three", "push");
+            localHistory.navigate({ url: "/three" }, "push");
             break;
           case 3:
             pending.finish();
@@ -140,15 +140,15 @@ describe("browser integration tests", () => {
         switch (calls++) {
           case 0:
             pending.finish();
-            localHistory.navigate("/uno", "push");
+            localHistory.navigate({ url: "/uno" }, "push");
             break;
           case 1:
             pending.finish();
-            localHistory.navigate("/dos", "push");
+            localHistory.navigate({ url: "/dos" }, "push");
             break;
           case 2:
             pending.finish();
-            localHistory.navigate("/tres", "push");
+            localHistory.navigate({ url: "/tres" }, "push");
             break;
           case 3:
             pending.finish();

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 6672,
-    "minified": 2588,
-    "gzipped": 1004,
+    "bundled": 6727,
+    "minified": 2610,
+    "gzipped": 1013,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 6873,
-    "minified": 2780,
-    "gzipped": 1053
+    "bundled": 6928,
+    "minified": 2802,
+    "gzipped": 1062
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 17082,
-    "minified": 4872,
-    "gzipped": 1944
+    "bundled": 16953,
+    "minified": 4861,
+    "gzipped": 1963
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 17082,
-    "minified": 4872,
-    "gzipped": 1944
+    "bundled": 16953,
+    "minified": 4861,
+    "gzipped": 1963
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- `history.navigate()` takes one argument, an object with an optional `state` property. The object can either contain URL components (`pathname`, `query`, and `hash`) or a URL string under the `url` property.
+
 ## 2.0.0-beta.10
 
 - Rename `base_segment` option to `base`.

--- a/packages/hash/src/hash.ts
+++ b/packages/hash/src/hash.ts
@@ -42,14 +42,15 @@ export function hash(
 
   function fromBrowser(providedState?: object): SessionLocation {
     let { hash } = window.location;
-    const path = decodeHashPath(hash);
+    const url = decodeHashPath(hash);
     let { key, state } = providedState || getStateFromHistory();
     if (!key) {
       key = keygen.major();
       // replace with the hash we received, not the decoded path
       window.history.replaceState({ key, state }, "", hash);
     }
-    return utils.keyed(utils.location(path), key);
+    const location = utils.location({ url, state });
+    return utils.keyed(location, key);
   }
 
   function href(location: Hrefable): string {

--- a/packages/hash/tests/integration/hash.ts
+++ b/packages/hash/tests/integration/hash.ts
@@ -43,7 +43,7 @@ describe("hash integration tests", () => {
         testHistory = hash(pending => {
           pending.finish();
         });
-        testHistory.navigate("/a-new-position", "push");
+        testHistory.navigate({ url: "/a-new-position" }, "push");
         expect(window.location.hash).toEqual("#/a-new-position");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(1);
         expect((<jasmine.Spy>window.history.replaceState).calls.count()).toBe(
@@ -74,7 +74,7 @@ describe("hash integration tests", () => {
         testHistory = hash(pending => {
           pending.finish();
         });
-        testHistory.navigate("/the-same-position", "replace");
+        testHistory.navigate({ url: "/the-same-position" }, "replace");
         expect(window.location.hash).toEqual("#/the-same-position");
         expect((<jasmine.Spy>window.history.pushState).calls.count()).toBe(0);
         expect((<jasmine.Spy>window.history.replaceState).calls.count()).toBe(
@@ -109,15 +109,15 @@ describe("hash integration tests", () => {
         switch (calls++) {
           case 0:
             pending.finish();
-            localHistory.navigate("/eins", "push");
+            localHistory.navigate({ url: "/eins" }, "push");
             break;
           case 1:
             pending.finish();
-            localHistory.navigate("/zwei", "push");
+            localHistory.navigate({ url: "/zwei" }, "push");
             break;
           case 2:
             pending.finish();
-            localHistory.navigate("/drei", "push");
+            localHistory.navigate({ url: "/drei" }, "push");
             break;
           case 3:
             pending.finish();
@@ -143,15 +143,15 @@ describe("hash integration tests", () => {
         switch (calls++) {
           case 0:
             pending.finish();
-            localHistory.navigate("/uno", "push");
+            localHistory.navigate({ url: "/uno" }, "push");
             break;
           case 1:
             pending.finish();
-            localHistory.navigate("/dos", "push");
+            localHistory.navigate({ url: "/dos" }, "push");
             break;
           case 2:
             pending.finish();
-            localHistory.navigate("/tres", "push");
+            localHistory.navigate({ url: "/tres" }, "push");
             break;
           case 3:
             pending.finish();

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5005,
-    "minified": 1732,
-    "gzipped": 717,
+    "bundled": 5113,
+    "minified": 1804,
+    "gzipped": 743,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5099,
-    "minified": 1819,
-    "gzipped": 770
+    "bundled": 5207,
+    "minified": 1891,
+    "gzipped": 794
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 14973,
-    "minified": 4237,
-    "gzipped": 1721
+    "bundled": 14893,
+    "minified": 4276,
+    "gzipped": 1759
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 14973,
-    "minified": 4237,
-    "gzipped": 1721
+    "bundled": 14893,
+    "minified": 4276,
+    "gzipped": 1759
   }
 }

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5113,
-    "minified": 1804,
-    "gzipped": 743,
+    "bundled": 5014,
+    "minified": 1738,
+    "gzipped": 722,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5207,
-    "minified": 1891,
-    "gzipped": 794
+    "bundled": 5108,
+    "minified": 1825,
+    "gzipped": 774
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 14893,
-    "minified": 4276,
-    "gzipped": 1759
+    "bundled": 14794,
+    "minified": 4210,
+    "gzipped": 1746
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 14893,
-    "minified": 4276,
-    "gzipped": 1759
+    "bundled": 14794,
+    "minified": 4210,
+    "gzipped": 1746
   }
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- `history.navigate()` takes one argument, an object with an optional `state` property. The object can either contain URL components (`pathname`, `query`, and `hash`) or a URL string under the `url` property.
+
 ## 2.0.0-beta.11
 
 - Rename `in_memory` to `inMemory`.

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
 - `history.navigate()` takes one argument, an object with an optional `state` property. The object can either contain URL components (`pathname`, `query`, and `hash`) or a URL string under the `url` property.
+- `inMemory`'s `locations` option no longer takes strings. Now, must be a URL object or a URL components object.
+- `createReusable`'s return function's `location` option no longer takes strings. Now, must be a URL object or a URL components object.
 
 ## 2.0.0-beta.11
 

--- a/packages/in-memory/src/createReusable.ts
+++ b/packages/in-memory/src/createReusable.ts
@@ -21,7 +21,14 @@ export function createReusable(
   }
 
   return function(fn: ResponseHandler, options: LocationOptions): History {
-    const location = utils.keyed(utils.location(options.location), [0, 0]);
+    const location = utils.keyed(
+      utils.location(
+        typeof options.location === "string"
+          ? { url: options.location }
+          : options.location
+      ),
+      [0, 0]
+    );
 
     return {
       location,

--- a/packages/in-memory/src/createReusable.ts
+++ b/packages/in-memory/src/createReusable.ts
@@ -21,14 +21,7 @@ export function createReusable(
   }
 
   return function(fn: ResponseHandler, options: LocationOptions): History {
-    const location = utils.keyed(
-      utils.location(
-        typeof options.location === "string"
-          ? { url: options.location }
-          : options.location
-      ),
-      [0, 0]
-    );
+    const location = utils.keyed(utils.location(options.location), [0, 0]);
 
     return {
       location,

--- a/packages/in-memory/src/inMemory.ts
+++ b/packages/in-memory/src/inMemory.ts
@@ -32,13 +32,10 @@ export function inMemory(
     return value !== undefined && value >= 0 && value < locations.length;
   }
   function initializeLocations(
-    locs: InputLocations = ["/"]
+    locs: InputLocations = [{ url: "/" }]
   ): Array<SessionLocation> {
-    return locs.map((loc: Hrefable) =>
-      utils.keyed(
-        utils.location(typeof loc === "string" ? { url: loc } : loc),
-        keygen.major()
-      )
+    return locs.map((loc: ToArgument) =>
+      utils.keyed(utils.location(loc), keygen.major())
     );
   }
 

--- a/packages/in-memory/src/inMemory.ts
+++ b/packages/in-memory/src/inMemory.ts
@@ -35,7 +35,10 @@ export function inMemory(
     locs: InputLocations = ["/"]
   ): Array<SessionLocation> {
     return locs.map((loc: Hrefable) =>
-      utils.keyed(utils.location(loc), keygen.major())
+      utils.keyed(
+        utils.location(typeof loc === "string" ? { url: loc } : loc),
+        keygen.major()
+      )
     );
   }
 

--- a/packages/in-memory/src/types.ts
+++ b/packages/in-memory/src/types.ts
@@ -2,6 +2,7 @@ import {
   HistoryConstructor,
   HistoryOptions,
   History,
+  ToArgument,
   LocationComponents,
   SessionLocation,
   PartialLocation,
@@ -14,11 +15,12 @@ export {
   History,
   SessionLocation,
   PartialLocation,
+  ToArgument,
   Hrefable,
   LocationComponents
 };
 
-export type InputLocations = Array<Hrefable>;
+export type InputLocations = Array<ToArgument>;
 
 export interface SessionOptions {
   locations?: InputLocations;
@@ -31,5 +33,5 @@ export interface InMemoryHistory extends History {
 }
 
 export interface LocationOptions {
-  location: Hrefable;
+  location: ToArgument;
 }

--- a/packages/in-memory/tests/createReusable.spec.ts
+++ b/packages/in-memory/tests/createReusable.spec.ts
@@ -11,7 +11,7 @@ describe("createReusable", () => {
         pending.finish();
       },
       {
-        location: "/one#step"
+        location: { url: "/one#step" }
       }
     );
     expect(testHistory.location).toMatchObject({
@@ -44,7 +44,7 @@ describe("createReusable", () => {
         pending.finish();
       },
       {
-        location: "/one"
+        location: { url: "/one" }
       }
     );
   });
@@ -57,7 +57,7 @@ describe("createReusable", () => {
         pending.finish();
       },
       {
-        location: "/one"
+        location: { url: "/one" }
       }
     );
   });
@@ -74,7 +74,7 @@ describe("createReusable", () => {
         pending.finish();
       },
       {
-        location: "/pathname?query=this#hash"
+        location: { url: "/pathname?query=this#hash" }
       }
     );
     expect(testHistory.location.query).toEqual({ query: "this" });
@@ -90,7 +90,7 @@ describe("no-op functions", () => {
           pending.finish();
         },
         {
-          location: "/one#step"
+          location: { url: "/one#step" }
         }
       );
       expect(() => {
@@ -107,11 +107,11 @@ describe("no-op functions", () => {
           pending.finish();
         },
         {
-          location: "/one#step"
+          location: { url: "/one#step" }
         }
       );
       expect(() => {
-        testHistory.navigate("/elsewhere");
+        testHistory.navigate({ url: "/elsewhere" });
       }).not.toThrow();
     });
   });
@@ -124,7 +124,7 @@ describe("no-op functions", () => {
           pending.finish();
         },
         {
-          location: "/one#step"
+          location: { url: "/one#step" }
         }
       );
       expect(() => {
@@ -161,7 +161,7 @@ describe("href", () => {
         pending.finish();
       },
       {
-        location: "/"
+        location: { url: "/" }
       }
     );
     const href = testHistory.href({ pathname: "/yo", query: { one: 1 } });

--- a/packages/in-memory/tests/inMemory.spec.ts
+++ b/packages/in-memory/tests/inMemory.spec.ts
@@ -23,7 +23,7 @@ function runAsyncTest(test: TestCase) {
       test.fn({
         constructor: inMemory,
         options: {
-          locations: ["/one"]
+          locations: [{ url: "/one" }]
         },
         resolve
       } as AsyncFnOptions);
@@ -36,7 +36,7 @@ function runTest(test: TestCase) {
     test.fn({
       constructor: inMemory,
       options: {
-        locations: ["/one"]
+        locations: [{ url: "/one" }]
       }
     } as FnOptions);
   });
@@ -70,7 +70,7 @@ describe("Memory constructor", () => {
         pending.finish();
       },
       {
-        locations: ["/one#step"]
+        locations: [{ url: "/one#step" }]
       }
     );
     expect(testHistory.location).toMatchObject({
@@ -100,7 +100,7 @@ describe("Memory constructor", () => {
         pending.finish();
       },
       {
-        locations: ["/one", "/two", "/three"],
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }],
         index: 2
       }
     );
@@ -116,7 +116,7 @@ describe("Memory constructor", () => {
           pending.finish();
         },
         {
-          locations: ["/one", "/two", "/three"],
+          locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }],
           index: value
         }
       );
@@ -133,7 +133,7 @@ describe("Memory constructor", () => {
         pending.finish();
       },
       {
-        locations: ["/one", "/two", "/three"],
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }],
         index: 0
       }
     );
@@ -202,7 +202,7 @@ describe("reset()", () => {
           pending.finish();
         },
         {
-          locations: ["/one", "/two", "/three"]
+          locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }]
         }
       );
       expect(testHistory.location).toMatchObject({
@@ -210,7 +210,7 @@ describe("reset()", () => {
       });
 
       testHistory.reset({
-        locations: ["/uno", "/dos"]
+        locations: [{ url: "/uno" }, { url: "/dos" }]
       });
       expect(testHistory.location).toMatchObject({
         pathname: "/uno"
@@ -223,7 +223,7 @@ describe("reset()", () => {
           pending.finish();
         },
         {
-          locations: ["/one", "/two", "/three"]
+          locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }]
         }
       );
       expect(testHistory.location).toMatchObject({
@@ -244,7 +244,7 @@ describe("reset()", () => {
           pending.finish();
         },
         {
-          locations: ["/one", "/two", "/three"]
+          locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }]
         }
       );
       expect(testHistory.location).toMatchObject({
@@ -260,7 +260,7 @@ describe("reset()", () => {
     it("reset removes existing locations", () => {
       const router = jest.fn();
       const testHistory = inMemory(router, {
-        locations: ["/one", "/two", "/three"]
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }]
       });
 
       // reset the call from attaching the router
@@ -271,7 +271,7 @@ describe("reset()", () => {
       // response handler is called because we can pop
       expect(router.mock.calls.length).toBe(1);
 
-      testHistory.reset({ locations: ["/uno"] });
+      testHistory.reset({ locations: [{ url: "/uno" }] });
       router.mockReset();
 
       testHistory.go(2);
@@ -288,14 +288,14 @@ describe("reset()", () => {
         pending.finish();
       },
       {
-        locations: ["/one", "/two", "/three"],
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }],
         index: 1
       }
     );
     expect(testHistory.location.pathname).toBe("/two");
 
     testHistory.reset({
-      locations: ["/uno", "/dos", "/tres"],
+      locations: [{ url: "/uno" }, { url: "/dos" }, { url: "/tres" }],
       index: 2
     });
     expect(testHistory.location.pathname).toBe("/tres");
@@ -307,14 +307,14 @@ describe("reset()", () => {
         pending.finish();
       },
       {
-        locations: ["/one", "/two", "/three"],
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }],
         index: 1
       }
     );
     expect(testHistory.location.pathname).toBe("/two");
 
     testHistory.reset({
-      locations: ["/uno", "/dos", "/tres"]
+      locations: [{ url: "/uno" }, { url: "/dos" }, { url: "/tres" }]
     });
     expect(testHistory.location.pathname).toBe("/uno");
   });
@@ -325,14 +325,14 @@ describe("reset()", () => {
         pending.finish();
       },
       {
-        locations: ["/one", "/two", "/three"],
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }],
         index: 1
       }
     );
     expect(testHistory.location.pathname).toBe("/two");
 
     testHistory.reset({
-      locations: ["/uno", "/dos", "/tres"],
+      locations: [{ url: "/uno" }, { url: "/dos" }, { url: "/tres" }],
       index: -1
     });
     expect(testHistory.location.pathname).toBe("/uno");
@@ -344,14 +344,14 @@ describe("reset()", () => {
         pending.finish();
       },
       {
-        locations: ["/one", "/two", "/three"],
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }],
         index: 1
       }
     );
     expect(testHistory.location.pathname).toBe("/two");
 
     testHistory.reset({
-      locations: ["/uno", "/dos", "/tres"],
+      locations: [{ url: "/uno" }, { url: "/dos" }, { url: "/tres" }],
       index: 7
     });
     expect(testHistory.location.pathname).toBe("/uno");
@@ -361,11 +361,11 @@ describe("reset()", () => {
     it("emits the new location", () => {
       const router = jest.fn();
       const testHistory = inMemory(router, {
-        locations: ["/one", "/two", "/three"]
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }]
       });
 
       testHistory.reset({
-        locations: ["/uno", "/dos"]
+        locations: [{ url: "/uno" }, { url: "/dos" }]
       });
       expect(router.mock.calls.length).toBe(1);
       expect(router.mock.calls[0][0]).toMatchObject({
@@ -378,11 +378,11 @@ describe("reset()", () => {
     it('emits the action as "push"', () => {
       const router = jest.fn();
       const testHistory = inMemory(router, {
-        locations: ["/one", "/two", "/three"]
+        locations: [{ url: "/one" }, { url: "/two" }, { url: "/three" }]
       });
 
       testHistory.reset({
-        locations: ["/uno", "/dos"]
+        locations: [{ url: "/uno" }, { url: "/dos" }]
       });
       expect(router.mock.calls[0][0]).toMatchObject({
         action: "push"

--- a/packages/in-memory/types/types.d.ts
+++ b/packages/in-memory/types/types.d.ts
@@ -1,6 +1,6 @@
-import { HistoryConstructor, HistoryOptions, History, LocationComponents, SessionLocation, PartialLocation, Hrefable } from "@hickory/root";
-export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, Hrefable, LocationComponents };
-export declare type InputLocations = Array<Hrefable>;
+import { HistoryConstructor, HistoryOptions, History, ToArgument, LocationComponents, SessionLocation, PartialLocation, Hrefable } from "@hickory/root";
+export { HistoryConstructor, HistoryOptions, History, SessionLocation, PartialLocation, ToArgument, Hrefable, LocationComponents };
+export declare type InputLocations = Array<ToArgument>;
 export interface SessionOptions {
     locations?: InputLocations;
     index?: number;
@@ -10,5 +10,5 @@ export interface InMemoryHistory extends History {
     reset(options?: SessionOptions): void;
 }
 export interface LocationOptions {
-    location: Hrefable;
+    location: ToArgument;
 }

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 8467,
-    "minified": 2980,
-    "gzipped": 1265,
+    "bundled": 8299,
+    "minified": 2999,
+    "gzipped": 1292,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 8634,
-    "minified": 3133,
-    "gzipped": 1307
+    "bundled": 8466,
+    "minified": 3152,
+    "gzipped": 1333
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 10403,
-    "minified": 3038,
-    "gzipped": 1352
+    "bundled": 10215,
+    "minified": 3005,
+    "gzipped": 1371
   },
   "dist/hickory-root.min.js": {
-    "bundled": 10403,
-    "minified": 3038,
-    "gzipped": 1352
+    "bundled": 10215,
+    "minified": 3005,
+    "gzipped": 1371
   }
 }

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next
+
+- `locationUtils.location` can take an object of shape `{ url: string, state: any }`.
+- Remove `string` option from first argument to `locationUtils.location`.
+- Remove `state` argument from `locationUtils.location`.
+
 ## 2.0.0-beta.11
 
 - Revert snake casing

--- a/packages/root/src/types/location.ts
+++ b/packages/root/src/types/location.ts
@@ -5,6 +5,11 @@ export interface LocationComponents {
   state?: any;
 }
 
+export interface URLWithState {
+  url: string;
+  state?: any;
+}
+
 export type PartialLocation = Partial<LocationComponents>;
 
 export type Key = [number, number];

--- a/packages/root/src/types/locationUtils.ts
+++ b/packages/root/src/types/locationUtils.ts
@@ -1,4 +1,11 @@
-import { LocationComponents, SessionLocation, Hrefable, Key } from "./location";
+import {
+  LocationComponents,
+  SessionLocation,
+  Hrefable,
+  Key,
+  PartialLocation,
+  URLWithState
+} from "./location";
 
 export interface QueryFunctions {
   parse: (query?: string) => any;
@@ -12,6 +19,6 @@ export interface LocationUtilOptions {
 
 export interface LocationUtils {
   keyed(location: LocationComponents, key: Key): SessionLocation;
-  location(value: string | object, state?: any): LocationComponents;
+  location(value: PartialLocation | URLWithState): LocationComponents;
   stringify(location: Hrefable): string;
 }

--- a/packages/root/src/types/navigate.ts
+++ b/packages/root/src/types/navigate.ts
@@ -1,8 +1,8 @@
 import { LocationUtils } from "./locationUtils";
 import { KeyFns } from "./keyGenerator";
-import { PartialLocation, SessionLocation } from "./location";
+import { PartialLocation, SessionLocation, URLWithState } from "./location";
 
-export type ToArgument = string | PartialLocation;
+export type ToArgument = PartialLocation | URLWithState;
 
 export type Action = "push" | "replace" | "pop";
 export type NavType = "anchor" | "push" | "replace";

--- a/packages/root/tests/navigateWith.spec.ts
+++ b/packages/root/tests/navigateWith.spec.ts
@@ -74,7 +74,7 @@ describe("navigateWith", () => {
           ...rest
         });
 
-        const nav = prepare("/next", "anchor");
+        const nav = prepare({ url: "/next" }, "anchor");
 
         it("returns a push navigation object", () => {
           expect(nav.location).toMatchObject({
@@ -108,7 +108,7 @@ describe("navigateWith", () => {
           ...rest
         });
 
-        const nav = prepare("/", "anchor");
+        const nav = prepare({ url: "/" }, "anchor");
 
         it("returns a replace navigation object", () => {
           expect(nav.location).toMatchObject({
@@ -142,7 +142,7 @@ describe("navigateWith", () => {
           keygen,
           ...rest
         });
-        const nav = prepare("/next", "push");
+        const nav = prepare({ url: "/next" }, "push");
 
         it("returns a push navigation object", () => {
           expect(nav.location).toMatchObject({
@@ -178,7 +178,7 @@ describe("navigateWith", () => {
           ...rest
         });
 
-        const nav = prepare("/next", "replace");
+        const nav = prepare({ url: "/next" }, "replace");
 
         it("returns a replace navigation object", () => {
           expect(nav.location).toMatchObject({
@@ -214,7 +214,7 @@ describe("navigateWith", () => {
 
         expect(() => {
           // @ts-ignore
-          const nav = prepare("/next", "test");
+          const nav = prepare({ url: "/next" }, "test");
         }).toThrow();
       });
     });

--- a/packages/root/types/types/location.d.ts
+++ b/packages/root/types/types/location.d.ts
@@ -4,6 +4,10 @@ export interface LocationComponents {
     hash: string;
     state?: any;
 }
+export interface URLWithState {
+    url: string;
+    state?: any;
+}
 export declare type PartialLocation = Partial<LocationComponents>;
 export declare type Key = [number, number];
 export interface SessionLocation extends LocationComponents {

--- a/packages/root/types/types/locationUtils.d.ts
+++ b/packages/root/types/types/locationUtils.d.ts
@@ -1,4 +1,4 @@
-import { LocationComponents, SessionLocation, Hrefable, Key } from "./location";
+import { LocationComponents, SessionLocation, Hrefable, Key, PartialLocation, URLWithState } from "./location";
 export interface QueryFunctions {
     parse: (query?: string) => any;
     stringify: (query?: any) => string;
@@ -9,6 +9,6 @@ export interface LocationUtilOptions {
 }
 export interface LocationUtils {
     keyed(location: LocationComponents, key: Key): SessionLocation;
-    location(value: string | object, state?: any): LocationComponents;
+    location(value: PartialLocation | URLWithState): LocationComponents;
     stringify(location: Hrefable): string;
 }

--- a/packages/root/types/types/navigate.d.ts
+++ b/packages/root/types/types/navigate.d.ts
@@ -1,7 +1,7 @@
 import { LocationUtils } from "./locationUtils";
 import { KeyFns } from "./keyGenerator";
-import { PartialLocation, SessionLocation } from "./location";
-export declare type ToArgument = string | PartialLocation;
+import { PartialLocation, SessionLocation, URLWithState } from "./location";
+export declare type ToArgument = PartialLocation | URLWithState;
 export declare type Action = "push" | "replace" | "pop";
 export declare type NavType = "anchor" | "push" | "replace";
 export declare type FinishNavigation = () => void;

--- a/tests/cases/cancel/cancel-call.ts
+++ b/tests/cases/cancel/cancel-call.ts
@@ -13,23 +13,23 @@ export default {
       switch (calls++) {
         case 0:
           pending.finish();
-          localHistory.navigate("/two", "push");
+          localHistory.navigate({ url: "/two" }, "push");
           break;
         case 1:
           pending.finish();
-          localHistory.navigate("/three", "push");
+          localHistory.navigate({ url: "/three" }, "push");
           break;
         case 2:
           pending.finish();
-          localHistory.navigate("/four", "push");
+          localHistory.navigate({ url: "/four" }, "push");
           break;
         case 3:
           pending.finish();
-          localHistory.navigate("/five", "push");
+          localHistory.navigate({ url: "/five" }, "push");
           break;
         case 4:
           pending.finish();
-          localHistory.navigate("/six", "push");
+          localHistory.navigate({ url: "/six" }, "push");
           break;
         case 5:
           pending.finish();

--- a/tests/cases/go/cancel-with-pop.ts
+++ b/tests/cases/go/cancel-with-pop.ts
@@ -13,23 +13,23 @@ export default {
       switch (calls++) {
         case 0:
           pending.finish();
-          localHistory.navigate("/two", "push");
+          localHistory.navigate({ url: "/two" }, "push");
           break;
         case 1:
           pending.finish();
-          localHistory.navigate("/three", "push");
+          localHistory.navigate({ url: "/three" }, "push");
           break;
         case 2:
           pending.finish();
-          localHistory.navigate("/four", "push");
+          localHistory.navigate({ url: "/four" }, "push");
           break;
         case 3:
           pending.finish();
-          localHistory.navigate("/five", "push");
+          localHistory.navigate({ url: "/five" }, "push");
           break;
         case 4:
           pending.finish();
-          localHistory.navigate("/six", "push");
+          localHistory.navigate({ url: "/six" }, "push");
           break;
         case 5:
           pending.finish();

--- a/tests/cases/go/cancel-with-push.ts
+++ b/tests/cases/go/cancel-with-push.ts
@@ -12,30 +12,30 @@ export default {
       switch (calls++) {
         case 0:
           pending.finish();
-          history.navigate("/two", "push");
+          history.navigate({ url: "/two" }, "push");
           break;
         case 1:
           pending.finish();
-          history.navigate("/three", "push");
+          history.navigate({ url: "/three" }, "push");
           break;
         case 2:
           pending.finish();
-          history.navigate("/four", "push");
+          history.navigate({ url: "/four" }, "push");
           break;
         case 3:
           pending.finish();
-          history.navigate("/five", "push");
+          history.navigate({ url: "/five" }, "push");
           break;
         case 4:
           pending.finish();
-          history.navigate("/six", "push");
+          history.navigate({ url: "/six" }, "push");
           break;
         case 5:
           pending.finish();
           history.go(-2);
           break;
         case 6:
-          history.navigate("/seven", "push");
+          history.navigate({ url: "/seven" }, "push");
           break;
         case 7:
           pending.finish();

--- a/tests/cases/go/cancel-with-replace.ts
+++ b/tests/cases/go/cancel-with-replace.ts
@@ -14,30 +14,30 @@ export default {
       switch (calls++) {
         case 0:
           pending.finish();
-          localHistory.navigate("/two", "push");
+          localHistory.navigate({ url: "/two" }, "push");
           break;
         case 1:
           pending.finish();
-          localHistory.navigate("/three", "push");
+          localHistory.navigate({ url: "/three" }, "push");
           break;
         case 2:
           pending.finish();
-          localHistory.navigate("/four", "push");
+          localHistory.navigate({ url: "/four" }, "push");
           break;
         case 3:
           pending.finish();
-          localHistory.navigate("/five", "push");
+          localHistory.navigate({ url: "/five" }, "push");
           break;
         case 4:
           pending.finish();
-          localHistory.navigate("/six", "push");
+          localHistory.navigate({ url: "/six" }, "push");
           break;
         case 5:
           pending.finish();
           localHistory.go(-2);
           break;
         case 6:
-          localHistory.navigate("/seven", "replace");
+          localHistory.navigate({ url: "/seven" }, "replace");
           break;
         case 7:
           pending.finish();

--- a/tests/cases/go/finishing-pop.ts
+++ b/tests/cases/go/finishing-pop.ts
@@ -13,7 +13,7 @@ export default {
       switch (calls++) {
         case 0:
           pending.finish();
-          localHistory.navigate("/two");
+          localHistory.navigate({ url: "/two" });
           break;
         case 1:
           pending.finish();

--- a/tests/cases/go/response-handler.ts
+++ b/tests/cases/go/response-handler.ts
@@ -13,23 +13,23 @@ export default {
       switch (calls++) {
         case 0:
           pending.finish();
-          localHistory.navigate("/two", "push");
+          localHistory.navigate({ url: "/two" }, "push");
           break;
         case 1:
           pending.finish();
-          localHistory.navigate("/three", "push");
+          localHistory.navigate({ url: "/three" }, "push");
           break;
         case 2:
           pending.finish();
-          localHistory.navigate("/four", "push");
+          localHistory.navigate({ url: "/four" }, "push");
           break;
         case 3:
           pending.finish();
-          localHistory.navigate("/five", "push");
+          localHistory.navigate({ url: "/five" }, "push");
           break;
         case 4:
           pending.finish();
-          localHistory.navigate("/six", "push");
+          localHistory.navigate({ url: "/six" }, "push");
           break;
         case 5:
           pending.finish();

--- a/tests/cases/navigate/cancel-call-location.ts
+++ b/tests/cases/navigate/cancel-call-location.ts
@@ -8,6 +8,6 @@ export default {
       pending.cancel();
       expect(history.location.pathname).toBe("/one");
     }, options);
-    history.navigate("/two", "replace");
+    history.navigate({ url: "/two" }, "replace");
   }
 };

--- a/tests/cases/navigate/finish-call-sets-location.ts
+++ b/tests/cases/navigate/finish-call-sets-location.ts
@@ -9,6 +9,6 @@ export default {
       pending.finish();
       expect(history.location.pathname).toBe("/two");
     }, options);
-    history.navigate("/two");
+    history.navigate({ url: "/two" });
   }
 };

--- a/tests/cases/navigate/finish-not-called.ts
+++ b/tests/cases/navigate/finish-not-called.ts
@@ -4,7 +4,7 @@ export default {
   msg: "does nothing if pending.finish() is not called",
   fn: function({ constructor, options = {} }: TestCaseArgs) {
     const history = constructor(pending => {}, options);
-    history.navigate("/two");
+    history.navigate({ url: "/two" });
     expect(history.location.pathname).toBe("/one");
   }
 };

--- a/tests/cases/navigate/finish-sets-location.ts
+++ b/tests/cases/navigate/finish-sets-location.ts
@@ -6,7 +6,7 @@ export default {
     const history = constructor(pending => {
       pending.finish();
     }, options);
-    history.navigate("/next");
+    history.navigate({ url: "/next" });
     expect(history.location).toMatchObject({
       pathname: "/next"
     });

--- a/tests/cases/navigate/invalid-method.ts
+++ b/tests/cases/navigate/invalid-method.ts
@@ -7,7 +7,7 @@ export default {
 
     expect(() => {
       // @ts-ignore
-      history.navigate("/somewhere", "throws");
+      history.navigate({ url: "/somewhere" }, "throws");
     }).toThrowError("Invalid navigation type: throws");
   }
 };

--- a/tests/cases/navigate/navigate-anchor-new-location.ts
+++ b/tests/cases/navigate/navigate-anchor-new-location.ts
@@ -6,6 +6,6 @@ export default {
     const history = constructor(pending => {
       expect(pending.action).toBe("push");
     }, options);
-    history.navigate("/two", "anchor");
+    history.navigate({ url: "/two" }, "anchor");
   }
 };

--- a/tests/cases/navigate/navigate-anchor-same-location.ts
+++ b/tests/cases/navigate/navigate-anchor-same-location.ts
@@ -6,6 +6,6 @@ export default {
     const history = constructor(pending => {
       expect(pending.action).toBe("replace");
     }, options);
-    history.navigate("/one", "anchor");
+    history.navigate({ url: "/one" }, "anchor");
   }
 };

--- a/tests/cases/navigate/navigate-no-method-new-location.ts
+++ b/tests/cases/navigate/navigate-no-method-new-location.ts
@@ -6,6 +6,6 @@ export default {
     const history = constructor(pending => {
       expect(pending.action).toBe("push");
     }, options);
-    history.navigate("/two");
+    history.navigate({ url: "/two" });
   }
 };

--- a/tests/cases/navigate/navigate-no-method-same-location.ts
+++ b/tests/cases/navigate/navigate-no-method-same-location.ts
@@ -6,6 +6,6 @@ export default {
     const history = constructor(pending => {
       expect(pending.action).toBe("replace");
     }, options);
-    history.navigate("/one");
+    history.navigate({ url: "/one" });
   }
 };

--- a/tests/cases/navigate/navigate-push.ts
+++ b/tests/cases/navigate/navigate-push.ts
@@ -6,6 +6,6 @@ export default {
     const history = constructor(pending => {
       expect(pending.action).toBe("push");
     }, options);
-    history.navigate("/two", "push");
+    history.navigate({ url: "/two" }, "push");
   }
 };

--- a/tests/cases/navigate/navigate-replace.ts
+++ b/tests/cases/navigate/navigate-replace.ts
@@ -6,6 +6,6 @@ export default {
     const history = constructor(pending => {
       expect(pending.action).toBe("replace");
     }, options);
-    history.navigate("/two", "replace");
+    history.navigate({ url: "/two" }, "replace");
   }
 };

--- a/tests/cases/navigate/push-increments-key-major.ts
+++ b/tests/cases/navigate/push-increments-key-major.ts
@@ -19,6 +19,6 @@ export default {
           expect(currentMinor).toBe(0);
       }
     }, options);
-    history.navigate("/next");
+    history.navigate({ url: "/next" });
   }
 };

--- a/tests/cases/navigate/replace-increments-key-minor.ts
+++ b/tests/cases/navigate/replace-increments-key-minor.ts
@@ -21,6 +21,6 @@ export default {
           expect(currentMinor).toBe(initMinorNum + 1);
       }
     }, options);
-    history.navigate("/one");
+    history.navigate({ url: "/one" });
   }
 };

--- a/tests/cases/navigate/to-is-string.ts
+++ b/tests/cases/navigate/to-is-string.ts
@@ -11,6 +11,6 @@ export default {
         query: "test=ing"
       });
     }, options);
-    history.navigate("/two?test=ing");
+    history.navigate({ url: "/two?test=ing" });
   }
 };

--- a/tests/cases/navigate/with-response-handler.ts
+++ b/tests/cases/navigate/with-response-handler.ts
@@ -5,7 +5,7 @@ export default {
   fn: function({ constructor, options = {} }: TestCaseArgs) {
     const router = jest.fn();
     const history = constructor(router, options);
-    history.navigate("/two");
+    history.navigate({ url: "/two" });
     expect(router.mock.calls.length).toBe(1);
   }
 };


### PR DESCRIPTION
Previously, `history.navigate` could take an object or a string as its first argument. When the first argument was a string, it was not possible to attach `state` to the location.

With this PR, `history.navigate` always takes an object as its first argument. This object can either be a partial location object (one with `pathname`, `hash`, and `query` properties) or a url object (one with a `url` string). In both cases, the object can have a `state` property, which is state that will be attached to the location.

```js
// before
history.navigate("/test#ing");
// (not possible to attach state)

// after
history.navigate({ url: "/test#ing", state: { msg: "woo hoo } });
```

The memory histories no longer take locations as strings. This makes the options more verbose, but keeps them consistent with `history.navigate`.

```js
// before
const history = inMemory(fn, {
  locations: ['/test']
});
reusable(fn, { location: '/test' })

// after
const history = inMemory(fn, {
  locations: [{ url: '/test' }]
});
reusable(fn, { location: { url: '/test' } })
```