### PR TITLE
Expect absolute pathnames

### DIFF
--- a/docs/api/browser.md
+++ b/docs/api/browser.md
@@ -25,8 +25,6 @@ The response handler function will be passed a "pending navigation" object. This
 
   - `stringify` - A function that will convert a query value into a search string. This function should return an empty string when it is called with no arguments.
 
-- `decode` - Whether or not to automatically decode the `pathname` when creating a location. This should almost always be `true`, but if you have a reason to use invalid URIs, then you _can_ set this to `false` (possibly to your own peril). (default: `true`)
-
 - `base` - An object with `add` and `remove` functions for adding and removing a base segment
   from locations/URLs, which is useful if the application isn't hosted from the root directory of a domain. The object can be created using the [`createBase`](./createBase.md) function.
 
@@ -89,18 +87,35 @@ The `go` function is used to jump forward and backward to already visited locati
 
 `num` - The number of steps forward or backward to go.
 
-### href()
+### url()
 
 ```js
-history.href({ pathname: "/spamalot" });
+history.url({ pathname: "/spamalot" });
 // /spamalot
+
+const base = createBase("/hip/hip");
+const hiptory = browser(fn, { base });
+hiptory.url("/hooray");
+// /hip/hip/hooray
 ```
 
-The `href` function generates the string representation of the location object. This string will be prepended with the `base` (if you provided one).
+The `url` function returns a URL string. It can take either a location object or a string.
+
+If the `history` is configured with a base segment, the base segment will be prepended to the URL string.
+
+When the argument is an object:
+
+1. If the `pathname` is `undefined`, the returned string will have no pathname component, including no base segment.
+2. If the `pathname` is included, it is expected to be absolute (begin with a forward slash `/`).
+
+When the argument is a string:
+
+1. If the first character is a question mark (`?`) or hash symbol (`#`), the returned string will have no pathname component, including no base segment.
+2. When there is a pathname, it is expected to be absolute (begin with a forward slash).
 
 #### arguments
 
-`location` - The location to create a path for.
+`location` - A location object or a string.
 
 ### destroy()
 

--- a/docs/api/hash.md
+++ b/docs/api/hash.md
@@ -25,8 +25,6 @@ The response handler function will be passed a "pending navigation" object. This
 
   - `stringify` - A function that will convert a query value into a search string. This function should return an empty string when it is called with no arguments.
 
-- `decode` - Whether or not to automatically decode the `pathname` when creating a location. This should almost always be `true`, but if you have a reason to use invalid URIs, then you _can_ set this to `false` (possibly to your own peril). (default: `true`)
-
 - `hashType` - The `hashType` specifies how we translate `window.location.hash` to a location (and vice versa). The options are `default`, `bang`. and `clean`.
 
   - `default` - The encoded path begins with `#/`. If you do not provide a `hashType` option, this one will be used.
@@ -47,7 +45,7 @@ const history = hash({ base: "/test" });
 The `/test` segment will be stripped from and included in the hash segment of the full URI.
 
 ```js
-const uri = history.href({ pathname: "/pathname" });
+const uri = history.url({ pathname: "/pathname" });
 // uri === '#/test/pathname'
 ```
 
@@ -112,18 +110,35 @@ The `go` function is used to jump forward and backward to already visited locati
 
 `num` - The number of steps forward or backward to go.
 
-### href()
+### url()
 
 ```js
-history.href({ pathname: "/spamalot" });
-// #/spamalot
+history.url({ pathname: "/spamalot" });
+// /spamalot
+
+const base = createBase("/hip/hip");
+const hiptory = browser(fn, { base });
+hiptory.url("/hooray");
+// /hip/hip/hooray
 ```
 
-The `href` function generates the string representation of the location object. This string could be parsed to create the same location object, which means that for a hash history, it will be prepended with the pound sign (`#`).
+The `url` function returns a URL string. It can take either a location object or a string.
+
+If the `history` is configured with a base segment, the base segment will be prepended to the URL string.
+
+When the argument is an object:
+
+1. If the `pathname` is `undefined`, the returned string will have no pathname component, including no base segment.
+2. If the `pathname` is included, it is expected to be absolute (begin with a forward slash `/`).
+
+When the argument is a string:
+
+1. If the first character is a question mark (`?`) or hash symbol (`#`), the returned string will have no pathname component, including no base segment.
+2. When there is a pathname, it is expected to be absolute (begin with a forward slash).
 
 #### arguments
 
-`location` - The location to create a path for.
+`location` - A location object or a string.
 
 ### destroy()
 

