### PR TITLE
Don't emit after destroying

### DIFF
--- a/packages/browser/.size-snapshot.json
+++ b/packages/browser/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-browser.es.js": {
-    "bundled": 4531,
-    "minified": 1809,
-    "gzipped": 791,
+    "bundled": 4567,
+    "minified": 1816,
+    "gzipped": 794,
     "treeshaked": {
       "rollup": {
         "code": 49,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-browser.js": {
-    "bundled": 4577,
-    "minified": 1854,
-    "gzipped": 836
+    "bundled": 4613,
+    "minified": 1861,
+    "gzipped": 839
   },
   "dist/hickory-browser.umd.js": {
-    "bundled": 14750,
-    "minified": 4601,
-    "gzipped": 1899
+    "bundled": 14790,
+    "minified": 4605,
+    "gzipped": 1901
   },
   "dist/hickory-browser.min.js": {
-    "bundled": 14750,
-    "minified": 4601,
-    "gzipped": 1899
+    "bundled": 14790,
+    "minified": 4605,
+    "gzipped": 1901
   }
 }

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Destroyed `history` instance no longer emits navigation.
+
 ## 2.0.0-beta.14
 
 - `url` function expects pathname to be absolute.

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -58,7 +58,7 @@ export function browser(
   let lastAction: Action =
     getStateFromHistory().key !== undefined ? "pop" : "push";
 
-  const {
+  let {
     emitNavigation,
     cancelPending,
     createNavigation,
@@ -150,6 +150,7 @@ export function browser(
     },
     destroy() {
       window.removeEventListener("popstate", popstate);
+      emitNavigation = noop;
     },
     navigate(to: URLWithState, navType: NavType = "anchor"): void {
       const navigation = prepare(to, navType);

--- a/packages/browser/tests/unit/browser.spec.ts
+++ b/packages/browser/tests/unit/browser.spec.ts
@@ -130,3 +130,23 @@ describe("url", () => {
     });
   });
 });
+
+describe("destroy", () => {
+  it("doesn't emit navigation after being destroyed", () => {
+    withDOM({ url: "http://example.com/one" }, () => {
+      let navCount = 0;
+      const testHistory = browser(pending => {
+        navCount++;
+        pending.finish();
+      });
+      testHistory.navigate({ url: "/two" });
+
+      expect(navCount).toBe(1);
+
+      testHistory.destroy();
+      testHistory.navigate({ url: "/three" });
+
+      expect(navCount).toBe(1);
+    });
+  });
+});

--- a/packages/hash/.size-snapshot.json
+++ b/packages/hash/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-hash.es.js": {
-    "bundled": 6766,
-    "minified": 2647,
-    "gzipped": 1021,
+    "bundled": 6802,
+    "minified": 2654,
+    "gzipped": 1023,
     "treeshaked": {
       "rollup": {
         "code": 81,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-hash.js": {
-    "bundled": 6961,
-    "minified": 2836,
-    "gzipped": 1073
+    "bundled": 6997,
+    "minified": 2843,
+    "gzipped": 1076
   },
   "dist/hickory-hash.umd.js": {
-    "bundled": 16907,
-    "minified": 5133,
-    "gzipped": 2057
+    "bundled": 16947,
+    "minified": 5137,
+    "gzipped": 2059
   },
   "dist/hickory-hash.min.js": {
-    "bundled": 16907,
-    "minified": 5133,
-    "gzipped": 2057
+    "bundled": 16947,
+    "minified": 5137,
+    "gzipped": 2059
   }
 }

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Destroyed `history` instance no longer emits navigation.
+
 ## 2.0.0-beta.14
 
 - `url` function expects pathname to be absolute.