--- a/docs/api/in-memory.md
+++ b/docs/api/in-memory.md
@@ -29,8 +29,6 @@ The response handler function will be passed a "pending navigation" object. This
 
   - `stringify` - A function that will convert a query value into a search string. This function should return an empty string when it is called with no arguments.
 
-- `decode` - Whether or not to automatically decode the `pathname` when creating a location. This should almost always be `true`, but if you have a reason to use invalid URIs, then you _can_ set this to `false` (possibly to your own peril). (default: `true`)
-
 - `base` - An object with `add` and `remove` functions for adding and removing a base segment
   from locations/URLs, which is useful if the application isn't hosted from the root directory of a domain. The object can be created using the [`createBase`](./createBase.md) function.
 
@@ -111,18 +109,35 @@ An object with the following (optional) properties:
 - `locations` - An array of location objects or strings.
 - `index` - The index of the "current" location in the locations array.
 
-### href()
+### url()
 
 ```js
-history.href({ pathname: "/spamalot" });
+history.url({ pathname: "/spamalot" });
 // /spamalot
+
+const base = createBase("/hip/hip");
+const hiptory = browser(fn, { base });
+hiptory.url("/hooray");
+// /hip/hip/hooray
 ```
 
-The `href` function generates the string representation of the location object.
+The `url` function returns a URL string. It can take either a location object or a string.
+
+If the `history` is configured with a base segment, the base segment will be prepended to the URL string.
+
+When the argument is an object:
+
+1. If the `pathname` is `undefined`, the returned string will have no pathname component, including no base segment.
+2. If the `pathname` is included, it is expected to be absolute (begin with a forward slash `/`).
+
+When the argument is a string:
+
+1. If the first character is a question mark (`?`) or hash symbol (`#`), the returned string will have no pathname component, including no base segment.
+2. When there is a pathname, it is expected to be absolute (begin with a forward slash).
 
 #### arguments
 
-`location` - The location to create a path for.
+`location` - A location object or a string.
 
 ### destroy()
 

--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 836
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 15472,
-    "minified": 4662,
-    "gzipped": 1919
+    "bundled": 14750,
+    "minified": 4601,
+    "gzipped": 1899
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 15472,
-    "minified": 4662,
-    "gzipped": 1919
+    "bundled": 14750,
+    "minified": 4601,
+    "gzipped": 1899
   }
 }

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- `url` function expects pathname to be absolute.
+
 ## 2.0.0-beta.13
 
 - Rename `history.href` to `history.url`.

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 1073
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 17629,
-    "minified": 5194,
-    "gzipped": 2077
+    "bundled": 16907,
+    "minified": 5133,
+    "gzipped": 2057
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 17629,
-    "minified": 5194,
-    "gzipped": 2077
+    "bundled": 16907,
+    "minified": 5133,
+    "gzipped": 2057
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- `url` function expects pathname to be absolute.
+
 ## 2.0.0-beta.13
 
 - Rename `history.href` to `history.url`.

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 784
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 15469,
-    "minified": 4542,
-    "gzipped": 1871
+    "bundled": 14747,
+    "minified": 4484,
+    "gzipped": 1850
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 15469,
-    "minified": 4542,
-    "gzipped": 1871
+    "bundled": 14747,
+    "minified": 4484,
+    "gzipped": 1850
   }
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- `url` function expects pathname to be absolute.
+
 ## 2.0.0-beta.13
 
 - Rename `history.href` to `history.url`.

--- a/packages/location-utils/.size-snapshot.json
+++ b/packages/location-utils/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-location-utils.es.js": {
-    "bundled": 589,
-    "minified": 390,
-    "gzipped": 182,
+    "bundled": 302,
+    "minified": 173,
+    "gzipped": 132,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-location-utils.js": {
-    "bundled": 780,
-    "minified": 563,
-    "gzipped": 247
+    "bundled": 419,
+    "minified": 278,
+    "gzipped": 182
   },
   "dist/hickory-location-utils.umd.js": {
-    "bundled": 1127,
-    "minified": 542,
-    "gzipped": 317
+    "bundled": 742,
+    "minified": 402,
+    "gzipped": 268
   },
   "dist/hickory-location-utils.min.js": {
-    "bundled": 1127,
-    "minified": 542,
-    "gzipped": 317
+    "bundled": 742,
+    "minified": 402,
+    "gzipped": 268
   }
 }

--- a/packages/location-utils/CHANGELOG.md
+++ b/packages/location-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Remove `complete___` exports.
+
 ## 2.0.0-beta.13
 
 - Remove `stripBase` function.

--- a/packages/location-utils/src/index.ts
+++ b/packages/location-utils/src/index.ts
@@ -8,18 +8,6 @@ export function ensureBeginsWith(
   return str.indexOf(prefix) === 0 ? str : prefix + str;
 }
 