--- a/packages/hash/src/hash.ts
+++ b/packages/hash/src/hash.ts
@@ -67,7 +67,7 @@ export function hash(
   let lastAction: Action =
     getStateFromHistory().key !== undefined ? "pop" : "push";
 
-  const {
+  let {
     emitNavigation,
     cancelPending,
     createNavigation,
@@ -156,6 +156,7 @@ export function hash(
     },
     destroy() {
       window.removeEventListener("popstate", popstate);
+      emitNavigation = noop;
     },
     navigate(to: URLWithState, navType: NavType = "anchor"): void {
       const navigation = prepare(to, navType);

--- a/packages/hash/tests/unit/hash.spec.ts
+++ b/packages/hash/tests/unit/hash.spec.ts
@@ -301,3 +301,23 @@ describe("url", () => {
     });
   });
 });
+
+describe("destroy", () => {
+  it("doesn't emit navigation after being destroyed", () => {
+    withDOM({ url: "http://example.com/one" }, () => {
+      let navCount = 0;
+      const testHistory = hash(pending => {
+        navCount++;
+        pending.finish();
+      });
+      testHistory.navigate({ url: "/two" });
+
+      expect(navCount).toBe(1);
+
+      testHistory.destroy();
+      testHistory.navigate({ url: "/three" });
+
+      expect(navCount).toBe(1);
+    });
+  });
+});

--- a/packages/in-memory/.size-snapshot.json
+++ b/packages/in-memory/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/hickory-in-memory.es.js": {
-    "bundled": 5052,
-    "minified": 1774,
-    "gzipped": 731,
+    "bundled": 5088,
+    "minified": 1781,
+    "gzipped": 735,
     "treeshaked": {
       "rollup": {
         "code": 22,
@@ -14,18 +14,18 @@
     }
   },
   "dist/hickory-in-memory.js": {
-    "bundled": 5140,
-    "minified": 1858,
-    "gzipped": 784
+    "bundled": 5176,
+    "minified": 1865,
+    "gzipped": 787
   },
   "dist/hickory-in-memory.umd.js": {
-    "bundled": 14747,
-    "minified": 4484,
-    "gzipped": 1850
+    "bundled": 14787,
+    "minified": 4488,
+    "gzipped": 1852
   },
   "dist/hickory-in-memory.min.js": {
-    "bundled": 14747,
-    "minified": 4484,
-    "gzipped": 1850
+    "bundled": 14787,
+    "minified": 4488,
+    "gzipped": 1852
   }
 }

--- a/packages/in-memory/CHANGELOG.md
+++ b/packages/in-memory/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Destroyed `history` instance no longer emits navigation.
+
 ## 2.0.0-beta.14
 
 - `url` function expects pathname to be absolute.

--- a/packages/in-memory/src/inMemory.ts
+++ b/packages/in-memory/src/inMemory.ts
@@ -50,7 +50,7 @@ export function inMemory(
 
   let lastAction: Action = "push";
 
-  const {
+  let {
     emitNavigation,
     cancelPending,
     createNavigation,
@@ -96,6 +96,7 @@ export function inMemory(
     },
     destroy(): void {
       destroyLocation();
+      emitNavigation = noop;
     },
     navigate(to: URLWithState, navType: NavType = "anchor"): void {
       const navigation = prepare(to, navType);

--- a/packages/in-memory/tests/inMemory.spec.ts
+++ b/packages/in-memory/tests/inMemory.spec.ts
@@ -354,3 +354,26 @@ describe("reset()", () => {
     });
   });
 });
+
+describe("destroy", () => {
+  it("doesn't emit navigation after being destroyed", () => {
+    let navCount = 0;
+    const testHistory = inMemory(
+      pending => {
+        navCount++;
+        pending.finish();
+      },
+      {
+        locations: [{ url: "/one" }]
+      }
+    );
+    testHistory.navigate({ url: "/two" });
+
+    expect(navCount).toBe(1);
+
+    testHistory.destroy();
+    testHistory.navigate({ url: "/three" });
+
+    expect(navCount).toBe(1);
+  });
+});


### PR DESCRIPTION
After a `history` instance is "destroyed", it should no longer emit navigations.