-export function completePathname(pathname?: string): string {
-  return ensureBeginsWith(pathname, "/");
-}
-
-export function completeHash(hash?: string): string {
-  return ensureBeginsWith(hash, "#");
-}
-
-export function completeQuery(query?: string): string {
-  return ensureBeginsWith(query, "?");
-}
-
 export function stripPrefix(str: string, prefix: string): string {
   return str.indexOf(prefix) === 0 ? str.slice(prefix.length) : str;
 }

--- a/packages/location-utils/tests/location-utils.spec.ts
+++ b/packages/location-utils/tests/location-utils.spec.ts
@@ -1,60 +1,20 @@
 import "jest";
-import {
-  completePathname,
-  completeHash,
-  completeQuery,
-  stripPrefix
-} from "../src";
+import { ensureBeginsWith, stripPrefix } from "../src";
 
 describe("location utils", () => {
-  describe("completePathname", () => {
-    it("prepends forward slash if it doesn't exist", () => {
-      expect(completePathname("test")).toBe("/test");
+  describe("ensureBeginsWith", () => {
+    it("returns empty string if first argument is undefined", () => {
+      expect(ensureBeginsWith(undefined, "?")).toBe("");
     });
 
-    it("does nothing if pathname already begins with forward slash", () => {
-      expect(completePathname("/best")).toBe("/best");
+    it("prepends second argument if first argument does not begin with it", () => {
+      const input = "test=ing";
+      expect(ensureBeginsWith(input, "?")).toBe(`?${input}`);
     });
 
-    it("returns empty string if argument is falsy", () => {
-      const falsy = [undefined, null, ""];
-      falsy.forEach(value => {
-        expect(completePathname(value)).toBe("");
-      });
-    });
-  });
-
-  describe("completeHash", () => {
-    it("prepends pound sign if it doesn't exist", () => {
-      expect(completeHash("test")).toBe("#test");
-    });
-
-    it("does nothing if hash already begins with pound sign", () => {
-      expect(completeHash("#best")).toBe("#best");
-    });
-
-    it("returns empty string if argument is falsy", () => {
-      const falsy = [undefined, null, ""];
-      falsy.forEach(value => {
-        expect(completeHash(value)).toBe("");
-      });
-    });
-  });
-
-  describe("completeQuery", () => {
-    it("prepends forward slash if it doesn't exist", () => {
-      expect(completeQuery("test=one")).toBe("?test=one");
-    });
-
-    it("does nothing if pathname already begins with forward slash", () => {
-      expect(completeQuery("?best=two")).toBe("?best=two");
-    });
-
-    it("returns empty string if argument is falsy", () => {
-      const falsy = [undefined, null, ""];
-      falsy.forEach(value => {
-        expect(completeQuery(value)).toBe("");
-      });
+    it("returns first argument if it begins with the second argument", () => {
+      const input = "?test=ing";
+      expect(ensureBeginsWith(input, "?")).toBe(input);
     });
   });
 

--- a/packages/location-utils/tsconfig.json
+++ b/packages/location-utils/tsconfig.json
@@ -7,7 +7,8 @@
     "module": "es6",
     "declaration": true,
     "declarationDir": "types",
-    "types": ["node"]
+    "types": ["node"],
+    "esModuleInterop": true
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules"]

--- a/packages/location-utils/types/index.d.ts
+++ b/packages/location-utils/types/index.d.ts
@@ -1,5 +1,2 @@
 export declare function ensureBeginsWith(str: string | undefined | null, prefix: string): string;
-export declare function completePathname(pathname?: string): string;
-export declare function completeHash(hash?: string): string;
-export declare function completeQuery(query?: string): string;
 export declare function stripPrefix(str: string, prefix: string): string;

--- a/packages/root/.size-snapshot.json
+++ b/packages/root/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-root.es.js": {
-    "bundled": 9095,
-    "minified": 3391,
-    "gzipped": 1413,
+    "bundled": 8644,
+    "minified": 3306,
+    "gzipped": 1396,
     "treeshaked": {
       "rollup": {
         "code": 32,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-root.js": {
-    "bundled": 9294,
-    "minified": 3577,
-    "gzipped": 1476
+    "bundled": 8824,
+    "minified": 3471,
+    "gzipped": 1463
   },
   "dist/hickory-root.umd.js": {
-    "bundled": 10896,
-    "minified": 3339,
-    "gzipped": 1469
+    "bundled": 10174,
+    "minified": 3281,
+    "gzipped": 1451
   },
   "dist/hickory-root.min.js": {
-    "bundled": 10896,
-    "minified": 3339,
-    "gzipped": 1469
+    "bundled": 10174,
+    "minified": 3281,
+    "gzipped": 1451
   }
 }

--- a/packages/root/CHANGELOG.md
+++ b/packages/root/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Location util's `stringify` function expects pathname to be absolute.
+
 ## 2.0.0-beta.13
 
 - `location` function only takes object with `url` property as its first argument. It also takes an optional second argument, which is a location object to inherit properties from.

--- a/packages/root/src/locationUtils.ts
+++ b/packages/root/src/locationUtils.ts
@@ -1,8 +1,4 @@
-import {
-  completePathname,
-  completeHash,
-  completeQuery
-} from "@hickory/location-utils";
+import { ensureBeginsWith } from "@hickory/location-utils";
 
 import {
   SessionLocation,
@@ -96,27 +92,22 @@ export default function locationUtils(
     stringify(location: Hrefable): string {
       if (typeof location === "string") {
         const firstChar = location.charAt(0);
-        // keep hash/query only strings relative
         if (firstChar === "#" || firstChar === "?") {
           return location;
         }
-        const pathname = completePathname(location);
-        return base ? base.add(pathname) : pathname;
+        return base ? base.add(location) : location;
       }
-      // Ensure that pathname begins with a forward slash, query begins
-      // with a question mark, and hash begins with a pound sign.
-      // If there is no pathname, it is relative and shouldn't
-      // start with the receive the base segment.
+
       const pathname =
         location.pathname !== undefined
           ? base
-            ? base.add(completePathname(location.pathname))
-            : completePathname(location.pathname)
+            ? base.add(location.pathname)
+            : location.pathname
           : "";
       return (
         pathname +
-        completeQuery(stringifyQuery(location.query)) +
-        completeHash(location.hash)
+        ensureBeginsWith(stringifyQuery(location.query), "?") +
+        ensureBeginsWith(location.hash, "#")
       );
     }
   };

--- a/packages/root/tests/locationUtils.spec.ts
+++ b/packages/root/tests/locationUtils.spec.ts
@@ -4,7 +4,7 @@ import * as qs from "qs";
 
 import { LocationComponents, Key } from "../src/types";
 
-describe("locationFactory", () => {
+describe("location utils", () => {
   describe("constructor", () => {
     describe("query option", () => {
       const consoleWarn = console.warn;
@@ -283,14 +283,6 @@ describe("locationFactory", () => {
           expect(output).toBe("#test");
         });
 
-        it("prepends forward slash if pathname does not have one", () => {
-          const input = {
-            pathname: "test"
-          };
-          const output = stringify(input);
-          expect(output).toBe("/test");
-        });
-
         describe("base", () => {
           it("adds the base to the generated string", () => {
             const { stringify } = locationUtils({
@@ -409,24 +401,12 @@ describe("locationFactory", () => {
       });
 
       describe("beginning with a pathname", () => {
-        it("prefixes pathname that is missing a forward slash", () => {
-          expect(stringify("test")).toBe("/test");
-        });
-
         it("prefixes with base", () => {
           const { stringify } = locationUtils({
             base: createBase("/prefix")
           });
           const path = stringify("/one/two/three#four");
           expect(path).toBe("/prefix/one/two/three#four");
-        });
-
-        it("prefixes pathname when joining with base", () => {
-          const { stringify } = locationUtils({
-            base: createBase("/prefix")
-          });
-          const path = stringify("one");
-          expect(path).toBe("/prefix/one");
         });
 
         describe("base with emptyRoot = true", () => {

--- a/packages/root/tsconfig.json
+++ b/packages/root/tsconfig.json
@@ -9,7 +9,8 @@
     "declaration": true,
     "declarationDir": "types",
     "outDir": ".build",
-    "types": ["node"]
+    "types": ["node"],
+    "esModuleInterop": true
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules"]

--- a/rollup/plugins.js
+++ b/rollup/plugins.js
@@ -6,11 +6,11 @@ const { sizeSnapshot } = require("rollup-plugin-size-snapshot");
 const typescript = require("rollup-plugin-typescript2");
 
 exports.replaceWithProduction = replace({
-  "process.env.NODE_ENV": "production"
+  "process.env.NODE_ENV": `"production"`
 });
 
 exports.replaceWithDevelopment = replace({
-  "process.env.NODE_ENV": "production"
+  "process.env.NODE_ENV": `"development"`
 });
 
 exports.resolveNode = resolve();


### PR DESCRIPTION
Calls to `history.url` should include absolute pathnames (if a pathname component is provided). Previously, a relative pathname (does not begin with a forward slash) would be turned into an absolute pathname. This could disguise incorrect behavior if the pathname was intended to be relative. Now, the pathname is expected to be absolute.